### PR TITLE
refactor: Platinum strict-typing + coverage to 97%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements_test.txt
 
-      # Baseline (non-strict) type check. Full --strict is the Platinum goal,
-      # still tracked as todo in quality_scale.yaml.
-      - name: Run mypy
+      # Strict type check (Platinum strict-typing). Config lives in pyproject.toml
+      # ([tool.mypy] strict = true).
+      - name: Run mypy (strict)
         run: mypy custom_components/fluidra_pool/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Platinum `strict-typing` reached** — the integration now passes `mypy --strict` (120 type issues resolved across 29 modules), and CI enforces it via `[tool.mypy] strict = true`. Type annotations only; no runtime behaviour change.
+- **Test coverage raised 94% → 97%** (1171 → 1259 tests); every module is now ≥ 90%. Previously thin modules (`switch/pump`, `switch/schedule`, `number`, `light`, `select/schedule`, `select/light`, `sensor/chlorinator`) are now fully covered.
+
 ## [2.42.2] - 2026-06-19
 
 ### Fixed

--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -272,7 +272,8 @@ def _get_device_data(coordinator: FluidraDataUpdateCoordinator, device_id: str) 
         return None
 
     for pool_data in coordinator.data.values():
-        for device in pool_data.get("devices", []):
+        devices: list[dict[str, Any]] = pool_data.get("devices", [])
+        for device in devices:
             if device.get("device_id") == device_id:
                 return device
     return None
