### PR TITLE
Add tecnoLC2 config for Klinwass chlorinator LC24009904 (#82)

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -337,6 +337,35 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=87,
     ),
+    "lc24009904_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # KLINWASS (tecnoLC2 with pH + ORP probes) — Issue #82.
+        # Was falling back to the generic config, which read c172 (water
+        # temperature ×10) as pH ÷100 → wrong pH 4.27, and showed each sensor
+        # equal to its setpoint. Diagnostics confirm the standard tecnoLC2
+        # layout: c20 = ORP setpoint (600, matches the app), c172 = water
+        # temperature ×10 (42.7 °C, matches status_data 41.7 °C). Same mapping
+        # as cc25019007 / lc24026011 / lc25000122.
+        identifier_patterns=["LC24009904.nn_*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "chlorination_level": 10,
+            "ph_setpoint": 16,
+            "orp_setpoint": 20,
+            "skip_mode_select": True,
+            "sensors": {
+                "ph": 165,  # pH measured (÷100).
+                "orp": 170,  # ORP measured (mV) — c177 is uncalibrated raw.
+                "temperature": 172,  # Water temperature (°C × 10).
+                "salinity": 174,  # Salinity (g/L × 100).
+            },
+            "specific_components": [10, 16, 20, 165, 170, 172, 174],
+        },
+        priority=87,
+    ),
     "cc25019007_chlorinator": DeviceConfig(
         device_type="chlorinator",
         # Zodiac OE iQ 12 (tecnoLC2) — Issue #55 follow-up.


### PR DESCRIPTION
## Summary

Adds a device-specific `DeviceConfig` for chlorinator `LC24009904` (KLINWASS, `thingType: tecnoLC2`, with pH + ORP probes). It currently matches no specific pattern and falls back to the generic config, producing wrong values (reported in #82).

## Root cause (confirmed from diagnostics)

The generic config reads the wrong components for this model:
- it maps `sensors.ph` and `ph_setpoint.read` both to **c172**, and `sensors.orp` and `orp_setpoint.read` both to **c177** → sensor == setpoint;
- **c172 is water temperature (×10), not pH** → the generic config showed pH 4.27 (= 427/100) instead of the real ~8.2.

Diagnostics back the standard tecnoLC2 layout:
- `c20 = 600` → ORP setpoint, matches the Fluidra app (600 mV);
- `c172 = 427` → water temperature ×10 = 42.7 °C, matches `status_data.waterTemperature = 41.7 °C`.

## Change

New entry using the same mapping as `cc25019007` / `lc24026011` / `lc25000122`:

| feature | component |
|---|---|
| pH | c165 (÷100) |
| ORP | c170 (mV) |
| temperature | c172 (×10) |
| salinity | c174 (×100) |
| pH setpoint | c16 |
| ORP setpoint | c20 |
| chlorination level | c10 |

`priority=87` so it wins over the generic `*.nn_*` (80).

## Validation

`python -m py_compile` passes. Live verification of pH/ORP/temperature is pending the chlorinator running with flow (a physical 'no flow' issue is being resolved on the device side); the mapping itself is confirmed by the diagnostics values above. Happy to capture a full component dump side-by-side with the app once the cell is running.

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Fluidra/KLINWASS tecnoLC2 chlorinator units, enabling monitoring and control of chlorination levels, pH, ORP, and sensor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->