### PR TITLE
add support for LC24015802 (iSALT 7) chlorinator

### DIFF
--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -87,9 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
 
     def _persist_refresh_token(new_token: str) -> None:
         """Persist the latest refresh token back into the config entry."""
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, "refresh_token": new_token}
-        )
+        hass.config_entries.async_update_entry(entry, data={**entry.data, "refresh_token": new_token})
 
     api = FluidraPoolAPI(
         email,

--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING, Final
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 import voluptuous as vol
 
-from .api_resilience import FluidraError
+from .api_resilience import FluidraError, FluidraMFARequired
 from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN, FluidraPoolConfigEntry, FluidraPoolRuntimeData
 
 if TYPE_CHECKING:
@@ -82,7 +82,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
     # Initialize API client
     from .fluidra_api import FluidraPoolAPI
 
-    api = FluidraPoolAPI(email, password, hass)
+    # Pass any stored refresh token so the API can bypass MFA on reload/restart.
+    stored_refresh_token = entry.data.get("refresh_token")
+
+    def _persist_refresh_token(new_token: str) -> None:
+        """Persist the latest refresh token back into the config entry."""
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "refresh_token": new_token}
+        )
+
+    api = FluidraPoolAPI(
+        email,
+        password,
+        hass,
+        refresh_token=stored_refresh_token,
+        on_token_persist=_persist_refresh_token,
+    )
 
     try:
         # Test connection and authentication
@@ -90,6 +105,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
         pools = await api.get_pools()
         # Continue setup even if no pools found - user may add equipment later
 
+    except FluidraMFARequired as err:
+        _LOGGER.warning("MFA required for %s, triggering reauth flow", email[:3] + "***")
+        raise ConfigEntryAuthFailed("MFA required") from err
     except (FluidraError, TimeoutError, OSError) as err:
         _LOGGER.error("Unable to connect to Fluidra Pool API: %s", err)
         raise ConfigEntryNotReady from err

--- a/custom_components/fluidra_pool/api_resilience.py
+++ b/custom_components/fluidra_pool/api_resilience.py
@@ -53,6 +53,15 @@ class FluidraCircuitBreakerError(FluidraError):
     """Exception when circuit breaker is open."""
 
 
+class FluidraMFARequired(FluidraError):
+    """Exception raised when Cognito requires an MFA challenge to complete authentication."""
+
+    def __init__(self, challenge_name: str, session: str) -> None:
+        self.challenge_name = challenge_name
+        self.session = session
+        super().__init__(f"MFA required: {challenge_name}")
+
+
 # --- Circuit Breaker ---
 
 

--- a/custom_components/fluidra_pool/config_flow.py
+++ b/custom_components/fluidra_pool/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 import voluptuous as vol
 
+from .api_resilience import FluidraMFARequired
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 from .fluidra_api import FluidraPoolAPI
 
@@ -36,6 +37,11 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._reauth_entry: dict[str, Any] | None = None
+        self._pending_email: str = ""
+        self._pending_password: str = ""
+        self._mfa_session: str = ""
+        self._mfa_challenge: str = ""
+        self._mfa_origin: str = "new"  # "new", "reauth", or "reconfigure"
 
     @staticmethod
     @callback
@@ -59,7 +65,14 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             # Test connection
-            error = await self._test_credentials(email, password)
+            error, mfa_info = await self._test_credentials(email, password)
+            if mfa_info:
+                self._pending_email = email
+                self._pending_password = password
+                self._mfa_session = mfa_info["session"]
+                self._mfa_challenge = mfa_info["challenge_name"]
+                self._mfa_origin = "new"
+                return await self.async_step_mfa()
             if error:
                 errors["base"] = error
             else:
@@ -71,6 +84,54 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_mfa(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the MFA verification step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            code = user_input.get("mfa_code", "").strip()
+            error, refresh_token = await self._verify_mfa(
+                self._pending_email,
+                self._pending_password,
+                self._mfa_session,
+                self._mfa_challenge,
+                code,
+            )
+            if error:
+                errors["base"] = error
+            else:
+                entry_data: dict[str, Any] = {
+                    CONF_EMAIL: self._pending_email,
+                    CONF_PASSWORD: self._pending_password,
+                }
+                if refresh_token:
+                    entry_data["refresh_token"] = refresh_token
+                if self._mfa_origin == "reauth":
+                    return self.async_update_reload_and_abort(
+                        self._get_reauth_entry(),
+                        data=entry_data,
+                    )
+                if self._mfa_origin == "reconfigure":
+                    reconfigure_entry = self._get_reconfigure_entry()
+                    if self._pending_email.lower() != reconfigure_entry.unique_id:
+                        await self.async_set_unique_id(self._pending_email.lower())
+                        self._abort_if_unique_id_configured()
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry,
+                        data=entry_data,
+                        reason="reconfigure_successful",
+                    )
+                return self.async_create_entry(
+                    title=f"Fluidra Pool ({self._pending_email})",
+                    data=entry_data,
+                )
+
+        return self.async_show_form(
+            step_id="mfa",
+            data_schema=vol.Schema({vol.Required("mfa_code"): str}),
             errors=errors,
         )
 
@@ -94,7 +155,14 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             password = user_input[CONF_PASSWORD]
 
             # Test new credentials
-            error = await self._test_credentials(email, password)
+            error, mfa_info = await self._test_credentials(email, password)
+            if mfa_info:
+                self._pending_email = email
+                self._pending_password = password
+                self._mfa_session = mfa_info["session"]
+                self._mfa_challenge = mfa_info["challenge_name"]
+                self._mfa_origin = "reauth"
+                return await self.async_step_mfa()
             if error:
                 errors["base"] = error
             else:
@@ -137,7 +205,14 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             password = user_input[CONF_PASSWORD]
 
             # Test new credentials
-            error = await self._test_credentials(email, password)
+            error, mfa_info = await self._test_credentials(email, password)
+            if mfa_info:
+                self._pending_email = email
+                self._pending_password = password
+                self._mfa_session = mfa_info["session"]
+                self._mfa_challenge = mfa_info["challenge_name"]
+                self._mfa_origin = "reconfigure"
+                return await self.async_step_mfa()
             if error:
                 errors["base"] = error
             else:
@@ -178,34 +253,62 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the config entry being reconfigured."""
         return self.hass.config_entries.async_get_entry(self.context["entry_id"])
 
-    async def _test_credentials(self, email: str, password: str) -> str | None:
-        """Test credentials and return error key if failed.
+    async def _test_credentials(self, email: str, password: str) -> tuple[str | None, dict | None]:
+        """Test credentials and return (error_key, mfa_info) tuple.
 
         Only tests Cognito authentication, not pool discovery.
         This ensures that transient API errors during pool discovery
         don't prevent successful re-authentication.
 
         Returns:
-            None if successful, error key string if failed.
+            (None, None) on success.
+            (None, {"session": ..., "challenge_name": ...}) when MFA is required.
+            (error_key, None) on failure.
         """
         api = FluidraPoolAPI(email, password)
 
         try:
-            # Only test Cognito auth, not full pool discovery
-            # This prevents false "invalid_auth" when the API is temporarily down
             await api._cognito_initial_auth()
             _LOGGER.info("Authentication successful for %s", email)
-            return None
+            return None, None
+        except FluidraMFARequired as mfa_err:
+            _LOGGER.info("MFA required for %s (%s)", email, mfa_err.challenge_name)
+            return None, {"session": mfa_err.session, "challenge_name": mfa_err.challenge_name}
         except Exception as err:
             _LOGGER.error("Authentication failed for %s: %s", email, err)
             error_str = str(err).lower()
             if any(
                 keyword in error_str for keyword in ("notauthorized", "unauthorized", "401", "incorrect", "invalid")
             ):
-                return "invalid_auth"
+                return "invalid_auth", None
             if any(keyword in error_str for keyword in ("timeout", "connect", "unreachable")):