@@ -290,7 +291,8 @@ def _get_schedule_component(coordinator: FluidraDataUpdateCoordinator, device_id
     device = _get_device_data(coordinator, device_id)
     if device is None:
         return COMPONENT_SCHEDULE
-    return DeviceIdentifier.get_feature(device, "schedule_component", COMPONENT_SCHEDULE)
+    component: int = DeviceIdentifier.get_feature(device, "schedule_component", COMPONENT_SCHEDULE)
+    return component
 
 
 def _get_coordinator_for_device(hass: HomeAssistant, device_id: str) -> FluidraDataUpdateCoordinator:
@@ -298,7 +300,7 @@ def _get_coordinator_for_device(hass: HomeAssistant, device_id: str) -> FluidraD
     coordinators: list[FluidraDataUpdateCoordinator] = []
     for entry in hass.config_entries.async_loaded_entries(DOMAIN):
         runtime_data = getattr(entry, "runtime_data", None)
-        coordinator = getattr(runtime_data, "coordinator", None)
+        coordinator: FluidraDataUpdateCoordinator | None = getattr(runtime_data, "coordinator", None)
         if coordinator is None:
             continue
 
@@ -453,7 +455,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator_for_device(hass, device_id)
 
         # Define presets
-        presets: dict[str, list[dict]] = {
+        presets: dict[str, list[dict[str, Any]]] = {
             "standard": [
                 {"enabled": True, "start_time": "08:00", "end_time": "12:00", "mode": "1", "days": [1, 2, 3, 4, 5]},
                 {"enabled": True, "start_time": "18:00", "end_time": "20:00", "mode": "1", "days": [1, 2, 3, 4, 5]},

--- a/custom_components/fluidra_pool/api_resilience.py
+++ b/custom_components/fluidra_pool/api_resilience.py
@@ -155,7 +155,7 @@ class RateLimiter:
 
     max_requests: int = RATE_LIMIT_REQUESTS
     window_seconds: float = RATE_LIMIT_WINDOW
-    _timestamps: deque = field(default_factory=deque)
+    _timestamps: deque[float] = field(default_factory=deque)
 
     def can_execute(self) -> bool:
         """Check if request can be executed within rate limits."""

--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
-from homeassistant.components.climate import (
-    ClimateEntity,
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
@@ -16,7 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .api_resilience import FluidraError
 from .const import (
@@ -46,6 +46,10 @@ from .device_registry import DeviceIdentifier
 from .entity import FluidraPoolControlEntity
 from .utils import mask_device_id
 
+if TYPE_CHECKING:
+    from .coordinator import FluidraDataUpdateCoordinator
+    from .fluidra_api import FluidraPoolAPI
+
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0  # Coordinator handles all updates
@@ -54,7 +58,7 @@ PARALLEL_UPDATES = 0  # Coordinator handles all updates
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: FluidraPoolConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Fluidra Pool climate entities."""
     coordinator = config_entry.runtime_data.coordinator
@@ -87,7 +91,13 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         "_pending_temperature",
     )
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
         """Initialize the climate entity."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._pending_temperature: float | None = None
@@ -606,7 +616,7 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             ) from err
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         device_data = self.device_data
         attrs = {

--- a/custom_components/fluidra_pool/config_flow.py
+++ b/custom_components/fluidra_pool/config_flow.py
@@ -282,7 +282,7 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             raise RuntimeError("Reconfigure config entry not found")
         return entry
 
-    async def _test_credentials(self, email: str, password: str) -> tuple[str | None, dict | None]:
+    async def _test_credentials(self, email: str, password: str) -> tuple[str | None, dict[str, Any] | None]:
         """Test credentials and return (error_key, mfa_info) tuple.
 
         Only tests Cognito authentication, not pool discovery.

--- a/custom_components/fluidra_pool/coordinator/_parsers.py
+++ b/custom_components/fluidra_pool/coordinator/_parsers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import time
 import logging
+from typing import Any
 
 from homeassistant.util import dt as dt_util
 
@@ -31,7 +32,7 @@ _OPERATION_TO_PERCENT: dict[str, int] = {
 }
 
 
-def parse_dm24049704_schedule_format(reported_value: dict) -> list[dict]:
+def parse_dm24049704_schedule_format(reported_value: dict[str, Any]) -> list[dict[str, Any]]:
     """Parse DM24049704 chlorinator schedule format (programs/slots) to standard format.
 
     The API returns component 258 in this format::
@@ -73,7 +74,7 @@ def parse_dm24049704_schedule_format(reported_value: dict) -> list[dict]:
         for days in program_days.values():
             days.sort()
 
-        result: list[dict] = []
+        result: list[dict[str, Any]] = []
         schedule_id = 1  # DM24049704 uses IDs starting at 1.
 
         for program in programs:
@@ -159,7 +160,7 @@ def _parse_cron_days(cron_time: str) -> list[int]:
     return []
 
 
-def calculate_auto_speed_from_schedules(device: dict) -> int:
+def calculate_auto_speed_from_schedules(device: dict[str, Any]) -> int:
     """Calculate current speed based on active schedules in auto mode."""
     try:
         schedule_data = device.get("schedule_data", [])

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -59,7 +59,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ),
         )
 
-    def get_pools_from_data(self) -> list[dict]:
+    def get_pools_from_data(self) -> list[dict[str, Any]]:
         """Get pools list from coordinator data (no API call).
 
         Use this in platform setup instead of api.get_pools() for faster startup.
@@ -111,15 +111,17 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("Failed to cleanup removed devices: %s", err)
 
     # Kept as a thin wrapper so existing callers (and tests) keep working.
-    def _parse_dm24049704_schedule_format(self, reported_value: dict) -> list[dict]:
+    def _parse_dm24049704_schedule_format(self, reported_value: dict[str, Any]) -> list[dict[str, Any]]:
         """Parse DM24049704 chlorinator schedule format (programs/slots) to standard format."""
         return parse_dm24049704_schedule_format(reported_value)
 
-    def _calculate_auto_speed_from_schedules(self, device: dict) -> int:
+    def _calculate_auto_speed_from_schedules(self, device: dict[str, Any]) -> int:
         """Calculate current speed based on active schedules in auto mode."""
         return calculate_auto_speed_from_schedules(device)
 
-    async def _fetch_components_parallel(self, device_id: str, components_to_scan: list[int]) -> dict[int, dict]:
+    async def _fetch_components_parallel(
+        self, device_id: str, components_to_scan: list[int]
+    ) -> dict[int, dict[str, Any]]:
         """Fetch multiple component states in parallel for a device.
 
         Returns a dict mapping component_id to component_state.
@@ -127,7 +129,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Cap concurrency so we don't trip rate limits or exhaust the connector.
         semaphore = asyncio.Semaphore(10)
 
-        async def fetch_one(component_id: int) -> tuple[int, dict | None]:
+        async def fetch_one(component_id: int) -> tuple[int, dict[str, Any] | None]:
             async with semaphore:
                 state = await self.api.get_component_state(device_id, component_id)
                 return (component_id, state)
@@ -135,7 +137,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         tasks = [fetch_one(cid) for cid in components_to_scan]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        component_states: dict[int, dict] = {}
+        component_states: dict[int, dict[str, Any]] = {}
         for result in results:
             if isinstance(result, BaseException):
                 # Keep a diagnostic trace instead of silently dropping the failure.
@@ -146,7 +148,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 component_states[cid] = state
         return component_states
 
-    def _process_component_state(self, device: dict, pool_id: str, component_id: int, component_state: dict) -> None:
+    def _process_component_state(
+        self, device: dict[str, Any], pool_id: str, component_id: int, component_state: dict[str, Any]
+    ) -> None:
         """Process a single component state and update device data.
 
         Extracted from _async_update_data to reduce code duplication.
@@ -365,7 +369,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._track_schedule_count(pool_id, device_id, schedule_data)
             device[f"component_{component_id}_data"] = component_state
 
-    def _track_schedule_count(self, pool_id: str, device_id: str, schedule_data: list[dict]) -> None:
+    def _track_schedule_count(self, pool_id: str, device_id: str, schedule_data: list[dict[str, Any]]) -> None:
         """Track schedule count changes for cleanup."""
         device_key = f"{pool_id}_{device_id}"
         # Cleanup happens asynchronously in a separate task to avoid blocking.
@@ -442,7 +446,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.exception("Error updating Fluidra Pool data")
             raise UpdateFailed(f"Error communicating with API: {type(err).__name__}") from err
 
-    async def _refresh_pool(self, pool: dict, previous_data: dict) -> None:
+    async def _refresh_pool(self, pool: dict[str, Any], previous_data: dict[str, Any]) -> None:
         """Refresh a single pool and its devices."""
         pool_id = pool["id"]
         prev_pool = previous_data.get(pool_id, {})

--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -120,7 +120,7 @@ class DeviceIdentifier:
         return False
 
     @staticmethod
-    def _check_component_signature(device: dict, component_id: int, value_patterns: list[str]) -> bool:
+    def _check_component_signature(device: dict[str, Any], component_id: int, value_patterns: list[str]) -> bool:
         """Check if a specific component contains expected values."""
         try:
             components = device.get("components", {})
@@ -133,7 +133,7 @@ class DeviceIdentifier:
         return False
 
     @staticmethod
-    def identify_device(device: dict) -> DeviceConfig | None:
+    def identify_device(device: dict[str, Any]) -> DeviceConfig | None:
         """Identify device type and return its configuration.
 
         Returns the best matching DeviceConfig based on priority and matching criteria.
@@ -177,7 +177,7 @@ class DeviceIdentifier:
         return result
 
     @staticmethod
-    def should_create_entity(device: dict, entity_type: str) -> bool:
+    def should_create_entity(device: dict[str, Any], entity_type: str) -> bool:
         """Check if a specific entity type should be created for this device."""
         config = DeviceIdentifier.identify_device(device)
         if not config:
@@ -185,7 +185,7 @@ class DeviceIdentifier:
         return entity_type in config.entities
 
     @staticmethod
-    def get_components_range(device: dict) -> int:
+    def get_components_range(device: dict[str, Any]) -> int:
         """Get the component scan range for this device."""
         config = DeviceIdentifier.identify_device(device)
         if not config:
@@ -193,15 +193,16 @@ class DeviceIdentifier:
         return config.components_range
 
     @staticmethod
-    def has_feature(device: dict, feature_name: str) -> bool:
+    def has_feature(device: dict[str, Any], feature_name: str) -> bool:
         """Check if device supports a specific feature."""
         config = DeviceIdentifier.identify_device(device)
         if not config:
             return False
-        return config.features.get(feature_name, False)
+        feature: bool = config.features.get(feature_name, False)
+        return feature
 
     @staticmethod
-    def get_feature(device: dict, feature_name: str, default: Any = None) -> Any:
+    def get_feature(device: dict[str, Any], feature_name: str, default: Any = None) -> Any:
         """Get a feature value for this device."""
         config = DeviceIdentifier.identify_device(device)
         if not config:

--- a/custom_components/fluidra_pool/diagnostics.py
+++ b/custom_components/fluidra_pool/diagnostics.py
@@ -113,7 +113,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Fluidra
     }
 
 
-def _redact_pools_data(pools_data: dict) -> dict:
+def _redact_pools_data(pools_data: dict[str, Any]) -> dict[str, Any]:
     """Redact sensitive information from pools data."""
     if not pools_data:
         return {}
@@ -145,12 +145,12 @@ def _redact_pools_data(pools_data: dict) -> dict:
     return redacted
 
 
-def _redact_devices_data(devices: list) -> list:
+def _redact_devices_data(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Redact sensitive information from devices data."""
     if not devices:
         return []
 
-    redacted_devices = []
+    redacted_devices: list[dict[str, Any]] = []
     for i, device in enumerate(devices):
         if isinstance(device, dict):
             redacted_device: dict[str, Any] = {}
@@ -181,7 +181,7 @@ def _redact_devices_data(devices: list) -> list:
     return redacted_devices
 
 
-def _redact_component_data(component_id: Any, component: dict) -> dict:
+def _redact_component_data(component_id: Any, component: dict[str, Any]) -> dict[str, Any]:
     """Redact a component dict.
 
     Telemetry components (pH, ORP, temperature, speed, schedules, …) are NOT

--- a/custom_components/fluidra_pool/entity.py
+++ b/custom_components/fluidra_pool/entity.py
@@ -35,11 +35,13 @@ class FluidraPoolEntity(CoordinatorEntity):
     @property
     def device_data(self) -> dict[str, Any]:
         """Get device data from coordinator."""
-        if self.coordinator.data is None:
+        data = self.coordinator.data
+        if data is None:
             return {}
-        pool = self.coordinator.data.get(self._pool_id)
+        pool: dict[str, Any] | None = data.get(self._pool_id)
         if pool:
-            for device in pool.get("devices", []):
+            devices: list[dict[str, Any]] = pool.get("devices", [])
+            for device in devices:
                 if device.get("device_id") == self._device_id:
                     return device
         return {}
@@ -47,9 +49,11 @@ class FluidraPoolEntity(CoordinatorEntity):
     @property
     def pool_data(self) -> dict[str, Any]:
         """Get pool data from coordinator."""
-        if self.coordinator.data is None:
+        data = self.coordinator.data
+        if data is None:
             return {}
-        return self.coordinator.data.get(self._pool_id, {})
+        pool: dict[str, Any] = data.get(self._pool_id, {})
+        return pool
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/fluidra_pool/fluidra_api/_devices.py
+++ b/custom_components/fluidra_pool/fluidra_api/_devices.py
@@ -188,7 +188,8 @@ class DevicesMixin(FluidraAPIBase):
     def get_device_by_id(self, device_id: str) -> dict[str, Any] | None:
         """Return a specific device by ID across all pools."""
         for pool in self._pools:
-            for device in pool["devices"]:
+            devices: list[dict[str, Any]] = pool["devices"]
+            for device in devices:
                 if device.get("device_id") == device_id:
                     return device
         return None
@@ -223,12 +224,14 @@ class DevicesMixin(FluidraAPIBase):
         if not isinstance(data, list):
             return None
 
-        for device in data:
+        device_list: list[dict[str, Any]] = data
+        for device in device_list:
             if device.get("id") == device_id:
                 return device
             children = device.get("devices")
             if isinstance(children, list):
-                for child in children:
+                child_list: list[dict[str, Any]] = children
+                for child in child_list:
                     if child.get("id") == device_id:
                         return child
         return None

--- a/custom_components/fluidra_pool/light.py
+++ b/custom_components/fluidra_pool/light.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_RGBW_COLOR,
-    ColorMode,
     LightEntity,
 )
+from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .api_resilience import FluidraError
 from .const import (
@@ -26,6 +26,10 @@ from .const import (
 )
 from .entity import FluidraPoolControlEntity
 
+if TYPE_CHECKING:
+    from .coordinator import FluidraDataUpdateCoordinator
+    from .fluidra_api import FluidraPoolAPI
+
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
@@ -34,7 +38,7 @@ PARALLEL_UPDATES = 0
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FluidraPoolConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Fluidra Pool light entities."""
     coordinator = entry.runtime_data.coordinator
@@ -71,7 +75,13 @@ class FluidraLight(FluidraPoolControlEntity, LightEntity):
     _attr_color_mode = ColorMode.RGBW
     _attr_supported_color_modes = {ColorMode.RGBW}
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str) -> None:
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
         """Initialize the light."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._attr_unique_id = f"{DOMAIN}_{pool_id}_{device_id}_light"

--- a/custom_components/fluidra_pool/number.py
+++ b/custom_components/fluidra_pool/number.py
@@ -3,20 +3,23 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .api_resilience import FluidraError
 from .const import DEVICE_TYPE_PUMP, DOMAIN, FluidraPoolConfigEntry
 from .coordinator import FluidraDataUpdateCoordinator
 from .device_registry import DeviceIdentifier
 from .entity import FluidraPoolControlEntity
+
+if TYPE_CHECKING:
+    from .fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +29,7 @@ PARALLEL_UPDATES = 0  # Coordinator handles all updates
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: FluidraPoolConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Fluidra Pool number entities."""
     coordinator = config_entry.runtime_data.coordinator
@@ -71,7 +74,7 @@ class FluidraChlorinatorLevelNumber(FluidraPoolControlEntity, NumberEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -162,7 +165,7 @@ class FluidraChlorinatorPhSetpoint(FluidraPoolControlEntity, NumberEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -204,9 +207,10 @@ class FluidraChlorinatorPhSetpoint(FluidraPoolControlEntity, NumberEntity):
         divisor = DeviceIdentifier.get_feature(self.device_data, "ph_setpoint_divisor", 100)
 
         try:
-            return float(raw_value) / divisor
+            value: float = float(raw_value) / divisor
         except (ValueError, TypeError):
             return 7.2
+        return value
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the pH setpoint."""
@@ -279,7 +283,7 @@ class FluidraChlorinatorOrpSetpoint(FluidraPoolControlEntity, NumberEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -383,7 +387,7 @@ class FluidraLightEffectSpeed(FluidraPoolControlEntity, NumberEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:

--- a/custom_components/fluidra_pool/quality_scale.yaml
+++ b/custom_components/fluidra_pool/quality_scale.yaml
@@ -67,6 +67,4 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession: done
-  strict-typing:
-    status: todo
-    comment: mypy --strict is not yet enforced in CI.
+  strict-typing: done

--- a/custom_components/fluidra_pool/repairs.py
+++ b/custom_components/fluidra_pool/repairs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -65,7 +67,7 @@ def async_delete_connection_issue(hass: HomeAssistant) -> None:
 async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
-    data: dict | None,
+    data: dict[str, Any] | None,
 ) -> RepairsFlow:
     """Create a repair flow for a fixable issue.
 

--- a/custom_components/fluidra_pool/select/chlorinator.py
+++ b/custom_components/fluidra_pool/select/chlorinator.py
@@ -19,6 +19,7 @@ from ..entity import FluidraPoolControlEntity
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class FluidraChlorinatorModeSelect(FluidraPoolControlEntity, SelectEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -69,7 +70,8 @@ class FluidraChlorinatorModeSelect(FluidraPoolControlEntity, SelectEntity):
             mode_value = int(mode_value)
         except (ValueError, TypeError):
             mode_value = 0
-        return self._value_to_mode.get(mode_value, "off")
+        mode: str = self._value_to_mode.get(mode_value, "off")
+        return mode
 
     def _optimistic_expired(self) -> bool:
         """Return True once the optimistic value has outlived its timeout."""

--- a/custom_components/fluidra_pool/select/light.py
+++ b/custom_components/fluidra_pool/select/light.py
@@ -16,6 +16,7 @@ from ..entity import FluidraPoolControlEntity
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class FluidraLightEffectSelect(FluidraPoolControlEntity, SelectEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:

--- a/custom_components/fluidra_pool/select/pump.py
+++ b/custom_components/fluidra_pool/select/pump.py
@@ -23,6 +23,7 @@ from ..entity import FluidraPoolControlEntity
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class FluidraPumpSpeedSelect(FluidraPoolControlEntity, SelectEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:

--- a/custom_components/fluidra_pool/select/schedule.py
+++ b/custom_components/fluidra_pool/select/schedule.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import EntityCategory
 
 from ..api_resilience import FluidraError
 from ..const import COMMAND_CONFIRMATION_DELAY, DOMAIN, UI_UPDATE_DELAY
@@ -19,6 +19,7 @@ from ..utils import convert_cron_days
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class FluidraScheduleModeSelect(FluidraPoolControlEntity, SelectEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
         schedule_id: str,
@@ -48,7 +49,7 @@ class FluidraScheduleModeSelect(FluidraPoolControlEntity, SelectEntity):
         # Speed options for schedules (using translation keys from schedule_mode.state).
         self._attr_options = ["0", "1", "2"]
 
-    def _get_schedule_data(self) -> dict | None:
+    def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
             device_data = self.device_data
@@ -59,7 +60,8 @@ class FluidraScheduleModeSelect(FluidraPoolControlEntity, SelectEntity):
                 for schedule in schedules:
                     schedule_id = schedule.get("id")
                     if str(schedule_id) == str(self._schedule_id):
-                        return schedule
+                        schedule_data: dict[str, Any] = schedule
+                        return schedule_data
 
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
@@ -196,7 +198,7 @@ class FluidraChlorinatorScheduleSpeedSelect(FluidraPoolControlEntity, SelectEnti
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
         schedule_id: str,
@@ -226,7 +228,7 @@ class FluidraChlorinatorScheduleSpeedSelect(FluidraPoolControlEntity, SelectEnti
         self._attr_unique_id = f"fluidra_{self._device_id}_schedule_{schedule_id}_speed"
         self._attr_entity_category = EntityCategory.CONFIG
 
-    def _get_schedule_data(self) -> dict | None:
+    def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
             device_data = self.device_data
@@ -235,7 +237,8 @@ class FluidraChlorinatorScheduleSpeedSelect(FluidraPoolControlEntity, SelectEnti
                 for schedule in schedules:
                     schedule_id = schedule.get("id")
                     if str(schedule_id) == str(self._schedule_id):
-                        return schedule
+                        schedule_data: dict[str, Any] = schedule
+                        return schedule_data
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
         return None

--- a/custom_components/fluidra_pool/sensor/base.py
+++ b/custom_components/fluidra_pool/sensor/base.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import DOMAIN
 from ..device_registry import DeviceIdentifier
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 
 class FluidraPoolSensorEntity(CoordinatorEntity, SensorEntity):
@@ -17,7 +23,14 @@ class FluidraPoolSensorEntity(CoordinatorEntity, SensorEntity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, sensor_type: str = ""):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        sensor_type: str = "",
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._api = api
@@ -26,23 +39,27 @@ class FluidraPoolSensorEntity(CoordinatorEntity, SensorEntity):
         self._sensor_type = sensor_type
 
     @property
-    def device_data(self) -> dict:
+    def device_data(self) -> dict[str, Any]:
         """Get device data from coordinator."""
-        if self.coordinator.data is None:
+        data = self.coordinator.data
+        if data is None:
             return {}
-        pool = self.coordinator.data.get(self._pool_id)
+        pool: dict[str, Any] | None = data.get(self._pool_id)
         if pool:
-            for device in pool.get("devices", []):
+            devices: list[dict[str, Any]] = pool.get("devices", [])
+            for device in devices:
                 if device.get("device_id") == self._device_id:
                     return device
         return {}
 
     @property
-    def pool_data(self) -> dict:
+    def pool_data(self) -> dict[str, Any]:
         """Get pool data from coordinator."""
-        if self.coordinator.data is None:
+        data = self.coordinator.data
+        if data is None:
             return {}
-        return self.coordinator.data.get(self._pool_id, {})
+        pool: dict[str, Any] = data.get(self._pool_id, {})
+        return pool
 
     @property
     def unique_id(self) -> str:
@@ -85,7 +102,13 @@ class FluidraPoolSensorBase(CoordinatorEntity, SensorEntity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, api, pool_id: str, sensor_type: str = ""):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        sensor_type: str = "",
+    ) -> None:
         """Initialize the pool sensor."""
         super().__init__(coordinator)
         self._api = api
@@ -93,11 +116,13 @@ class FluidraPoolSensorBase(CoordinatorEntity, SensorEntity):
         self._sensor_type = sensor_type
 
     @property
-    def pool_data(self) -> dict:
+    def pool_data(self) -> dict[str, Any]:
         """Get pool data from coordinator."""
-        if self.coordinator.data is None:
+        data = self.coordinator.data
+        if data is None:
             return {}
-        return self.coordinator.data.get(self._pool_id, {})
+        pool: dict[str, Any] = data.get(self._pool_id, {})
+        return pool
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -19,6 +19,7 @@ from ..device_registry import DeviceIdentifier
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class FluidraChlorinatorSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
         sensor_type: str,
@@ -111,13 +112,14 @@ class FluidraChlorinatorSensor(CoordinatorEntity, SensorEntity):
             self._divisor = custom_divisors[sensor_type]
 
     @property
-    def device_data(self) -> dict:
+    def device_data(self) -> dict[str, Any]:
         """Get device data from coordinator."""
         if self.coordinator.data is None:
             return {}
-        pool = self.coordinator.data.get(self._pool_id)
+        pool: dict[str, Any] | None = self.coordinator.data.get(self._pool_id)
         if pool:
-            for device in pool.get("devices", []):
+            devices: list[dict[str, Any]] = pool.get("devices", [])
+            for device in devices:
                 if device.get("device_id") == self._device_id:
                     return device
         return {}
@@ -157,7 +159,8 @@ class FluidraChlorinatorSensor(CoordinatorEntity, SensorEntity):
             return None
 
         try:
-            return float(raw_value) / self._divisor
+            value: float = float(raw_value) / self._divisor
+            return value
         except (ValueError, TypeError):
             _LOGGER.debug("Failed to parse sensor value %s for component %s", raw_value, self._component_id)
             return None

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -16,6 +16,7 @@ from .base import FluidraPoolSensorEntity
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 class FluidraTemperatureSensor(FluidraPoolSensorEntity):
     """Temperature sensor for pool heaters and heat pumps."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, sensor_type: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        sensor_type: str,
+    ) -> None:
         """Initialize temperature sensor."""
         super().__init__(coordinator, api, pool_id, device_id, sensor_type)
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
@@ -100,7 +108,13 @@ class FluidraRunningHoursSensor(FluidraPoolSensorEntity):
     _attr_native_unit_of_measurement = "h"
     _attr_icon = "mdi:clock-outline"
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
         """Initialize running hours sensor."""
         super().__init__(coordinator, api, pool_id, device_id, "running_hours")
 
@@ -120,7 +134,7 @@ class FluidraPumpSpeedSensor(FluidraPoolSensorEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -162,7 +176,7 @@ class FluidraPumpSpeedSensor(FluidraPoolSensorEntity):
         return self._get_speed_mode()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         is_running = self.device_data.get("is_running", False)
         pump_reported = self.device_data.get("pump_reported")
@@ -198,7 +212,7 @@ class FluidraPumpScheduleSensor(FluidraPoolSensorEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -223,7 +237,7 @@ class FluidraPumpScheduleSensor(FluidraPoolSensorEntity):
             pass
         return None
 
-    def _format_schedule_time(self, schedule: dict) -> str:
+    def _format_schedule_time(self, schedule: dict[str, Any]) -> str:
         """Format schedule time range for display."""
         start_time = self._parse_cron_time(schedule.get("startTime", ""))
         end_time = self._parse_cron_time(schedule.get("endTime", ""))
@@ -237,7 +251,7 @@ class FluidraPumpScheduleSensor(FluidraPoolSensorEntity):
         speed_map = {"0": "low (45%)", "1": "medium (65%)", "2": "high (100%)"}
         return speed_map.get(operation, "low (45%)")
 
-    def _get_current_schedule(self, schedules: list[dict]) -> dict | None:
+    def _get_current_schedule(self, schedules: list[dict[str, Any]]) -> dict[str, Any] | None:
         """Get currently active schedule based on current time."""
         now = datetime.now().time()
 
@@ -252,12 +266,13 @@ class FluidraPumpScheduleSensor(FluidraPoolSensorEntity):
                 return schedule
         return None
 
-    def _get_schedules_data(self) -> list[dict]:
+    def _get_schedules_data(self) -> list[dict[str, Any]]:
         """Get schedules data from device data."""
         device_data = self.device_data
 
         if "schedule_data" in device_data:
-            return device_data["schedule_data"]
+            schedule_data: list[dict[str, Any]] = device_data["schedule_data"]
+            return schedule_data
         return []
 
     @property
@@ -320,7 +335,7 @@ class FluidraDeviceInfoSensor(FluidraPoolSensorEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:

--- a/custom_components/fluidra_pool/sensor/pool.py
+++ b/custom_components/fluidra_pool/sensor/pool.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature
 
 from .base import FluidraPoolSensorBase
 
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
+
 
 class FluidraPoolWeatherSensor(FluidraPoolSensorBase):
     """Sensor for weather temperature at pool location."""
 
-    def __init__(self, coordinator, api, pool_id: str):
+    def __init__(self, coordinator: FluidraDataUpdateCoordinator, api: FluidraPoolAPI, pool_id: str) -> None:
         """Initialize the pool weather sensor."""
         super().__init__(coordinator, api, pool_id, "weather")
         self._attr_translation_key = "weather_temperature"
@@ -30,7 +36,8 @@ class FluidraPoolWeatherSensor(FluidraPoolSensorBase):
                 if isinstance(current, dict) and "main" in current and "temp" in current["main"]:
                     # Convert Kelvin → Celsius (rounded to 1 decimal).
                     temp_kelvin = current["main"]["temp"]
-                    return round(temp_kelvin - 273.15, 1)
+                    value: float = round(temp_kelvin - 273.15, 1)
+                    return value
 
         return None
 
@@ -61,7 +68,7 @@ class FluidraPoolStatusSensor(FluidraPoolSensorBase):
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_options = ["using", "maintenance", "offline", "winterized", "connected", "unknown_state"]
 
-    def __init__(self, coordinator, api, pool_id: str):
+    def __init__(self, coordinator: FluidraDataUpdateCoordinator, api: FluidraPoolAPI, pool_id: str) -> None:
         """Initialize the pool status sensor."""
         super().__init__(coordinator, api, pool_id, "status")
         self._attr_translation_key = "pool_status"
@@ -102,7 +109,7 @@ class FluidraPoolStatusSensor(FluidraPoolSensorBase):
         return "mdi:help-circle"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         pool_data = self.pool_data
         attrs = {}
@@ -165,7 +172,7 @@ class FluidraPoolStatusSensor(FluidraPoolSensorBase):
 class FluidraPoolLocationSensor(FluidraPoolSensorBase):
     """Sensor for pool location and geographic information."""
 
-    def __init__(self, coordinator, api, pool_id: str):
+    def __init__(self, coordinator: FluidraDataUpdateCoordinator, api: FluidraPoolAPI, pool_id: str) -> None:
         """Initialize the pool location sensor."""
         super().__init__(coordinator, api, pool_id, "location")
         self._attr_translation_key = "pool_location"
@@ -177,8 +184,8 @@ class FluidraPoolLocationSensor(FluidraPoolSensorBase):
 
         geolocation = pool_data.get("geolocation", {})
         if geolocation:
-            locality = geolocation.get("locality")
-            country_code = geolocation.get("countryCode")
+            locality: str | None = geolocation.get("locality")
+            country_code: str | None = geolocation.get("countryCode")
 
             if locality and country_code:
                 return f"{locality}, {country_code}"
@@ -195,7 +202,7 @@ class FluidraPoolLocationSensor(FluidraPoolSensorBase):
         return "mdi:map-marker"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         pool_data = self.pool_data
         attrs = {}
@@ -226,7 +233,7 @@ class FluidraPoolWaterQualitySensor(FluidraPoolSensorBase):
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_options = ["auto", "manual", "not_configured"]
 
-    def __init__(self, coordinator, api, pool_id: str):
+    def __init__(self, coordinator: FluidraDataUpdateCoordinator, api: FluidraPoolAPI, pool_id: str) -> None:
         """Initialize the pool water quality sensor."""
         super().__init__(coordinator, api, pool_id, "water_quality")
         self._attr_translation_key = "water_quality"
@@ -252,7 +259,7 @@ class FluidraPoolWaterQualitySensor(FluidraPoolSensorBase):
         return "mdi:water-check"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         pool_data = self.pool_data
         attrs = {}

--- a/custom_components/fluidra_pool/switch/base.py
+++ b/custom_components/fluidra_pool/switch/base.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from homeassistant.components.switch import SwitchEntity
 
 from ..const import DOMAIN
 from ..entity import FluidraPoolControlEntity
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 
 class FluidraPoolSwitchEntity(FluidraPoolControlEntity, SwitchEntity):
@@ -15,7 +20,13 @@ class FluidraPoolSwitchEntity(FluidraPoolControlEntity, SwitchEntity):
 
     __slots__ = ("_last_action_time", "_pending_state")
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._pending_state: bool | None = None

--- a/custom_components/fluidra_pool/switch/chlorinator.py
+++ b/custom_components/fluidra_pool/switch/chlorinator.py
@@ -16,6 +16,7 @@ from .base import FluidraPoolSwitchEntity
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class FluidraChlorinatorBoostSwitch(FluidraPoolSwitchEntity):
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
-        api,
+        api: FluidraPoolAPI,
         pool_id: str,
         device_id: str,
     ) -> None:
@@ -198,7 +199,8 @@ class FluidraChlorinatorSwitch(FluidraPoolSwitchEntity):
         pump_reported = self.device_data.get("pump_reported")
         if pump_reported is not None:
             return bool(pump_reported)
-        return self.device_data.get("is_running", False)
+        value: bool = self.device_data.get("is_running", False)
+        return value
 
     @property
     def is_on(self) -> bool:
@@ -266,7 +268,7 @@ class FluidraChlorinatorSwitch(FluidraPoolSwitchEntity):
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="chlorinator_set_failed") from err
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         on_off_component = DeviceIdentifier.get_feature(self.device_data, "on_off_component", 9)
         return {

--- a/custom_components/fluidra_pool/switch/heater.py
+++ b/custom_components/fluidra_pool/switch/heater.py
@@ -55,7 +55,8 @@ class FluidraHeatPumpSwitch(FluidraPoolSwitchEntity):
         if self.device_data.get("is_running", False):
             return True
 
-        return self.device_data.get("is_heating", False)
+        value: bool = self.device_data.get("is_heating", False)
+        return value
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the heat pump on using discovered API with optimistic UI."""
@@ -110,9 +111,9 @@ class FluidraHeatPumpSwitch(FluidraPoolSwitchEntity):
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="heat_pump_set_failed") from e
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attrs = {
+        attrs: dict[str, Any] = {
             "component_id": 9,
             "operation": "heat_pump_control",
             "device_type": "heat_pump",
@@ -191,7 +192,7 @@ class FluidraHeaterSwitch(FluidraPoolSwitchEntity):
             self._clear_pending_state()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         attrs: dict[str, Any] = {}
         if "current_temperature" in self.device_data:

--- a/custom_components/fluidra_pool/switch/pump.py
+++ b/custom_components/fluidra_pool/switch/pump.py
@@ -89,7 +89,7 @@ class FluidraPumpSwitch(FluidraPoolSwitchEntity):
             self._clear_pending_state()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         return {
             "component_id": 9,
@@ -181,7 +181,7 @@ class FluidraAutoModeSwitch(FluidraPoolSwitchEntity):
             self._clear_pending_state()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         return {
             "component_id": 10,

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import EntityCategory
 
 from ..api_resilience import FluidraError
 from ..const import DOMAIN
@@ -14,13 +14,24 @@ from ..device_registry import DeviceIdentifier
 from ..utils import convert_cron_days
 from .base import FluidraPoolSwitchEntity
 
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
     """Switch for enabling/disabling existing schedules."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+    ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._schedule_id = schedule_id
@@ -42,7 +53,7 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
             return "mdi:calendar-clock"
         return "mdi:calendar-outline"
 
-    def _get_schedule_data(self) -> dict | None:
+    def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
             device_data = self.device_data
@@ -56,7 +67,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                 for schedule in schedules:
                     schedule_id = schedule.get("id")
                     if str(schedule_id) == str(self._schedule_id):
-                        return schedule
+                        value: dict[str, Any] = schedule
+                        return value
 
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
@@ -64,7 +76,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
 
     def _get_schedule_component(self) -> int:
         """Get the schedule component used by this device."""
-        return DeviceIdentifier.get_feature(self.device_data, "schedule_component", 20)
+        value: int = DeviceIdentifier.get_feature(self.device_data, "schedule_component", 20)
+        return value
 
     @property
     def available(self) -> bool:
@@ -87,7 +100,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                 return self._pending_state
 
         if schedule:
-            return schedule.get("enabled", False)
+            value: bool = schedule.get("enabled", False)
+            return value
         return False
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -216,7 +230,7 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
             self._clear_pending_state()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         schedule = self._get_schedule_data()
         attrs: dict[str, Any] = {

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import time
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from homeassistant.components.time import TimeEntity
@@ -18,7 +18,8 @@ from ..entity import FluidraPoolControlEntity
 from ..utils import extract_cron_days
 
 if TYPE_CHECKING:
-    pass
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +75,15 @@ class FluidraScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
 
     __slots__ = ("_optimistic_value", "_schedule_id", "_time_type")
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str, time_type: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+        time_type: str,
+    ) -> None:
         """Initialize the time entity."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._schedule_id = schedule_id
@@ -85,7 +94,7 @@ class FluidraScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
         """Get the correct schedule component ID for this device."""
         device_data = self.device_data
         # Per-device override (e.g. 258 for DM24049704 chlorinator).
-        schedule_comp = DeviceIdentifier.get_feature(device_data, "schedule_component")
+        schedule_comp: int = DeviceIdentifier.get_feature(device_data, "schedule_component")
         if schedule_comp:
             return schedule_comp
         # Default to component 20 (pumps).
@@ -114,7 +123,7 @@ class FluidraScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
             "via_device": (DOMAIN, self._pool_id),
         }
 
-    def _get_schedule_data(self) -> dict | None:
+    def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
             device_data = self.device_data
@@ -128,7 +137,8 @@ class FluidraScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
                 for schedule in schedules:
                     schedule_id = schedule.get("id")
                     if str(schedule_id) == str(self._schedule_id):
-                        return schedule
+                        result: dict[str, Any] = schedule
+                        return result
 
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
@@ -155,7 +165,7 @@ class FluidraScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
         days_str = ",".join(map(str, days))
         return f"{time_obj.minute} {time_obj.hour} * * {days_str}"
 
-    def _get_schedule_days(self, schedule: dict | None) -> set[int]:
+    def _get_schedule_days(self, schedule: dict[str, Any] | None) -> set[int]:
         """Return the active days for a schedule."""
         if not schedule:
             return set(range(1, 8))
@@ -243,7 +253,15 @@ class FluidraLightScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
 
     SCHEDULE_COMPONENT = 40  # LumiPlus light schedules live on component 40.
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str, time_type: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+        time_type: str,
+    ) -> None:
         """Initialize the time entity."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._schedule_id = schedule_id
@@ -261,7 +279,7 @@ class FluidraLightScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
             "via_device": (DOMAIN, self._pool_id),
         }
 
-    def _get_schedule_data(self) -> dict | None:
+    def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
             device_data = self.device_data
@@ -273,7 +291,8 @@ class FluidraLightScheduleTimeEntity(FluidraPoolControlEntity, TimeEntity):
                 for schedule in schedules:
                     schedule_id = schedule.get("id")
                     if str(schedule_id) == str(self._schedule_id):
-                        return schedule
+                        result: dict[str, Any] = schedule
+                        return result
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
         return None

--- a/custom_components/fluidra_pool/time/light.py
+++ b/custom_components/fluidra_pool/time/light.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 from datetime import time
 import logging
+from typing import TYPE_CHECKING
 
 import aiohttp
+from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import EntityCategory
 
 from ..api_resilience import FluidraError
 from ..const import DOMAIN
 from .base import FluidraLightScheduleTimeEntity
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 class FluidraLightScheduleStartTimeEntity(FluidraLightScheduleTimeEntity):
     """Time entity for LumiPlus Connect light schedule start time."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+    ) -> None:
         """Initialize the start time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, "start")
 
@@ -110,7 +122,14 @@ class FluidraLightScheduleStartTimeEntity(FluidraLightScheduleTimeEntity):
 class FluidraLightScheduleEndTimeEntity(FluidraLightScheduleTimeEntity):
     """Time entity for LumiPlus Connect light schedule end time."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+    ) -> None:
         """Initialize the end time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, "end")
 

--- a/custom_components/fluidra_pool/time/schedule.py
+++ b/custom_components/fluidra_pool/time/schedule.py
@@ -5,15 +5,20 @@ from __future__ import annotations
 import asyncio
 from datetime import time
 import logging
+from typing import TYPE_CHECKING
 
 import aiohttp
+from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers.entity import EntityCategory
 
 from ..api_resilience import FluidraError
 from ..const import COMMAND_CONFIRMATION_DELAY, DOMAIN
 from ..utils import convert_cron_days
 from .base import FluidraScheduleTimeEntity
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +26,14 @@ _LOGGER = logging.getLogger(__name__)
 class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
     """Time entity for schedule start time."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+    ) -> None:
         """Initialize the start time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, "start")
 
@@ -183,7 +195,14 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
 class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
     """Time entity for schedule end time."""
 
-    def __init__(self, coordinator, api, pool_id: str, device_id: str, schedule_id: str):
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        schedule_id: str,
+    ) -> None:
         """Initialize the end time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, "end")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,11 @@ known-first-party = ["custom_components.fluidra_pool"]
 asyncio_mode = "auto"
 
 [tool.mypy]
-# Baseline (non-strict) type checking enforced in CI. Full `--strict` compliance
-# is the Platinum `strict-typing` goal and is still tracked as todo in
-# quality_scale.yaml — do not assume strict here yet.
+# Strict type checking enforced in CI (Platinum `strict-typing`).
 # 3.13 matches the CI runtime and the Home Assistant 2026.x requirement (HA ships
 # PEP 696 syntax that mypy cannot parse under an older target).
 python_version = "3.13"
+strict = true
 ignore_missing_imports = true
 
 [tool.bandit]

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -155,3 +155,160 @@ def test_handle_coordinator_update_clears_optimistic_when_backend_caught_up(
     light._optimistic_is_on = True
     light._handle_coordinator_update()
     assert (light._optimistic_is_on is True) is expected_keeps_optimistic
+
+
+# --- brightness / rgbw_color guarded parse paths -------------------------
+
+
+def test_brightness_returns_none_on_non_numeric_reported_value() -> None:
+    """A non-numeric brightness reportedValue hits the guarded except -> None (lines 127-128)."""
+    light = _build_light({str(LUMIPLUS_COMPONENT_BRIGHTNESS): {"reportedValue": "bright"}})
+    assert light.brightness is None
+
+
+def test_rgbw_color_returns_none_on_non_numeric_channel() -> None:
+    """A non-numeric colour channel triggers the guarded except -> None (lines 143-144)."""
+    light = _build_light(
+        {str(LUMIPLUS_COMPONENT_COLOR): {"reportedValue": {"r": "x", "g": 0, "b": 0, "extra": {"w": 0}}}}
+    )
+    assert light.rgbw_color is None
+
+
+# --- _handle_coordinator_update: brightness + rgbw clearing & guards -------
+
+
+def test_handle_coordinator_update_power_bad_reported_value_swallowed() -> None:
+    """A non-numeric reported power while optimistic ON hits the guarded pass (lines 155-156)."""
+    light = _build_light({str(LUMIPLUS_COMPONENT_POWER): {"reportedValue": "garbage"}})
+    light._optimistic_is_on = True
+    light._handle_coordinator_update()
+    # The except path is a no-op, so the optimistic flag is preserved.
+    assert light._optimistic_is_on is True
+
+
+def test_handle_coordinator_update_clears_brightness_once_backend_matches() -> None:
+    """Optimistic brightness drops when the device echoes the matching 0-100 value (lines 161-165)."""
+    # 128/255*100 ≈ 50.2 -> round() == 50; device reports 50 -> match -> clear.
+    light = _build_light({str(LUMIPLUS_COMPONENT_BRIGHTNESS): {"reportedValue": 50}})
+    light._optimistic_brightness = 128
+    light._handle_coordinator_update()
+    assert light._optimistic_brightness is None
+
+
+def test_handle_coordinator_update_keeps_brightness_until_backend_matches() -> None:
+    """Optimistic brightness stays put while the device still reports the old value."""
+    light = _build_light({str(LUMIPLUS_COMPONENT_BRIGHTNESS): {"reportedValue": 10}})
+    light._optimistic_brightness = 255  # expects ~100 on the wire
+    light._handle_coordinator_update()
+    assert light._optimistic_brightness == 255
+
+
+def test_handle_coordinator_update_brightness_bad_reported_value_swallowed() -> None:
+    """A non-numeric reported brightness hits the guarded except (lines 166-167) and is kept."""
+    light = _build_light({str(LUMIPLUS_COMPONENT_BRIGHTNESS): {"reportedValue": "nope"}})
+    light._optimistic_brightness = 200
+    light._handle_coordinator_update()
+    assert light._optimistic_brightness == 200
+
+
+def test_handle_coordinator_update_clears_rgbw_once_backend_matches() -> None:
+    """Optimistic RGBW drops on an exact tuple match from the backend (lines 171-179)."""
+    light = _build_light(
+        {str(LUMIPLUS_COMPONENT_COLOR): {"reportedValue": {"r": 10, "g": 20, "b": 30, "extra": {"w": 40}}}}
+    )
+    light._optimistic_rgbw = (10, 20, 30, 40)
+    light._handle_coordinator_update()
+    assert light._optimistic_rgbw is None
+
+
+def test_handle_coordinator_update_keeps_rgbw_until_backend_matches() -> None:
+    """Optimistic RGBW stays put while the backend still reports a different colour."""
+    light = _build_light(
+        {str(LUMIPLUS_COMPONENT_COLOR): {"reportedValue": {"r": 0, "g": 0, "b": 0, "extra": {"w": 0}}}}
+    )
+    light._optimistic_rgbw = (10, 20, 30, 40)
+    light._handle_coordinator_update()
+    assert light._optimistic_rgbw == (10, 20, 30, 40)
+
+
+def test_handle_coordinator_update_rgbw_bad_channel_swallowed() -> None:
+    """A non-numeric colour channel during reconciliation hits the guarded except (lines 180-181)."""
+    light = _build_light(
+        {str(LUMIPLUS_COMPONENT_COLOR): {"reportedValue": {"r": "bad", "g": 0, "b": 0, "extra": {"w": 0}}}}
+    )
+    light._optimistic_rgbw = (10, 20, 30, 40)
+    light._handle_coordinator_update()
+    # Parse failed -> kept (not cleared).
+    assert light._optimistic_rgbw == (10, 20, 30, 40)
+
+
+# --- async_turn_on / async_turn_off failure paths -------------------------
+
+
+async def test_async_turn_on_color_path_and_optimistic_state() -> None:
+    """turn_on with only RGBW_COLOR drives the colour write and exposes the optimistic colour."""
+    light = _build_light()
+    await light.async_turn_on(**{ATTR_RGBW_COLOR: (1, 2, 3, 4)})
+
+    assert light.is_on is True
+    assert light.rgbw_color == (1, 2, 3, 4)
+    light._api.set_component_json_value.assert_awaited_once_with(
+        DEVICE_ID,
+        LUMIPLUS_COMPONENT_COLOR,
+        {"r": 1, "g": 2, "b": 3, "k": 5000, "extra": {"w": 4}},
+    )
+    light.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_async_turn_on_raises_when_power_write_fails() -> None:
+    """A False from the power write rolls back every optimistic override and raises."""
+    light = _build_light()
+    light._api.set_component_string_value = AsyncMock(return_value=False)
+
+    with pytest.raises(HomeAssistantError):
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 128, ATTR_RGBW_COLOR: (1, 2, 3, 4)})
+
+    assert light._optimistic_is_on is None
+    assert light._optimistic_brightness is None
+    assert light._optimistic_rgbw is None
+    light.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_async_turn_on_raises_and_rolls_back_on_api_exception() -> None:
+    """A raised TimeoutError mid-write rolls back optimistics and surfaces HomeAssistantError."""
+    light = _build_light()
+    light._api.set_component_value = AsyncMock(side_effect=TimeoutError)
+
+    with pytest.raises(HomeAssistantError):
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 200})
+
+    assert light._optimistic_is_on is None
+    assert light._optimistic_brightness is None
+    light.async_write_ha_state.assert_called()
+    light.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_async_turn_off_raises_when_power_write_fails() -> None:
+    """A False from the power-off write rolls back the optimistic flag and raises."""
+    light = _build_light()
+    light._api.set_component_string_value = AsyncMock(return_value=False)
+
+    with pytest.raises(HomeAssistantError):
+        await light.async_turn_off()
+
+    assert light._optimistic_is_on is None
+    light.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_async_turn_off_raises_and_rolls_back_on_api_exception() -> None:
+    """A raised ClientError on turn_off rolls back and raises HomeAssistantError."""
+    import aiohttp
+
+    light = _build_light()
+    light._api.set_component_string_value = AsyncMock(side_effect=aiohttp.ClientError)
+
+    with pytest.raises(HomeAssistantError):
+        await light.async_turn_off()
+
+    assert light._optimistic_is_on is None
+    light.coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -151,6 +151,55 @@ async def test_chlorination_async_set_clamps_to_max_when_step_overshoots() -> No
     api.control_device_component.assert_awaited_once_with(DEVICE_ID, 10, 95)
 
 
+def test_chlorination_handle_coordinator_update_writes_state() -> None:
+    """Coordinator updates push a fresh HA state for the level entity."""
+    device = _chlorinator_device(
+        components={"10": {"reportedValue": 30}},
+        features={"chlorination_level": 10},
+    )
+    number = FluidraChlorinatorLevelNumber(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    number._handle_coordinator_update()
+    number.async_write_ha_state.assert_called_once()
+
+
+def test_chlorination_icon_is_water_percent() -> None:
+    """The level slider uses the water-percent icon."""
+    device = _chlorinator_device(features={"chlorination_level": 10})
+    number = FluidraChlorinatorLevelNumber(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.icon == "mdi:water-percent"
+
+
+def test_chlorination_extra_state_attributes_simple_int() -> None:
+    """A plain-int chlorination_level reports read==write in its attributes."""
+    device = _chlorinator_device(
+        components={"10": {"reportedValue": 30}},
+        features={"chlorination_level": 10},
+    )
+    number = FluidraChlorinatorLevelNumber(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs == {"read_component": 10, "write_component": 10, "device_id": DEVICE_ID}
+
+
+def test_chlorination_extra_state_attributes_dict_component() -> None:
+    """A dict-form chlorination_level exposes distinct read/write components."""
+    device = _chlorinator_device(
+        components={"164": {"reportedValue": 60}},
+        features={"chlorination_level": {"write": 4, "read": 164}},
+    )
+    number = FluidraChlorinatorLevelNumber(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["read_component"] == 164
+    assert attrs["write_component"] == 4
+    assert attrs["device_id"] == DEVICE_ID
+
+
 # --- FluidraChlorinatorPhSetpoint ----------------------------------------
 
 
@@ -205,6 +254,101 @@ async def test_ph_setpoint_async_set_supports_simple_int_feature() -> None:
     api.control_device_component.assert_awaited_once_with(DEVICE_ID, 16, 720)
 
 
+def test_ph_setpoint_native_value_simple_int_reads_same_component() -> None:
+    """A plain-int ph_setpoint reads the value from that single component."""
+    device = _chlorinator_device(
+        components={"16": {"reportedValue": 730}},
+        features={"ph_setpoint": 16, "ph_setpoint_divisor": 100},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.native_value == 7.3
+
+
+def test_ph_setpoint_native_value_guards_non_numeric() -> None:
+    """A non-numeric pH reading falls back to the 7.2 default instead of raising."""
+    device = _chlorinator_device(
+        components={"172": {"reportedValue": "bad"}},
+        features={"ph_setpoint": {"write": 8, "read": 172}},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.native_value == 7.2
+
+
+def test_ph_setpoint_icon_is_ph() -> None:
+    """The pH setpoint uses the pH icon."""
+    device = _chlorinator_device(features={"ph_setpoint": {"write": 8, "read": 172}})
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.icon == "mdi:ph"
+
+
+def test_ph_setpoint_extra_state_attributes_dict_with_reading() -> None:
+    """Dict-form pH exposes read/write and a divided current reading."""
+    device = _chlorinator_device(
+        components={"172": {"reportedValue": 715}},
+        features={"ph_setpoint": {"write": 8, "read": 172}, "ph_setpoint_divisor": 100},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["read_component"] == 172
+    assert attrs["write_component"] == 8
+    assert attrs["current_ph_reading"] == 7.15
+    assert attrs["device_id"] == DEVICE_ID
+    assert attrs["ph_range"] == "6.8-7.6"
+
+
+def test_ph_setpoint_extra_state_attributes_simple_int() -> None:
+    """Plain-int pH reports read==write in its attributes."""
+    device = _chlorinator_device(
+        components={"16": {"reportedValue": 700}},
+        features={"ph_setpoint": 16, "ph_setpoint_divisor": 100},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["read_component"] == 16
+    assert attrs["write_component"] == 16
+    assert attrs["current_ph_reading"] == 7.0
+
+
+def test_ph_setpoint_extra_state_attributes_no_reading() -> None:
+    """With no reading, current_ph_reading stays None (the parse block is skipped)."""
+    device = _chlorinator_device(
+        components={},
+        features={"ph_setpoint": {"write": 8, "read": 172}},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["current_ph_reading"] is None
+
+
+def test_ph_setpoint_extra_state_attributes_non_numeric_reading_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-numeric reading leaves current_ph_reading None and logs a debug line."""
+    import logging
+
+    device = _chlorinator_device(
+        components={"172": {"reportedValue": "oops"}},
+        features={"ph_setpoint": {"write": 8, "read": 172}},
+    )
+    number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.number"):
+        attrs = number.extra_state_attributes
+
+    assert attrs["current_ph_reading"] is None
+    assert "Failed to parse pH reading" in caplog.text
+
+
 # --- FluidraChlorinatorOrpSetpoint ---------------------------------------
 
 
@@ -242,6 +386,68 @@ def test_orp_setpoint_native_value_guards_non_numeric() -> None:
     number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
     _attach_ha(number)
     assert number.native_value == 700.0
+
+
+def test_orp_setpoint_native_value_simple_int_reads_same_component() -> None:
+    """A plain-int orp_setpoint reads its raw mV value from that single component."""
+    device = _chlorinator_device(
+        components={"11": {"reportedValue": 680}},
+        features={"orp_setpoint": 11},
+    )
+    number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.native_value == 680.0
+
+
+def test_orp_setpoint_native_value_default_when_no_reading() -> None:
+    """Missing ORP reading falls back to 700.0 rather than returning None."""
+    device = _chlorinator_device(
+        components={},
+        features={"orp_setpoint": {"write": 11, "read": 177}},
+    )
+    number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.native_value == 700.0
+
+
+def test_orp_setpoint_icon_is_lightning_bolt() -> None:
+    """The ORP setpoint uses the lightning-bolt icon."""
+    device = _chlorinator_device(features={"orp_setpoint": {"write": 11, "read": 177}})
+    number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+    assert number.icon == "mdi:lightning-bolt"
+
+
+def test_orp_setpoint_extra_state_attributes_dict_with_reading() -> None:
+    """Dict-form ORP exposes read/write and the raw current reading."""
+    device = _chlorinator_device(
+        components={"177": {"reportedValue": 690}},
+        features={"orp_setpoint": {"write": 11, "read": 177}},
+    )
+    number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["read_component"] == 177
+    assert attrs["write_component"] == 11
+    assert attrs["current_orp_reading"] == 690
+    assert attrs["device_id"] == DEVICE_ID
+    assert attrs["orp_range"] == "650-750 mV"
+
+
+def test_orp_setpoint_extra_state_attributes_simple_int() -> None:
+    """Plain-int ORP reports read==write in its attributes."""
+    device = _chlorinator_device(
+        components={"11": {"reportedValue": 700}},
+        features={"orp_setpoint": 11},
+    )
+    number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
+    _attach_ha(number)
+
+    attrs = number.extra_state_attributes
+    assert attrs["read_component"] == 11
+    assert attrs["write_component"] == 11
+    assert attrs["current_orp_reading"] == 700
 
 
 # --- FluidraLightEffectSpeed ---------------------------------------------
@@ -312,3 +518,30 @@ async def test_light_effect_speed_logs_and_skips_refresh_on_failure(caplog: pyte
 
     assert "Failed to set effect speed" in caplog.text
     coord.async_request_refresh.assert_not_awaited()
+
+
+def test_light_effect_speed_icon_is_speedometer() -> None:
+    """The effect-speed slider uses the speedometer icon."""
+    coord = _coord_with(_light_device(1))
+    coord.data[POOL_ID]["devices"][0]["device_id"] = "LP24-001"
+    number = FluidraLightEffectSpeed(
+        coord, SimpleNamespace(set_component_value=AsyncMock(return_value=True)), POOL_ID, "LP24-001"
+    )
+    _attach_ha(number)
+    assert number.icon == "mdi:speedometer"
+
+
+def test_light_effect_speed_extra_state_attributes() -> None:
+    """Effect-speed attributes expose component 20, the device id and the 1-8 range."""
+    coord = _coord_with(_light_device(4))
+    coord.data[POOL_ID]["devices"][0]["device_id"] = "LP24-001"
+    number = FluidraLightEffectSpeed(
+        coord, SimpleNamespace(set_component_value=AsyncMock(return_value=True)), POOL_ID, "LP24-001"
+    )
+    _attach_ha(number)
+
+    assert number.extra_state_attributes == {
+        "component": 20,
+        "device_id": "LP24-001",
+        "speed_range": "1-8",
+    }

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -248,3 +248,49 @@ async def test_light_effect_async_select_raises_on_api_rejection() -> None:
     # The finally block still clears the optimistic option on the way out.
     assert select._optimistic_option is None
     select.coordinator.async_request_refresh.assert_not_awaited()
+
+
+def test_light_effect_optimistic_option_takes_precedence() -> None:
+    """A pending optimistic option overrides the reported component value."""
+    select = _light_effect(0)  # device reports static_color
+    select._optimistic_option = "scene_7"
+    assert select.current_option == "scene_7"
+
+
+def test_light_effect_uncoercible_value_falls_back_to_static_color() -> None:
+    """A non-numeric reportedValue can't be int()-coerced → static_color (lines 96-97)."""
+    select = _light_effect("not-a-number")  # type: ignore[arg-type]
+    assert select.current_option == "static_color"
+
+
+def test_light_effect_icon_is_palette() -> None:
+    """The light effect select always uses the palette icon."""
+    select = _light_effect(0)
+    assert select.icon == "mdi:palette"
+
+
+def test_light_effect_extra_state_attributes() -> None:
+    """Attributes expose device_id, effect component, reported/desired values and optimistic option."""
+    device = _pinned_device(
+        LIGHT_ID,
+        features={"effect_select": 18},
+        components={"18": {"reportedValue": 3, "desiredValue": 5}},
+    )
+    select = FluidraLightEffectSelect(_coord_with(device), _api(), POOL_ID, LIGHT_ID)
+    _attach_ha(select)
+    select._optimistic_option = "scene_2"
+    attrs = select.extra_state_attributes
+    assert attrs["device_id"] == LIGHT_ID
+    assert attrs["effect_component"] == FluidraLightEffectSelect.EFFECT_COMPONENT
+    assert attrs["reported_value"] == 3
+    assert attrs["desired_value"] == 5
+    assert attrs["optimistic_option"] == "scene_2"
+
+
+def test_light_effect_extra_state_attributes_missing_component() -> None:
+    """With no component data, reported/desired values are None."""
+    select = _light_effect(None)  # no component 18 in the device
+    attrs = select.extra_state_attributes
+    assert attrs["reported_value"] is None
+    assert attrs["desired_value"] is None
+    assert attrs["optimistic_option"] is None

--- a/tests/test_select_schedule.py
+++ b/tests/test_select_schedule.py
@@ -425,3 +425,216 @@ def test_format_cron_time_keeps_explicit_days() -> None:
     select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
     _attach_ha(select)
     assert select._format_cron_time("30 14 * * 1,3,5") == "30 14 * * 1,3,5"
+
+
+def test_format_cron_time_returns_input_when_too_few_parts() -> None:
+    """A malformed CRON string with fewer than 5 fields is returned unchanged."""
+    device = _chlor_device(schedule_data=[SCHEDULE])
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+    assert select._format_cron_time("5 8") == "5 8"
+
+
+# --- coverage gaps: schedule mode (pump) -------------------------------
+
+
+def test_schedule_mode_get_schedule_data_swallows_malformed_schedule() -> None:
+    """A non-dict entry in schedule_data triggers the guarded except → None."""
+    device = _pump_device(["not-a-dict"])  # schedule.get(...) raises AttributeError
+    select = FluidraScheduleModeSelect(_coord(device), _api(), POOL_ID, PUMP_ID, schedule_id="1")
+    _attach_ha(select)
+    assert select._get_schedule_data() is None
+    # available combines super().available with the (now None) schedule lookup.
+    assert select.available is False
+
+
+def test_schedule_mode_extra_state_attributes_with_schedule() -> None:
+    """When the schedule exists, attrs expose start/end time, enabled and state."""
+    schedule = {
+        **SCHEDULE,
+        "startTime": "0 8 * * 1,2,3,4,5",
+        "endTime": "0 10 * * 1,2,3,4,5",
+        "enabled": True,
+        "state": "RUNNING",
+    }
+    device = _pump_device([schedule])
+    select = FluidraScheduleModeSelect(_coord(device), _api(), POOL_ID, PUMP_ID, schedule_id="1")
+    _attach_ha(select)
+    attrs = select.extra_state_attributes
+    assert attrs["schedule_id"] == "1"
+    assert attrs["device_id"] == PUMP_ID
+    assert attrs["available_modes"] == ["0", "1", "2"]
+    assert attrs["start_time"] == "0 8 * * 1,2,3,4,5"
+    assert attrs["end_time"] == "0 10 * * 1,2,3,4,5"
+    assert attrs["enabled"] is True
+    assert attrs["state"] == "RUNNING"
+
+
+def test_schedule_mode_extra_state_attributes_without_schedule() -> None:
+    """Without a matching schedule, only the static keys are present."""
+    device = _pump_device([SCHEDULE])
+    select = FluidraScheduleModeSelect(_coord(device), _api(), POOL_ID, PUMP_ID, schedule_id="99")
+    _attach_ha(select)
+    attrs = select.extra_state_attributes
+    assert attrs == {
+        "schedule_id": "99",
+        "device_id": PUMP_ID,
+        "available_modes": ["0", "1", "2"],
+    }
+    assert "start_time" not in attrs
+
+
+# --- coverage gaps: chlorinator schedule speed -------------------------
+
+
+def test_chlor_schedule_speed_get_schedule_data_swallows_malformed_schedule() -> None:
+    """A non-dict schedule entry hits the guarded except → None (so unavailable)."""
+    device = _chlor_device(schedule_data=[None])  # schedule.get(...) raises AttributeError
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+    assert select._get_schedule_data() is None
+    assert select.available is False
+
+
+def test_chlor_schedule_speed_current_option_defaults_when_no_schedule() -> None:
+    """No matching schedule and no optimistic value → first option (s1)."""
+    device = _chlor_device(schedule_data=[SCHEDULE])
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="404")
+    _attach_ha(select)
+    assert select._optimistic_option is None
+    assert select.current_option == "s1"
+
+
+async def test_chlor_schedule_speed_select_no_op_without_schedule_data() -> None:
+    """No schedule_data key → optimistic write is rolled back and no API call."""
+    device = _chlor_device(schedule_data=[SCHEDULE])
+    # Remove schedule_data so async_select_option hits the early-return branch.
+    del device["schedule_data"]
+    api = _api()
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), api, POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+
+    await select.async_select_option("s1")
+
+    assert select._optimistic_option is None
+    api.set_schedule.assert_not_called()
+
+
+async def test_chlor_schedule_speed_exo_preserves_other_component_actions() -> None:
+    """EXO update reads componentActions of the untouched schedule (loop else-branch)."""
+    schedules = [
+        {**SCHEDULE, "id": 1, "startActions": {"componentActions": [{"id": 0, "reportedValue": 3}]}},
+        {**SCHEDULE, "id": 2, "startActions": {"componentActions": [{"id": 0, "reportedValue": 1}]}},
+    ]
+    device = _chlor_device(schedule_data=schedules, output_type="output")
+    api = _api()
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), api, POOL_ID, CHLOR_ID, schedule_id="2")
+    _attach_ha(select)
+
+    await select.async_select_option("pump")  # → reportedValue 1 for schedule 2
+
+    sent = api.set_schedule.call_args.args[1]
+    by_id = {s["id"]: s["startActions"]["componentActions"][0]["reportedValue"] for s in sent}
+    assert by_id[2] == 1  # New value for the target.
+    assert by_id[1] == 3  # Untouched schedule keeps its existing reportedValue.
+
+
+def _chlor_device_generic_component(*, schedule_data: list[dict], schedule_component: int) -> dict:
+    """Speed-mode chlorinator with a non-258 schedule_component (generic else-branch)."""
+    return {
+        "device_id": CHLOR_ID,
+        "name": "Chlorinator",
+        "family": "",
+        "model": "",
+        "type": "chlorinator",
+        "online": True,
+        "components": {},
+        "schedule_data": schedule_data,
+        "_identify_cache": {
+            "key": (CHLOR_ID, "", "", "chlorinator", ""),
+            "config": SimpleNamespace(
+                device_type="chlorinator",
+                features={"schedule_output_type": "speed", "schedule_component": schedule_component},
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=[],
+            ),
+        },
+    }
+
+
+async def test_chlor_schedule_speed_generic_branch_for_non_258_component() -> None:
+    """speed output + schedule_component != 258 takes the generic scheduler branch (line 335)."""
+    schedules = [{**SCHEDULE, "id": 1, "enabled": True, "startActions": {"operationName": "1"}}]
+    device = _chlor_device_generic_component(schedule_data=schedules, schedule_component=259)
+    api = _api()
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), api, POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+
+    await select.async_select_option("s3")
+
+    api.set_schedule.assert_awaited_once()
+    assert api.set_schedule.call_args.kwargs["component_id"] == 259
+    sent = api.set_schedule.call_args.args[1]
+    # Generic branch keeps the original groupId == id and raw start/end times (no CRON padding).
+    assert sent[0]["groupId"] == sent[0]["id"]
+    assert sent[0]["startActions"]["operationName"] == "3"
+    assert sent[0]["startTime"] == "0 8 * * 1,2,3,4,5"
+
+
+async def test_chlor_schedule_speed_wraps_api_error_and_clears_optimistic() -> None:
+    """A FluidraError raised by set_schedule is swallowed and optimistic state cleared (355-366)."""
+    device = _chlor_device(schedule_data=[SCHEDULE])
+    api = SimpleNamespace(set_schedule=AsyncMock(side_effect=FluidraError("boom")))
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), api, POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+
+    # The handler logs and recovers (no raise), leaving optimistic state cleared.
+    await select.async_select_option("s2")
+
+    assert select._optimistic_option is None
+
+
+def test_chlor_schedule_speed_icon_per_option() -> None:
+    """Icon reflects the current speed: s1 slow, s2 medium, else default."""
+    for op_name, expected in (("1", "mdi:speedometer-slow"), ("2", "mdi:speedometer-medium"), ("3", "mdi:speedometer")):
+        device = _chlor_device(schedule_data=[{**SCHEDULE, "startActions": {"operationName": op_name}}])
+        select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
+        _attach_ha(select)
+        assert select.icon == expected
+
+
+def test_chlor_schedule_speed_extra_state_attributes_with_schedule() -> None:
+    """With a schedule, attrs expose times, enabled and state."""
+    schedule = {
+        **SCHEDULE,
+        "startTime": "0 8 * * 1,2,3,4,5",
+        "endTime": "0 10 * * 1,2,3,4,5",
+        "enabled": True,
+        "state": "RUNNING",
+    }
+    device = _chlor_device(schedule_data=[schedule])
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+    attrs = select.extra_state_attributes
+    assert attrs["schedule_id"] == "1"
+    assert attrs["device_id"] == CHLOR_ID
+    assert attrs["available_speeds"] == ["s1", "s2", "s3"]
+    assert attrs["start_time"] == "0 8 * * 1,2,3,4,5"
+    assert attrs["end_time"] == "0 10 * * 1,2,3,4,5"
+    assert attrs["enabled"] is True
+    assert attrs["state"] == "RUNNING"
+
+
+def test_chlor_schedule_speed_extra_state_attributes_without_schedule() -> None:
+    """Without a matching schedule, only static keys are present."""
+    device = _chlor_device(schedule_data=[SCHEDULE])
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="404")
+    _attach_ha(select)
+    attrs = select.extra_state_attributes
+    assert attrs == {
+        "schedule_id": "404",
+        "device_id": CHLOR_ID,
+        "available_speeds": ["s1", "s2", "s3"],
+    }
+    assert "start_time" not in attrs

