### PR TITLE
feat(chlorinators): Add configuration for chlorinator LC25050627

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -740,6 +740,37 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=92,
     ),
+    "lc25050627_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # LC25050627 — bridged chlorinator (tecnoLC2 family).
+        # Mapping confirmed by full component scan (Issue #XX).
+        # c0   = ON/OFF switch.
+        # c10  = chlorination level (0-100%).
+        # c16  = pH setpoint (÷100).
+        # c165 = pH measured (÷100) — e.g. 720 = 7.20 pH.
+        # c172 = temperature (°C × 10) — e.g. 284 = 28.4°C.
+        # c174 = salinity (g/L × 100) — e.g. 536 = 5.36 g/L.
+        # No ORP probe on this model (c20/c170 are None).
+        identifier_patterns=["LC25050627*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "on_off_component": 0,
+            "chlorination_level": 10,
+            "ph_setpoint": 16,
+            "boost_mode": 103,
+            "skip_mode_select": True,
+            "sensors": {
+                "ph": 165,
+                "temperature": 172,
+                "salinity": 174,
+            },
+            "specific_components": [0, 10, 16, 103, 165, 172, 174],
+        },
+        priority=90,
+    ),
     "ns25_exo_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["NS*"],


### PR DESCRIPTION
## Summary

Adds device support for the **Gre SWGA** chlorinator (identifier `LC25050627`), a
bridged unit from the **tecnoLC2** family. The component mapping was obtained from a
full component scan of my real device and cross-checked against the values shown in
the official **Fluidra Pool** app.

## Device details

- **Brand:** Gre
- **Model:** SWGA
- **Identifier:** `LC25050627`
- **Family:** tecnoLC2 (bridged chlorinator)

| Component | Meaning | Notes |
|-----------|---------------------------|------------------------------|
| c10       | Chlorination level        | 0–100% |
| c16       | pH setpoint               | ÷100 |
| c103      | Boost mode                | — |
| c165      | pH measured               | ÷100 (e.g. `720` = 7.20 pH) |
| c172      | Temperature               | °C × 10 (e.g. `284` = 28.4°C) |
| c174      | Salinity                  | g/L × 100 (e.g. `536` = 5.36 g/L) |

## Changes

- New `lc25050627_chlorinator` entry in
  `custom_components/fluidra_pool/device_registry/configs/chlorinators.py`.
- Exposes `switch`, `number` and `sensor_info` entities.
- `skip_mode_select` enabled (device does not support mode selection).

## Testing

Tested on a real Gre SWGA device running in Home Assistant, with all values
cross-checked against the official Fluidra Pool app:

- [x] Chlorination level slider (0–100%)
- [x] pH setpoint write/read (÷100)
- [x] pH measured reading matches the Fluidra Pool app
- [x] Temperature reading matches the Fluidra Pool app
- [x] Salinity reading matches the Fluidra Pool app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LC25050627 chlorinator model, chlorination level adjustment, pH setpoint configuration, and boost mode activation. Real-time monitoring of pH, temperature, and salinity values is now available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foXaCe/Fluidra-pool/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->