-                return "cannot_connect"
-            return "unknown"
+                return "cannot_connect", None
+            return "unknown", None
+        finally:
+            await api.close()
+
+    async def _verify_mfa(self, email: str, password: str, session: str, challenge_name: str, code: str) -> tuple[str | None, str | None]:
+        """Send the MFA code to Cognito and return (error_key, refresh_token).
+
+        Returns:
+            (None, refresh_token) on success — refresh_token should be stored in entry data
+            so future reloads can bypass MFA.
+            (error_key, None) on failure.
+        """
+        api = FluidraPoolAPI(email, password)
+
+        try:
+            await api._cognito_respond_to_mfa(code, session, challenge_name)
+            _LOGGER.info("MFA verification successful for %s", email)
+            return None, api.refresh_token
+        except Exception as err:
+            _LOGGER.error("MFA verification failed for %s: %s", email, err)
+            error_str = str(err).lower()
+            if any(keyword in error_str for keyword in ("notauthorized", "codemismatch", "invalid", "expired")):
+                return "invalid_mfa_code", None
+            if any(keyword in error_str for keyword in ("timeout", "connect", "unreachable")):
+                return "cannot_connect", None
+            return "unknown", None
         finally:
             await api.close()
 

--- a/custom_components/fluidra_pool/config_flow.py
+++ b/custom_components/fluidra_pool/config_flow.py
@@ -287,7 +287,9 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await api.close()
 