--- a/tests/test_sensor_full.py
+++ b/tests/test_sensor_full.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.sensor import (
     FluidraChlorinatorSensor,
     FluidraDeviceInfoSensor,
@@ -1089,6 +1090,113 @@ async def test_setup_chlorinator_creates_measurement_sensors() -> None:
     added = await _run_setup(coordinator)
     chlor = [e for e in added if isinstance(e, FluidraChlorinatorSensor)]
     assert len(chlor) == 3
+
+
+# --------------------------------------------------------------------------- #
+# FluidraChlorinatorSensor — divisor override, device_data, device_info, attrs #
+# --------------------------------------------------------------------------- #
+
+
+def test_chlorinator_custom_divisor_overrides_default() -> None:
+    """A `sensor_divisors` feature overrides the per-type default divisor (line 112)."""
+    # Default ph divisor is 100; override it to 50 via the device registry feature.
+    device = _pinned_device(
+        DEVICE_ID,
+        device_type="chlorinator",
+        features={"sensor_divisors": {"ph": 50}},
+        components={"165": {"reportedValue": 360}},
+    )
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    assert sensor._divisor == 50
+    # 360 / 50 = 7.2 (would be 3.6 with the default divisor of 100).
+    assert sensor.native_value == pytest.approx(7.2)
+
+
+def test_chlorinator_custom_divisor_ignored_for_other_types() -> None:
+    """A `sensor_divisors` map that doesn't list this type leaves the default in place."""
+    device = _pinned_device(
+        DEVICE_ID,
+        device_type="chlorinator",
+        features={"sensor_divisors": {"orp": 2}},
+        components={"165": {"reportedValue": 731}},
+    )
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    # ph not in the override map -> keeps default divisor 100.
+    assert sensor._divisor == 100
+    assert sensor.native_value == pytest.approx(7.31)
+
+
+def test_chlorinator_device_data_empty_when_coordinator_data_none() -> None:
+    """device_data degrades to {} when coordinator.data is None (line 118)."""
+    coord = MagicMock()
+    coord.data = None
+    coord.last_update_success = True
+    sensor = FluidraChlorinatorSensor(coord, SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    assert sensor.device_data == {}
+    assert sensor.native_value is None
+    assert sensor.available is False
+
+
+def test_chlorinator_device_data_empty_when_device_not_found() -> None:
+    """device_data returns {} when the pool exists but the device_id isn't present (line 125)."""
+    other = _pinned_device("OTHER-DEV", device_type="chlorinator", components={"165": {"reportedValue": 720}})
+    sensor = FluidraChlorinatorSensor(_coord([other]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    assert sensor.device_data == {}
+    assert sensor.native_value is None
+
+
+def test_chlorinator_device_info_uses_device_name_and_manufacturer() -> None:
+    """device_info pulls the device name + manufacturer from the payload (lines 130-131)."""
+    device = _pinned_device(
+        DEVICE_ID,
+        device_type="chlorinator",
+        components={"165": {"reportedValue": 720}},
+        name="Salt Cell",
+        manufacturer="Hayward",
+    )
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    info = sensor.device_info
+    assert info["name"] == "Salt Cell"
+    assert info["manufacturer"] == "Hayward"
+    assert info["model"] == "Chlorinator"
+    assert (DOMAIN, DEVICE_ID) in info["identifiers"]
+    assert info["via_device"] == (DOMAIN, POOL_ID)
+
+
+def test_chlorinator_device_info_falls_back_to_generated_name() -> None:
+    """A device without a name falls back to 'Chlorinator <id>' and the default manufacturer."""
+    device = _pinned_device(DEVICE_ID, device_type="chlorinator", components={"165": {"reportedValue": 720}})
+    device.pop("name", None)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    info = sensor.device_info
+    assert info["name"] == f"Chlorinator {DEVICE_ID}"
+    assert info["manufacturer"] == "Fluidra"
+
+
+def test_chlorinator_extra_state_attributes() -> None:
+    """extra_state_attributes exposes component id, type, raw value and divisor (lines 171-174)."""
+    device = _pinned_device(
+        DEVICE_ID,
+        device_type="chlorinator",
+        components={"170": {"reportedValue": 654}},
+    )
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 170)
+    attrs = sensor.extra_state_attributes
+    assert attrs["component_id"] == 170
+    assert attrs["sensor_type"] == "orp"
+    assert attrs["raw_value"] == 654
+    assert attrs["divisor"] == 1
+    assert attrs["device_id"] == DEVICE_ID
+
+
+def test_chlorinator_extra_state_attributes_raw_value_none_when_missing() -> None:
+    """When the component is absent, raw_value is None but the other keys still populate."""
+    device = _pinned_device(DEVICE_ID, device_type="chlorinator", components={})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    attrs = sensor.extra_state_attributes
+    assert attrs["raw_value"] is None
+    assert attrs["component_id"] == 165
+    assert attrs["divisor"] == 100
 
 
 async def test_setup_falls_back_to_get_pools_when_no_cache() -> None:

--- a/tests/test_switch_pump_schedule_cov.py
+++ b/tests/test_switch_pump_schedule_cov.py
@@ -1,0 +1,410 @@
+"""Coverage-gap tests for switch/pump.py and switch/schedule.py.
+
+These modules differ from heater/chlorinator: their async_turn_on/off methods
+*swallow* API errors (debug log + clear pending state) instead of re-raising
+HomeAssistantError. The tests here exercise the branches not already covered by
+test_switch.py / test_entity_error_paths.py:
+
+pump.py
+* icon OFF branch (both pump + auto-mode)
+* is_on optimistic clear on match AND on expiry (pump + auto-mode)
+* async_turn_on/off: API-returns-False revert, and the exception handler
+  (no raise, pending cleared, no refresh) for both pump + auto-mode
+
+schedule.py
+* icon OFF branch
+* _get_schedule_data: empty device_data -> None, and the exception handler
+* is_on: pending state surfaces while server hasn't caught up (return path)
+* async_turn_on: empty current_schedules early-return
+* async_turn_off: missing schedule_data key + empty list early-returns
+* async_turn_on/off: API-returns-False revert + exception handler (no raise)
+* extra_state_attributes with a schedule present (start/end/state/actions)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
+from custom_components.fluidra_pool.switch import (
+    FluidraAutoModeSwitch,
+    FluidraPumpSwitch,
+    FluidraScheduleEnableSwitch,
+)
+
+POOL_ID = "pool-1"
+DEVICE_ID = "LE24500883"
+
+
+# --- shared fixture builders ---------------------------------------------
+
+
+def _coordinator(devices: list[dict]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": devices}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _api(**overrides: Any) -> SimpleNamespace:
+    defaults = {
+        "start_pump": AsyncMock(return_value=True),
+        "stop_pump": AsyncMock(return_value=True),
+        "enable_auto_mode": AsyncMock(return_value=True),
+        "disable_auto_mode": AsyncMock(return_value=True),
+        "set_schedule": AsyncMock(return_value=True),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _attach_ha(entity) -> None:
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _skip_sleep() -> Any:
+    """Never actually sleep in the optimistic confirmation delays."""
+    with patch("custom_components.fluidra_pool.switch.pump.asyncio.sleep", new=AsyncMock()):
+        yield
+
+
+# =========================================================================
+# FluidraPumpSwitch
+# =========================================================================
+
+
+def _pump(device_extra: dict | None = None, **api_overrides: Any) -> FluidraPumpSwitch:
+    device = {
+        "device_id": DEVICE_ID,
+        "name": "Pump",
+        "model": "E30iQ",
+        "type": "pump",
+        "online": True,
+    }
+    device.update(device_extra or {})
+    pump = FluidraPumpSwitch(_coordinator([device]), _api(**api_overrides), POOL_ID, DEVICE_ID)
+    _attach_ha(pump)
+    return pump
+
+
+def test_pump_icon_off_branch() -> None:
+    """The icon falls back to pump-off when the pump is not running."""
+    off = _pump({"is_running": False})
+    on = _pump({"is_running": True})
+    assert off.icon == "mdi:pump-off"
+    assert on.icon == "mdi:pump"
+
+
+def test_pump_is_on_clears_pending_when_actual_matches() -> None:
+    """Optimistic ON is dropped as soon as the poll reports the same value."""
+    pump = _pump({"pump_reported": 1})
+    pump._set_pending_state(True)
+    assert pump.is_on is True
+    assert pump._pending_state is None  # reconciled with the real value
+
+
+def test_pump_is_on_clears_pending_on_expiry() -> None:
+    """An expired optimistic ON yields the real (mismatched) reported state."""
+    pump = _pump({"pump_reported": 0})
+    pump._set_pending_state(True)
+    pump._last_action_time = 0.0  # far in the past -> expired
+    assert pump.is_on is False
+    assert pump._pending_state is None
+
+
+async def test_pump_turn_on_returns_false_reverts_no_refresh() -> None:
+    """start_pump False rolls back the optimistic state and skips refresh."""
+    pump = _pump(start_pump=AsyncMock(return_value=False))
+    await pump.async_turn_on()
+    assert pump._pending_state is None
+    pump.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_pump_turn_on_api_raises_is_swallowed_and_clears_pending() -> None:
+    """pump turn_on swallows API errors (no raise) and clears pending state."""
+    pump = _pump(start_pump=AsyncMock(side_effect=FluidraConnectionError("boom")))
+    await pump.async_turn_on()  # must NOT raise
+    assert pump._pending_state is None
+    pump.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_pump_turn_off_returns_false_reverts_no_refresh() -> None:
+    """stop_pump False rolls back the optimistic state and skips refresh."""
+    pump = _pump({"is_running": True}, stop_pump=AsyncMock(return_value=False))
+    await pump.async_turn_off()
+    assert pump._pending_state is None
+    pump.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_pump_turn_off_api_raises_is_swallowed_and_clears_pending() -> None:
+    """pump turn_off swallows API errors (no raise) and clears pending state."""
+    pump = _pump({"is_running": True}, stop_pump=AsyncMock(side_effect=aiohttp.ClientError("net")))
+    await pump.async_turn_off()  # must NOT raise
+    assert pump._pending_state is None
+
+
+# =========================================================================
+# FluidraAutoModeSwitch
+# =========================================================================
+
+
+def _auto(device_extra: dict | None = None, **api_overrides: Any) -> FluidraAutoModeSwitch:
+    device = {
+        "device_id": DEVICE_ID,
+        "name": "Pump",
+        "type": "pump",
+        "online": True,
+        "auto_mode_enabled": False,
+    }
+    device.update(device_extra or {})
+    auto = FluidraAutoModeSwitch(_coordinator([device]), _api(**api_overrides), POOL_ID, DEVICE_ID)
+    _attach_ha(auto)
+    return auto
+
+
+def test_auto_mode_icon_off_branch() -> None:
+    """The icon falls back to autorenew-off when auto mode is off."""
+    off = _auto({"auto_mode_enabled": False})
+    on = _auto({"auto_reported": 1})
+    assert off.icon == "mdi:autorenew-off"
+    assert on.icon == "mdi:auto-mode"
+
+
+def test_auto_mode_is_on_falls_back_to_legacy_flag() -> None:
+    """Without auto_reported, the legacy auto_mode_enabled drives is_on."""
+    assert _auto({"auto_mode_enabled": True}).is_on is True
+    assert _auto({"auto_mode_enabled": False}).is_on is False
+
+
+def test_auto_mode_is_on_clears_pending_when_actual_matches() -> None:
+    """Optimistic ON clears once the reported value confirms it."""
+    auto = _auto({"auto_reported": 1})
+    auto._set_pending_state(True)
+    assert auto.is_on is True
+    assert auto._pending_state is None
+
+
+def test_auto_mode_is_on_clears_pending_on_expiry() -> None:
+    """An expired optimistic ON yields the real (mismatched) state."""
+    auto = _auto({"auto_reported": 0})
+    auto._set_pending_state(True)
+    auto._last_action_time = 0.0
+    assert auto.is_on is False
+    assert auto._pending_state is None
+
+
+def test_auto_mode_is_on_pending_shows_through_until_match() -> None:
+    """A fresh optimistic ON is reported even while auto still says off."""
+    auto = _auto({"auto_reported": 0})
+    auto._set_pending_state(True)
+    assert auto.is_on is True
+    assert auto._pending_state is True
+
+
+async def test_auto_mode_turn_on_returns_false_reverts_no_refresh() -> None:
+    """enable_auto_mode False rolls back the optimistic state, no refresh."""
+    auto = _auto(enable_auto_mode=AsyncMock(return_value=False))
+    await auto.async_turn_on()
+    assert auto._pending_state is None
+    auto.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_auto_mode_turn_on_api_raises_is_swallowed() -> None:
+    """auto-mode turn_on swallows API errors and clears pending state."""
+    auto = _auto(enable_auto_mode=AsyncMock(side_effect=FluidraConnectionError("boom")))
+    await auto.async_turn_on()  # must NOT raise
+    assert auto._pending_state is None
+    auto.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_auto_mode_turn_off_returns_false_reverts_no_refresh() -> None:
+    """disable_auto_mode False rolls back the optimistic state, no refresh."""
+    auto = _auto({"auto_mode_enabled": True}, disable_auto_mode=AsyncMock(return_value=False))
+    await auto.async_turn_off()
+    assert auto._pending_state is None
+    auto.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_auto_mode_turn_off_api_raises_is_swallowed() -> None:
+    """auto-mode turn_off swallows API errors and clears pending state."""
+    auto = _auto({"auto_mode_enabled": True}, disable_auto_mode=AsyncMock(side_effect=aiohttp.ClientError("net")))
+    await auto.async_turn_off()  # must NOT raise
+    assert auto._pending_state is None
+
+
+# =========================================================================
+# FluidraScheduleEnableSwitch
+# =========================================================================
+
+
+SCHEDULE_4 = {
+    "id": 4,
+    "enabled": False,
+    "startTime": "00 13 * * 0,1,2,3,4,5,6",
+    "endTime": "30 14 * * 0,1,2,3,4,5,6",
+    "startActions": {"operationName": "0"},
+    "endActions": {"operationName": "1"},
+    "state": "IDLE",
+}
+
+
+def _schedule(schedules: list[dict], schedule_id: str = "4", **api_overrides: Any) -> FluidraScheduleEnableSwitch:
+    device = {
+        "device_id": DEVICE_ID,
+        "name": "Pump",
+        "type": "pump",
+        "model": "E30iQ",
+        "online": True,
+        "schedule_data": schedules,
+    }
+    switch = FluidraScheduleEnableSwitch(
+        _coordinator([device]),
+        _api(**api_overrides),
+        POOL_ID,
+        DEVICE_ID,
+        schedule_id=schedule_id,
+    )
+    _attach_ha(switch)
+    return switch
+
+
+def test_schedule_icon_off_branch() -> None:
+    """Icon falls back to calendar-outline when the schedule is disabled."""
+    off = _schedule([SCHEDULE_4])
+    on = _schedule([{**SCHEDULE_4, "enabled": True}])
+    assert off.icon == "mdi:calendar-outline"
+    assert on.icon == "mdi:calendar-clock"
+
+
+def test_schedule_get_schedule_data_returns_none_when_device_empty() -> None:
+    """With no device_data in the coordinator, _get_schedule_data returns None."""
+    switch = _schedule([SCHEDULE_4])
+    # Empty the coordinator so device_data resolves to {} (falsy).
+    switch.coordinator.data = {}
+    assert switch._get_schedule_data() is None
+
+
+def test_schedule_get_schedule_data_swallows_exception() -> None:
+    """A broken schedule payload is caught and yields None (debug-logged)."""
+    switch = _schedule([SCHEDULE_4])
+    # device_data raises when iterated/accessed -> exception handler -> None.
+    bad = MagicMock()
+    bad.__contains__.side_effect = TypeError("broken schedule payload")
+    with patch.object(type(switch), "device_data", new_callable=lambda: property(lambda self: bad)):
+        assert switch._get_schedule_data() is None
+
+
+def test_schedule_is_on_pending_shows_through_until_server_catches_up() -> None:
+    """While the server still reports the old value, the optimistic state shows."""
+    # Pending ON but the schedule still reports disabled -> return pending (not cleared).
+    switch = _schedule([SCHEDULE_4])  # enabled == False
+    switch._set_pending_state(True)
+    assert switch.is_on is True
+    assert switch._pending_state is True  # not yet reconciled
+
+
+async def test_schedule_turn_on_empty_schedules_early_return() -> None:
+    """schedule_data present but empty -> no API call, pending cleared."""
+    switch = _schedule([])  # key present, list empty
+    await switch.async_turn_on()
+    switch._api.set_schedule.assert_not_awaited()
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_on_returns_false_reverts() -> None:
+    """set_schedule False rolls back the optimistic ON state."""
+    switch = _schedule([SCHEDULE_4], set_schedule=AsyncMock(return_value=False))
+    await switch.async_turn_on()
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_on_api_raises_is_swallowed() -> None:
+    """Enable swallows API errors (no raise) and clears pending state."""
+    switch = _schedule([SCHEDULE_4], set_schedule=AsyncMock(side_effect=FluidraConnectionError("boom")))
+    await switch.async_turn_on()  # must NOT raise
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_off_missing_schedule_data_key_early_return() -> None:
+    """No schedule_data key at all -> no API call, pending cleared."""
+    switch = _schedule([])
+    switch.coordinator.data[POOL_ID]["devices"][0].pop("schedule_data")
+    await switch.async_turn_off()
+    switch._api.set_schedule.assert_not_awaited()
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_off_empty_schedules_early_return() -> None:
+    """schedule_data present but empty -> no API call on turn_off, pending cleared."""
+    switch = _schedule([])
+    await switch.async_turn_off()
+    switch._api.set_schedule.assert_not_awaited()
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_off_sets_only_target_disabled() -> None:
+    """Disabling schedule 4 leaves the other schedules' enabled state intact."""
+    schedules = [{**SCHEDULE_4, "id": idx + 1, "enabled": True} for idx in range(3)]
+    schedules.append({**SCHEDULE_4, "enabled": True})  # id=4 starts enabled
+    switch = _schedule(schedules)
+    await switch.async_turn_off()
+    switch._api.set_schedule.assert_awaited_once()
+    args, kwargs = switch._api.set_schedule.call_args
+    assert args[0] == DEVICE_ID
+    sent = args[1]
+    assert kwargs["component_id"] == 20
+    assert len(sent) == 8  # padded to 8 slots for pump component 20
+    # id=4 disabled, ids 1-3 still enabled, padded 5-8 disabled.
+    by_id = {s["id"]: s["enabled"] for s in sent}
+    assert by_id[4] is False
+    assert by_id[1] is True
+    assert by_id[2] is True
+    assert by_id[3] is True
+
+
+async def test_schedule_turn_off_returns_false_reverts() -> None:
+    """set_schedule False rolls back the optimistic OFF state."""
+    switch = _schedule([{**SCHEDULE_4, "enabled": True}], set_schedule=AsyncMock(return_value=False))
+    await switch.async_turn_off()
+    assert switch._pending_state is None
+
+
+async def test_schedule_turn_off_api_raises_is_swallowed() -> None:
+    """Disable swallows API errors (no raise) and clears pending state."""
+    switch = _schedule(
+        [{**SCHEDULE_4, "enabled": True}],
+        set_schedule=AsyncMock(side_effect=aiohttp.ClientError("net")),
+    )
+    await switch.async_turn_off()  # must NOT raise
+    assert switch._pending_state is None
+
+
+def test_schedule_extra_state_attributes_with_schedule_present() -> None:
+    """Attributes expose the schedule's times, state and start/end actions."""
+    switch = _schedule([SCHEDULE_4])
+    attrs = switch.extra_state_attributes
+    assert attrs["schedule_id"] == "4"
+    assert attrs["device_id"] == DEVICE_ID
+    assert attrs["start_time"] == SCHEDULE_4["startTime"]
+    assert attrs["end_time"] == SCHEDULE_4["endTime"]
+    assert attrs["state"] == "IDLE"
+    assert attrs["start_action"] == {"operationName": "0"}
+    assert attrs["end_action"] == {"operationName": "1"}
+    assert attrs["pending_action"] is False
+
+
+def test_schedule_extra_state_attributes_without_schedule() -> None:
+    """With no matching schedule, only the base attributes are present."""
+    switch = _schedule([])
+    attrs = switch.extra_state_attributes
+    assert attrs["schedule_id"] == "4"
+    assert "start_time" not in attrs
+    assert attrs["pending_action"] is False


### PR DESCRIPTION
## Strict-typing (Platinum)
Resolve all 120 `mypy --strict` errors across 29 modules (type annotations only, no runtime behaviour change). Enable `strict = true` in `[tool.mypy]` so CI enforces it; flip `quality_scale` `strict-typing` to done.

## Coverage
94% → **97%**, every module now ≥90% (1171 → 1259 tests). Previously thin modules (switch/pump, switch/schedule, number, light, select/schedule, select/light, sensor/chlorinator) are now fully covered.

Verified locally: `mypy` strict clean (pin 2.1.0 = CI), ruff check+format clean, 1259 tests pass, hassfest 0 invalid, loads clean on HA dev. `unique_id` unchanged.