### PR TITLE
feat: expose more z260iq-specific features

### DIFF
--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -21,8 +21,13 @@ from .const import (
     DOMAIN,
     LG_MODE_TO_VALUE,
     LG_PRESET_MODES,
+    LG_PRESET_SMART_COOLING,
+    LG_PRESET_SMART_HEAT_COOL,
     LG_PRESET_SMART_HEATING,
     LG_VALUE_TO_MODE,
+    Z260_MAX_TEMP,
+    Z260_MIN_TEMP,
+    Z260_TEMP_STEP,
     Z550_MAX_TEMP,
     Z550_MIN_TEMP,
     Z550_MODE_AUTO,
@@ -141,6 +146,8 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         """Return the minimum temperature."""
         if DeviceIdentifier.has_feature(self.device_data, "z550_mode"):
             return Z550_MIN_TEMP
+        if DeviceIdentifier.has_feature(self.device_data, "z260iq_mode"):
+            return Z260_MIN_TEMP
         return 10.0
 
     @property
@@ -148,6 +155,8 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         """Return the maximum temperature."""
         if DeviceIdentifier.has_feature(self.device_data, "z550_mode"):
             return Z550_MAX_TEMP
+        if DeviceIdentifier.has_feature(self.device_data, "z260iq_mode"):
+            return Z260_MAX_TEMP
         return 40.0
 
     @property
@@ -155,6 +164,8 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         """Return the supported step of target temperature."""
         if DeviceIdentifier.has_feature(self.device_data, "z550_mode"):
             return Z550_TEMP_STEP
+        if DeviceIdentifier.has_feature(self.device_data, "z260iq_mode"):
+            return Z260_TEMP_STEP
         return 1.0
 
     @property
@@ -176,6 +187,9 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         """Return the list of available hvac operation modes."""
         # Z550iQ+ supports heat/cool/auto
         if DeviceIdentifier.has_feature(self.device_data, "z550_mode"):
+            return [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL]
+        # Z260iQ supports heat/cool/heat_cool
+        if DeviceIdentifier.has_feature(self.device_data, "z260iq_mode"):
             return [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL]
         return [HVACMode.OFF, HVACMode.HEAT]
 
@@ -265,6 +279,25 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
                 return HVACMode.HEAT_COOL
             # Default to HEAT if mode unknown but pump is ON
             return HVACMode.HEAT
+
+        # Z260iQ: ON/OFF from component 13, mode from component 14
+        if DeviceIdentifier.has_feature(device_data, "z260iq_mode"):
+            heat_pump_reported = device_data.get("heat_pump_reported")
+            if heat_pump_reported is not None and not bool(heat_pump_reported):
+                return HVACMode.OFF
+            mode_value = device_data.get("z260iq_mode_value")
+            if mode_value is not None:
+                # 0=Smart Heat, 3=Boost Heat, 4=Silence Heat → HEAT
+                # 1=Smart Cool, 5=Boost Cool, 6=Silence Cool → COOL
+                # 2=Smart H+C → HEAT_COOL
+                if mode_value in (0, 3, 4):
+                    return HVACMode.HEAT
+                elif mode_value in (1, 5, 6):
+                    return HVACMode.COOL
+                elif mode_value == 2:
+                    return HVACMode.HEAT_COOL
+            # Fallback: if ON, assume HEAT
+            return HVACMode.HEAT if bool(heat_pump_reported) else HVACMode.OFF
 
         # For heat pumps with preset modes, use multiple sources like the switch
         if DeviceIdentifier.has_feature(device_data, "preset_modes"):
@@ -358,6 +391,32 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
                             success = await self._api.control_device_component(self._device_id, 16, Z550_MODE_COOLING)
                         elif hvac_mode == HVACMode.HEAT_COOL:
                             success = await self._api.control_device_component(self._device_id, 16, Z550_MODE_AUTO)
+            elif DeviceIdentifier.has_feature(self.device_data, "z260iq_mode"):
+                # Z260iQ: ON/OFF via component 13, mode via component 14
+                if hvac_mode == HVACMode.OFF:
+                    success = await self._api.control_device_component(self._device_id, 13, 0)
+                else:
+                    # Determine component 14 value from target HVAC mode:
+                    # Use the current preset to preserve the specific mode, or default to Smart variant
+                    current_preset = self.preset_mode
+                    if hvac_mode == HVACMode.HEAT:
+                        # Keep current preset if it's already a HEAT preset, else default to Smart Heat
+                        mode_value = LG_MODE_TO_VALUE.get(current_preset, LG_MODE_TO_VALUE[LG_PRESET_SMART_HEATING])
+                        if mode_value not in (0, 3, 4):
+                            mode_value = LG_MODE_TO_VALUE[LG_PRESET_SMART_HEATING]
+                    elif hvac_mode == HVACMode.COOL:
+                        mode_value = LG_MODE_TO_VALUE.get(current_preset, LG_MODE_TO_VALUE[LG_PRESET_SMART_COOLING])
+                        if mode_value not in (1, 5, 6):
+                            mode_value = LG_MODE_TO_VALUE[LG_PRESET_SMART_COOLING]
+                    elif hvac_mode == HVACMode.HEAT_COOL:
+                        mode_value = LG_MODE_TO_VALUE[LG_PRESET_SMART_HEAT_COOL]
+                    else:
+                        self._pending_hvac_mode = None
+                        self._last_hvac_action_time = None
+                        return
+                    success = await self._api.control_device_component(self._device_id, 14, mode_value)
+                    if success:
+                        success = await self._api.control_device_component(self._device_id, 13, 1)
             else:
                 # Standard heat pump (LG, etc.)
                 if hvac_mode == HVACMode.HEAT:
@@ -588,5 +647,24 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             attrs["component_37_raw"] = device_data.get("components", {}).get("37", {}).get("reportedValue")
             attrs["component_40_raw"] = device_data.get("components", {}).get("40", {}).get("reportedValue")
             attrs["component_61_raw"] = device_data.get("components", {}).get("61", {}).get("reportedValue")
+
+        # Z260iQ specific attributes
+        if DeviceIdentifier.has_feature(device_data, "z260iq_mode"):
+            air_temp = device_data.get("air_temperature")
+            if air_temp is not None:
+                attrs["air_temperature"] = air_temp
+            no_flow = device_data.get("no_flow_alarm")
+            if no_flow is not None:
+                attrs["no_flow_alarm"] = no_flow
+            running_hours = device_data.get("running_hours")
+            if running_hours is not None:
+                attrs["running_hours"] = running_hours
+            z260iq_mode_value = device_data.get("z260iq_mode_value")
+            if z260iq_mode_value is not None:
+                attrs["z260iq_mode_raw"] = z260iq_mode_value
+            attrs["component_13_raw"] = device_data.get("components", {}).get("13", {}).get("reportedValue")
+            attrs["component_14_raw"] = device_data.get("components", {}).get("14", {}).get("reportedValue")
+            attrs["component_28_raw"] = device_data.get("components", {}).get("28", {}).get("reportedValue")
+            attrs["component_67_raw"] = device_data.get("components", {}).get("67", {}).get("reportedValue")
 
         return attrs

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -122,6 +122,11 @@ LG_MODE_TO_VALUE: Final = {
 
 LG_VALUE_TO_MODE: Final = {v: k for k, v in LG_MODE_TO_VALUE.items()}
 
+# Z260iQ Heat Pump Constants
+Z260_MIN_TEMP: Final = 7.0
+Z260_MAX_TEMP: Final = 40.0
+Z260_TEMP_STEP: Final = 1.0
+
 # LumiPlus Connect component IDs
 LUMIPLUS_COMPONENT_POWER: Final = 11
 LUMIPLUS_COMPONENT_BRIGHTNESS: Final = 17

--- a/custom_components/fluidra_pool/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator.py
@@ -338,6 +338,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator):
 
         if component_id == 0:
             device["device_id_component"] = reported_value
+            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
+                try:
+                    device["running_hours"] = int(reported_value)
+                except (ValueError, TypeError):
+                    pass
         elif component_id == 1:
             device["part_numbers_component"] = reported_value
         elif component_id == 2:
@@ -382,6 +387,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator):
                 device["is_heating"] = bool(reported_value)
         elif component_id == 14:
             device["component_14_data"] = component_state