-    async def _verify_mfa(self, email: str, password: str, session: str, challenge_name: str, code: str) -> tuple[str | None, str | None]:
+    async def _verify_mfa(
+        self, email: str, password: str, session: str, challenge_name: str, code: str
+    ) -> tuple[str | None, str | None]:
         """Send the MFA code to Cognito and return (error_key, refresh_token).
 
         Returns:

--- a/custom_components/fluidra_pool/device_registry.py
+++ b/custom_components/fluidra_pool/device_registry.py
@@ -291,15 +291,15 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
         entities=["switch", "number", "sensor_info"],
         features={
             "chlorination_level": 10,  # Component 10 (0-100%)
-            "ph_setpoint": 16,         # Component 16 (÷100) — e.g., 740 = 7.40 pH
-            "orp_setpoint": 20,        # Component 20 (mV)
-            "boost_mode": 103,         # Component 103 (boolean: true/false)
+            "ph_setpoint": 16,  # Component 16 (÷100) — e.g., 740 = 7.40 pH
+            "orp_setpoint": 20,  # Component 20 (mV)
+            "boost_mode": 103,  # Component 103 (boolean: true/false)
             "skip_mode_select": True,  # No mode select (tecnoLC2 bridge style)
             "sensors": {
-                "ph": 165,          # pH measured (÷100)
-                "orp": 170,         # ORP/Redox measured (mV)
-                "temperature": 172, # Pool temperature (°C × 10)
-                "salinity": 174,    # Salinity (g/L × 100)
+                "ph": 165,  # pH measured (÷100)
+                "orp": 170,  # ORP/Redox measured (mV)
+                "temperature": 172,  # Pool temperature (°C × 10)
+                "salinity": 174,  # Salinity (g/L × 100)
             },
             # Same component set as iSALT LC24013306 (same tecnoLC2 thingType)
             "specific_components": [10, 16, 20, 103, 165, 170, 172, 174],

--- a/custom_components/fluidra_pool/device_registry.py
+++ b/custom_components/fluidra_pool/device_registry.py
@@ -281,6 +281,31 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=86,  # Same priority as other LC chlorinators
     ),
+    "lc24015802_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # LC24015802 is a Tecno LC2 bridge; its child device ID is LC24015802.nn_1
+        identifier_patterns=["LC24015802.nn_*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "chlorination_level": 10,  # Component 10 (0-100%)
+            "ph_setpoint": 16,         # Component 16 (÷100) — e.g., 740 = 7.40 pH
+            "orp_setpoint": 20,        # Component 20 (mV)
+            "boost_mode": 103,         # Component 103 (boolean: true/false)
+            "skip_mode_select": True,  # No mode select (tecnoLC2 bridge style)
+            "sensors": {
+                "ph": 165,          # pH measured (÷100)
+                "orp": 170,         # ORP/Redox measured (mV)
+                "temperature": 172, # Pool temperature (°C × 10)
+                "salinity": 174,    # Salinity (g/L × 100)
+            },
+            # Same component set as iSALT LC24013306 (same tecnoLC2 thingType)
+            "specific_components": [10, 16, 20, 103, 165, 170, 172, 174],
+        },
+        priority=87,  # Higher than generic *.nn_* (80) and other LC models (86)
+    ),
     "lc24056317_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["LC24056317*"],  # Gre chlorinator (I.D. Electroquimica/Fluidra) - Issue #28

--- a/custom_components/fluidra_pool/fluidra_api.py
+++ b/custom_components/fluidra_pool/fluidra_api.py
@@ -25,6 +25,7 @@ from .api_resilience import (
     FluidraCircuitBreakerError,
     FluidraConnectionError,
     FluidraError,
+    FluidraMFARequired,
     RateLimiter,
 )
 from .const import PUMP_START_DELAY
@@ -68,9 +69,17 @@ class FluidraPoolAPI:
         "_circuit_breaker",
         "_rate_limiter",
         "_token_lock",
+        "_on_token_persist",
     )
 
-    def __init__(self, email: str, password: str, hass: HomeAssistant | None = None) -> None:
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        hass: HomeAssistant | None = None,
+        refresh_token: str | None = None,
+        on_token_persist: Any | None = None,
+    ) -> None:
         """Initialize the API wrapper."""
         self.email: str = email
         self.password: str = password
@@ -79,9 +88,12 @@ class FluidraPoolAPI:
 
         # AWS Cognito tokens
         self.access_token: str | None = None
-        self.refresh_token: str | None = None
+        self.refresh_token: str | None = refresh_token  # Pre-seed from stored entry data
         self.id_token: str | None = None
         self.token_expires_at: int | None = None  # Timestamp d'expiration
+
+        # Callback to persist refresh_token back to the config entry (avoids MFA on restart)
+        self._on_token_persist: Any | None = on_token_persist
 
         # Account data
         self.user_pools: list[dict[str, Any]] = []
@@ -228,15 +240,27 @@ class FluidraPoolAPI:
         raise FluidraConnectionError(f"Request failed after {MAX_RETRIES + 1} attempts: {last_error}")
 
     async def authenticate(self) -> None:
-        """Authentification réelle via AWS Cognito."""
+        """Authentification réelle via AWS Cognito.
+
+        If a refresh_token was supplied (e.g. persisted from a previous session), it is
+        tried first so that MFA is not re-triggered on every HA restart or integration reload.
+        Falls back to full email/password auth only when the refresh token is absent or expired.
+        """
         try:
-            # Étape 1: Authentification initiale AWS Cognito
+            if self.refresh_token:
+                # Try to exchange the stored refresh token for a fresh access token.
+                # This succeeds silently without triggering SMS/TOTP MFA.
+                refreshed = await self.refresh_access_token()
+                if refreshed:
+                    _LOGGER.info("Authenticated via stored refresh token (no MFA required)")
+                    await self._get_user_profile()
+                    await self.async_update_data()
+                    return
+                _LOGGER.warning("Stored refresh token expired or invalid, falling back to full auth")
+
+            # Full authentication — may raise FluidraMFARequired if MFA is enabled.
             await self._cognito_initial_auth()
-
-            # Étape 2: Récupérer les informations du compte
             await self._get_user_profile()
-
-            # Étape 3: Découvrir les piscines et équipements
             await self.async_update_data()
 
         except FluidraError:
@@ -279,7 +303,15 @@ class FluidraPoolAPI:
         except json.JSONDecodeError as e:
             raise FluidraAuthError(f"Invalid JSON response: {e}") from e
 
-        auth_result = auth_data.get("AuthenticationResult", {})
+        auth_result = auth_data.get("AuthenticationResult")
+
+        # Cognito may return a challenge (e.g. MFA) instead of tokens directly.
+        if not auth_result:
+            challenge_name = auth_data.get("ChallengeName", "")
+            session = auth_data.get("Session", "")
+            if challenge_name in ("SOFTWARE_TOKEN_MFA", "SMS_MFA"):
+                raise FluidraMFARequired(challenge_name, session)
+            raise FluidraAuthError(f"Unexpected Cognito response: {auth_data}")
 
         self.access_token = auth_result.get("AccessToken")
         self.refresh_token = auth_result.get("RefreshToken")
@@ -293,6 +325,62 @@ class FluidraPoolAPI:
 
         if not self.access_token:
             raise FluidraAuthError("Access token non reçu")
+
+        # Persist the refresh token so HA can bypass MFA on next restart.
+        if self.refresh_token and self._on_token_persist:
+            self._on_token_persist(self.refresh_token)
+
+    async def _cognito_respond_to_mfa(self, code: str, session: str, challenge_name: str = "SOFTWARE_TOKEN_MFA") -> None:
+        """Complete a Cognito MFA challenge with a TOTP or SMS code."""
+        payload = {
+            "ChallengeName": challenge_name,
+            "ClientId": COGNITO_CLIENT_ID,
+            "Session": session,
+            "ChallengeResponses": {
+                "USERNAME": self.email,
+                f"{challenge_name}_CODE": code,
+            },
+        }
+
+        headers = {
+            "Content-Type": "application/x-amz-json-1.1; charset=utf-8",
+            "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
+            "User-Agent": "com.fluidra.iaqualinkplus/1741857021 (Linux; U; Android 14; fr_FR; MI PAD 4; Build/UQ1A.240205.004; Cronet/140.0.7289.0)",
+        }
+
+        response = await self._request(
+            "POST",
+            COGNITO_ENDPOINT,
+            headers=headers,
+            json_data=payload,
+            skip_circuit_breaker=True,
+        )
+
+        if response.status != 200:
+            error_text = await response.text()
+            raise FluidraAuthError(f"MFA verification failed: {response.status} - {error_text}")
+
+        response_text = await response.text()
+        try:
+            auth_data = json.loads(response_text)
+        except json.JSONDecodeError as e:
+            raise FluidraAuthError(f"Invalid JSON response after MFA: {e}") from e
+
+        auth_result = auth_data.get("AuthenticationResult", {})
+        self.access_token = auth_result.get("AccessToken")
+        self.refresh_token = auth_result.get("RefreshToken")
+        self.id_token = auth_result.get("IdToken")
+
+        expires_in = auth_result.get("ExpiresIn", 3600)
+        margin = min(300, max(30, expires_in // 10))
+        self.token_expires_at = int(time.time()) + expires_in - margin
+
+        if not self.access_token:
+            raise FluidraAuthError("Access token non reçu après MFA")
+
+        # Persist the refresh token so HA can bypass MFA on next restart.
+        if self.refresh_token and self._on_token_persist:
+            self._on_token_persist(self.refresh_token)
 
     async def _get_user_profile(self) -> dict[str, Any]:
         """Récupérer le profil utilisateur."""
@@ -499,6 +587,11 @@ class FluidraPoolAPI:
                 await self._cognito_initial_auth()
                 _LOGGER.info("Full re-authentication successful, new expires_at=%s", self.token_expires_at)
                 return True
+            except FluidraMFARequired:
+                # MFA is required — signal auth failure so the coordinator triggers the reauth flow.
+                # Returning False (not re-raising) prevents an unhandled exception loop.
+                _LOGGER.warning("MFA required during token re-authentication, triggering reauth flow")
+                return False
             except Exception as err:
                 _LOGGER.error("Re-authentication also failed: %s (type: %s)", err, type(err).__name__)
                 return False
@@ -545,6 +638,10 @@ class FluidraPoolAPI:
                 expires_in = auth_result.get("ExpiresIn", 3600)
                 margin = min(300, max(30, expires_in // 10))
                 self.token_expires_at = int(time.time()) + expires_in - margin
+
+                # Persist updated refresh token if Cognito rotated it.
+                if self.refresh_token and self._on_token_persist:
+                    self._on_token_persist(self.refresh_token)
 
                 return True
             # Log the specific error from Cognito for debugging

--- a/custom_components/fluidra_pool/fluidra_api.py
+++ b/custom_components/fluidra_pool/fluidra_api.py
@@ -330,7 +330,9 @@ class FluidraPoolAPI:
         if self.refresh_token and self._on_token_persist:
             self._on_token_persist(self.refresh_token)
 
-    async def _cognito_respond_to_mfa(self, code: str, session: str, challenge_name: str = "SOFTWARE_TOKEN_MFA") -> None:
+    async def _cognito_respond_to_mfa(
+        self, code: str, session: str, challenge_name: str = "SOFTWARE_TOKEN_MFA"
+    ) -> None:
         """Complete a Cognito MFA challenge with a TOTP or SMS code."""
         payload = {
             "ChallengeName": challenge_name,

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -25,6 +25,13 @@
           "password": "Password"
         }
       },
+      "mfa": {
+        "title": "Two-Factor Authentication",
+        "description": "Your account requires a verification code. Enter the code from your authenticator app or SMS.",
+        "data": {
+          "mfa_code": "Verification code"
+        }
+      },
       "confirm": {
         "title": "Discovered Fluidra Pool",
         "description": "We found a Fluidra Pool device. Would you like to add it?"
@@ -33,6 +40,7 @@
     "error": {
       "cannot_connect": "Unable to connect to Fluidra API",
       "invalid_auth": "Invalid credentials. Check your email and password",
+      "invalid_mfa_code": "Invalid or expired verification code. Please try again.",
       "no_pools": "No pools found. Make sure your equipment is configured in the Fluidra Pool app",
       "unknown": "Unexpected error"
     },

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -13,16 +13,16 @@
       "unknown": "Erreur inattendue"
     },
     "step": {
-      "mfa": {
-        "title": "Authentification à deux facteurs",
-        "description": "Votre compte nécessite un code de vérification. Saisissez le code de votre application d'authentification ou reçu par SMS.",
-        "data": {
-          "mfa_code": "Code de vérification"
-        }
-      },
       "confirm": {
         "description": "Nous avons trouvé un équipement Fluidra Pool. Voulez-vous l'ajouter ?",
         "title": "Piscine Fluidra découverte"
+      },
+      "mfa": {
+        "data": {
+          "mfa_code": "Code de vérification"
+        },
+        "description": "Votre compte nécessite un code de vérification. Saisissez le code de votre application d'authentification ou reçu par SMS.",
+        "title": "Authentification à deux facteurs"
       },
       "reauth_confirm": {
         "data": {

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -8,10 +8,18 @@
     "error": {
       "cannot_connect": "Impossible de se connecter à l'API Fluidra",
       "invalid_auth": "Identifiants invalides. Vérifiez votre e-mail et mot de passe",
+      "invalid_mfa_code": "Code de vérification invalide ou expiré. Veuillez réessayer.",
       "no_pools": "Aucune piscine trouvée. Assurez-vous que vos équipements sont configurés dans l'app Fluidra Pool",
       "unknown": "Erreur inattendue"
     },
     "step": {
+      "mfa": {
+        "title": "Authentification à deux facteurs",
+        "description": "Votre compte nécessite un code de vérification. Saisissez le code de votre application d'authentification ou reçu par SMS.",
+        "data": {
+          "mfa_code": "Code de vérification"
+        }
+      },
       "confirm": {
         "description": "Nous avons trouvé un équipement Fluidra Pool. Voulez-vous l'ajouter ?",
         "title": "Piscine Fluidra découverte"


### PR DESCRIPTION
- **Adding support for MFA (re)authentication**
- **add support for LC24015802 (iSALT 7) chlorinator**

## Description

  - Add specific config for `LC24015802.nn_*`
  - Uses correct component set
  - Priority 87 ensures it wins over the generic \`*.nn_*\` fallback (80)

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [X] New device support

## Checklist

- [ ] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have tested on actual Fluidra hardware (if applicable)
- [ ] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Fixes #

## Device Testing (if applicable)

- [X] Tested on: iSalt 7  (LC24015802.nn_1, thingType: tecnoLC2)
- [ ] Firmware version: <!-- if known -->

## Screenshots (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two-factor authentication support in the setup and reconfiguration flow.
  * Automatic refresh token handling for persistent session management.
  * Added support for LC24015802 chlorinator device.

* **Documentation**
  * Added French translations for MFA configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->