### PR TITLE
chore(deps): update test stack for Python 3.14 (supersedes #95, #96)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ asyncio_mode = "auto"
 
 [tool.mypy]
 # Strict type checking enforced in CI (Platinum `strict-typing`).
-# 3.13 matches the CI runtime and the Home Assistant 2026.x requirement (HA ships
+# 3.14 matches the CI runtime and the Home Assistant 2026.x requirement (HA ships
 # PEP 696 syntax that mypy cannot parse under an older target).
-python_version = "3.13"
+python_version = "3.14"
 strict = true
 ignore_missing_imports = true
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 # Test/CI dependencies (pinned for reproducible CI runs).
 # pytest-homeassistant-custom-component pins a compatible Home Assistant,
 # pytest and pytest-asyncio as transitive dependencies.
-pytest-homeassistant-custom-component==0.13.316
-pytest-cov==7.0.0
+pytest-homeassistant-custom-component==0.13.340
+pytest-cov==7.1.0
 mypy==2.1.0


### PR DESCRIPTION
Bumps the test stack now that CI runs on Python 3.14 (#98):
- `pytest-homeassistant-custom-component` 0.13.316 → **0.13.340**
- `pytest-cov` 7.0.0 → **7.1.0**
- `[tool.mypy] python_version` → **3.14** (match runtime; newer HA ships PEP 696 syntax)

Both pins previously failed on Python 3.13 (#95/#96 red). **Verified locally on Python 3.14.6 + HA 2026.6.4**: pip resolution OK, `mypy --strict` clean, 1259 tests pass.

Closes #95, closes #96.