+            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
+                try:
+                    device["z260iq_mode_value"] = int(reported_value)
+                except (ValueError, TypeError):
+                    pass
         elif component_id == 15:
             device["component_15_speed"] = reported_value or component_state.get("desiredValue") or 0
             temp_raw = reported_value or component_state.get("desiredValue")
@@ -473,17 +483,23 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator):
                 except (ValueError, TypeError):
                     pass
             device[f"component_{component_id}_data"] = component_state
-        else:
-            # Generic air temperature component (e.g., Z260iQ c67)
-            air_temp_comp = DeviceIdentifier.get_feature(device, "air_temp_component")
-            if air_temp_comp and component_id == air_temp_comp and reported_value is not None:
+        elif component_id == 28:
+            device["component_28_data"] = component_state
+            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
+                try:
+                    device["no_flow_alarm"] = int(reported_value) != 0
+                except (ValueError, TypeError):
+                    pass
+        elif component_id == 67:
+            device["component_67_data"] = component_state
+            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
                 try:
                     air_temp = float(reported_value) / 10.0
-                    if -20.0 <= air_temp <= 60.0:
+                    if -30.0 <= air_temp <= 60.0:
                         device["air_temperature"] = air_temp
                 except (ValueError, TypeError):
                     pass
-
+        else:
             schedule_comp = DeviceIdentifier.get_feature(device, "schedule_component")
             if schedule_comp and component_id == schedule_comp:
                 if isinstance(reported_value, dict) and "programs" in reported_value:

--- a/custom_components/fluidra_pool/device_registry.py
+++ b/custom_components/fluidra_pool/device_registry.py
@@ -51,7 +51,13 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
             "hvac_modes": ["off", "heat"],
             "skip_auto_mode": True,
             "skip_schedules": True,
-            "specific_components": [13, 14, 15, 19],  # ON/OFF, target temp, current temp, water temp
+            "specific_components": [
+                7,
+                13,
+                14,
+                15,
+                19,
+            ],  # 7=signature (BXWAA), ON/OFF, target temp, current temp, water temp
         },
         priority=100,
     ),
@@ -69,30 +75,56 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
             "hvac_modes": ["off", "heat"],
             "skip_auto_mode": True,
             "skip_schedules": True,
-            "specific_components": [13, 14, 15, 19],  # ON/OFF, target temp, current temp, water temp
+            "specific_components": [
+                7,
+                13,
+                14,
+                15,
+                19,
+            ],  # 7=signature (for differentiation), ON/OFF, target temp, current temp, water temp
         },
         priority=95,
     ),
     "z260iq_heat_pump": DeviceConfig(
         device_type="heat_pump",
-        name_patterns=["z260", "z26"],
+        identifier_patterns=["LF*"],
         family_patterns=["heat pump"],
         components_range=5,  # Minimal scan, specific components below
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info", "sensor_temperature"],
+        entities=[
+            "climate",
+            "switch",
+            "sensor_info",
+            "sensor_temperature",
+            "sensor_running_hours",
+            "binary_sensor_no_flow",
+        ],
         features={
+            "z260iq_mode": True,  # Flag for Z260iQ-specific handling
             "preset_modes": True,
             "temperature_control": True,
-            "hvac_modes": ["off", "heat", "cool", "auto"],
+            "hvac_modes": ["off", "heat", "cool", "heat_cool"],
             "skip_auto_mode": True,
             "skip_schedules": True,
-            # Same combined mode system as LG (component 14: 0-6)
-            # 0=Smart Heating, 1=Smart Cooling, 2=Smart Heat/Cool
-            # 3=Boost Heating, 4=Silence Heating, 5=Boost Cooling, 6=Silence Cooling
-            "air_temp_component": 67,  # Air temperature (÷10)
-            "specific_components": [0, 13, 14, 15, 17, 19, 28, 67],
+            "min_temp": 7.0,
+            "max_temp": 40.0,
+            "temp_step": 1.0,
+            # Component mappings:
+            # - 0:  Running hours (raw integer, unit h) — read-only
+            # - 13: ON/OFF (0=OFF, 1=ON)
+            # - 14: Operation mode / preset (0=Smart Heating, 1=Smart Cooling,
+            #        2=Smart H+C, 3=Boost Heating, 4=Silence Heating,
+            #        5=Boost Cooling, 6=Silence Cooling) — same values as LG
+            # - 15: Setpoint temperature (×0.1, e.g. 260=26.0°C)
+            # - 17: Device status (0=OK, 7=Error) — read-only info
+            # - 19: Water temperature (×0.1)
+            # - 28: No-flow alarm (0=OK, 1=No Flow)
+            # - 67: Air temperature (×0.1)
+            # - 81: Min setpoint (15°C, informational)
+            # - 82: Max setpoint (40°C, informational)
+            "specific_components": [0, 7, 13, 14, 15, 17, 19, 28, 67, 81, 82],
         },
-        priority=97,  # Higher than z550iq
+        priority=97,  # Higher than z250iq (95) and z550iq (96); component-7 check elevates further
     ),
     "z550iq_heat_pump": DeviceConfig(
         device_type="heat_pump",
@@ -765,6 +797,13 @@ class DeviceIdentifier:
             if config_name == "lg_heat_pump":
                 if DeviceIdentifier._check_component_signature(device, 7, ["BXWAA"]):
                     score += 100  # Very strong indicator
+
+            # Special case: Z260iQ heat pump signature (component 7 with BXWAD)
+            if config_name == "z260iq_heat_pump":
+                if DeviceIdentifier._check_component_signature(device, 7, ["BXWAD"]):
+                    score += 100  # Very strong indicator
+                else:
+                    score = 0  # Without BXWAD, never match z260iq (fall back to z250iq)
 
             # Update best match if this score is higher
             if score > best_score:

--- a/custom_components/fluidra_pool/sensor.py
+++ b/custom_components/fluidra_pool/sensor.py
@@ -79,11 +79,22 @@ async def async_setup_entry(
                     entities.append(
                         FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "air")
                     )
+                # Z260iQ heat pump specific temperature sensors
+                if DeviceIdentifier.has_feature(device, "z260iq_mode"):
+                    entities.append(
+                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "water")
+                    )
+                    entities.append(
+                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "air")
+                    )
 
             if DeviceIdentifier.should_create_entity(device, "sensor_brightness"):
                 # Brightness sensor for lights
                 if "brightness" in device:
                     entities.append(FluidraLightBrightnessSensor(coordinator, coordinator.api, pool["id"], device_id))
+
+            if DeviceIdentifier.should_create_entity(device, "sensor_running_hours"):
+                entities.append(FluidraRunningHoursSensor(coordinator, coordinator.api, pool["id"], device_id))
 
             # Chlorinator sensors - create based on sensors_config from device registry
             device_type = device.get("type", "")
@@ -286,6 +297,24 @@ class FluidraLightBrightnessSensor(FluidraPoolSensorEntity):
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return "mdi:brightness-percent"
+
+
+class FluidraRunningHoursSensor(FluidraPoolSensorEntity):
+    """Running hours sensor for Z260iQ heat pumps (component 0)."""
+
+    _attr_translation_key = "running_hours"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "h"
+    _attr_icon = "mdi:clock-outline"
+
+    def __init__(self, coordinator, api, pool_id: str, device_id: str):
+        """Initialize running hours sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "running_hours")
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the running hours from component 0."""
+        return self.device_data.get("running_hours")
 
 
 class FluidraPumpSpeedSensor(FluidraPoolSensorEntity):


### PR DESCRIPTION
Add dedicated z260iq_mode feature flag with explicit component handling instead of the generic air_temp_component approach. This ensures air temperature, running hours, no-flow alarm, and HVAC mode control are properly exposed to Home Assistant.

Changes summary:
- const.py: add Z260_MIN_TEMP, Z260_MAX_TEMP, Z260_TEMP_STEP constants
- device_registry.py: overhaul z260iq config with z260iq_mode flag, BXWAD signature check, expanded entities and component list
- coordinator.py: explicit z260iq handling for components 0 (running hours), 14 (mode value), 28 (no-flow alarm), 67 (air temperature)
- sensor.py: z260iq water/air temperature sensors and running hours sensor entity with FluidraRunningHoursSensor class
- climate.py: z260iq HVAC mode interpretation, set mode via c13/c14, temperature bounds, and extra state attributes

## Description

@foXaCe Thanks for merging support so quickly for Z260iQ heat pump.
Unfortunately, air temperature was not exposed to home assistant.
Checking the states the climate device offers in developer settings:
```
hvac_modes: off, heat
min_temp: 10
max_temp: 40
target_temp_step: 1
preset_modes: smart_heating, smart_cooling, smart_heat_cool, boost_heating, silence_heating, boost_cooling, silence_cooling
current_temperature: 22.2
temperature: 26
hvac_action: heating
preset_mode: smart_heating
device_type: heat_pump
device_id: LF23512683
pool_id: <POOL_ID>
model: Z260iQ
family: Heat Pumps
connectivity: 
connected: true
sessionIdentifier: <SESSION_IDENTIFIER>
timestamp: 1775654243201
last_update: null
pending_temperature: false
is_updating: false
heat_pump_reported: 1
is_heating: true
is_running: false
component_13_raw: 1
component_15_raw: 260
component_15_temperature: 26
state_sync_working: true
control_working: true
water_temperature: 22.2
icon: mdi:heat-pump
friendly_name: Z260iQ Heatpump
supported_features: 401
```
I also tried implementing some of the other components... With this PR, I get these values (including air temperature):

```
hvac_modes: off, heat, cool, heat_cool
min_temp: 7
max_temp: 40
target_temp_step: 1
preset_modes: smart_heating, smart_cooling, smart_heat_cool, boost_heating, silence_heating, boost_cooling, silence_cooling
current_temperature: 22.4
temperature: 26
hvac_action: heating
preset_mode: smart_heating
device_type: heat_pump
device_id: LF23512683
pool_id: <POOL_ID>
model: Z260iQ
family: Heat Pumps
connectivity: 
connected: true
sessionIdentifier: <SESSION_IDENTIFIER>
timestamp: 1775654243201
last_update: null
pending_temperature: false
is_updating: false
heat_pump_reported: 1
is_heating: true
is_running: false
component_13_raw: 1
component_15_raw: 260
component_15_temperature: 26
state_sync_working: true
control_working: true
icon: mdi:heat-pump
friendly_name: Z260iQ Heatpump
supported_features: 401
water_temperature: 22.4
z260iq_mode_raw: 0
component_14_raw: 0
component_28_raw: 0
component_67_raw: 194
air_temperature: 19.4
no_flow_alarm: false
running_hours: 8055
```

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] New device support

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested on actual Fluidra hardware (if applicable)
- [x] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Fixes #41 

## Device Testing (if applicable)

- [x] Tested on: Zodiac Z260iQ heat pump
- [x] Firmware version: 2.5.0

## Screenshots (if applicable)
<img width="906" height="237" alt="image" src="https://github.com/user-attachments/assets/f857c8bd-0b84-47b6-946c-93d47d963c51" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Z260iQ heat pump devices with full climate control integration.
  * Extended operational temperature control range (7–40°C with 1°C increments).
  * Introduced combined heat/cool operation mode for enhanced climate flexibility.
  * Added device running hours tracking and no-flow alarm monitoring.
  * Enhanced air temperature sensing with expanded diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->