### PR TITLE
feat: Platinum quality scale (dynamic + stale devices) & LC25024524 fix (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dynamic device discovery (`dynamic-devices`)** — pool devices added in the Fluidra app now appear in Home Assistant automatically on the next poll, with no reload required. Every platform (sensor, switch, select, number, time, climate, light) wires up newly-discovered devices through a coordinator listener.
+
 ### Changed
-- **Platinum `strict-typing` reached** — the integration now passes `mypy --strict` (120 type issues resolved across 29 modules), and CI enforces it via `[tool.mypy] strict = true`. Type annotations only; no runtime behaviour change.
-- **Test coverage raised 94% → 97%** (1171 → 1259 tests); every module is now ≥ 90%. Previously thin modules (`switch/pump`, `switch/schedule`, `number`, `light`, `select/schedule`, `select/light`, `sensor/chlorinator`) are now fully covered.
+- **Reached Platinum quality scale** — with `dynamic-devices` and `stale-devices` now done (and `strict-typing` already enforced), the integration meets every Bronze→Platinum rule; `quality_scale` is bumped to `platinum`.
+- **Safer stale-device cleanup (`stale-devices`)** — a removed device is purged from the registry only after it has been absent from several consecutive successful polls, so a transient partial cloud response can no longer wipe devices, entities and their history on a single hiccup.
+- **Platinum `strict-typing`** — the integration passes `mypy --strict` (120 type issues resolved across 29 modules); CI enforces it via `[tool.mypy] strict = true`. Type annotations only; no runtime behaviour change.
+- **Test coverage raised 94% → 97%** (1171 → 1268 tests); every module is ≥ 90%.
+- Declared an explicit config-entry-only `CONFIG_SCHEMA`, silencing the hassfest configuration-schema warning.
 
 ## [2.42.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test coverage raised 94% → 97%** (1171 → 1268 tests); every module is ≥ 90%.
 - Declared an explicit config-entry-only `CONFIG_SCHEMA`, silencing the hassfest configuration-schema warning.
 
+### Fixed
+- **Chlorinator `LC25024524` read wrong sensor values** (Issue #73, @Ausstriken) — this tecnoLC2 unit fell back to the generic profile, which read component 172 (water temperature) as pH (÷100 → 3.16). A dedicated profile now reads pH (c165), ORP (c170), temperature (c172) and salinity (c174) correctly — confirmed against the Fluidra app.
+
 ## [2.42.2] - 2026-06-19
 
 ### Fixed

--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Configured only via config entries (UI) and services — no YAML schema.
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 PLATFORMS: Final = [
     Platform.SWITCH,
     Platform.SENSOR,

--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -60,22 +60,45 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool climate entities."""
+    """Set up Fluidra Pool climate entities, including devices added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
 
-    entities = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create climate entities for any device not seen yet (dynamic-devices)."""
+        entities: list[ClimateEntity] = []
 
-    # Use cached pools data instead of API call for faster startup
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                # Create climate entities based on device registry
+                if DeviceIdentifier.should_create_entity(device, "climate"):
+                    entities.append(FluidraHeatPumpClimate(coordinator, coordinator.api, pool_id, device_id))
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
     pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
+    _add_entities(pools)
 
-            # Create climate entities based on device registry
-            if device_id and DeviceIdentifier.should_create_entity(device, "climate"):
-                entities.append(FluidraHeatPumpClimate(coordinator, coordinator.api, pool["id"], device_id))
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
 
-    async_add_entities(entities)
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))
 
 
 class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -37,6 +37,11 @@ DEVICE_TYPE_LIGHT = "light"
 DEVICE_TYPE_SENSOR = "sensor"
 DEVICE_TYPE_CHLORINATOR = "chlorinator"
 
+# Stale-device reconciliation: a device must be absent from this many consecutive
+# successful polls before it is purged from the registry, so a transient partial
+# cloud response cannot wipe devices, entities and their history on one hiccup.
+STALE_DEVICE_THRESHOLD: Final = 3
+
 # Attributes
 ATTR_DEVICE_ID = "device_id"
 ATTR_POOL_ID = "pool_id"

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from ..api_resilience import FluidraError
-from ..const import DEFAULT_SCAN_INTERVAL, DOMAIN, FluidraPoolConfigEntry
+from ..const import DEFAULT_SCAN_INTERVAL, DOMAIN, STALE_DEVICE_THRESHOLD, FluidraPoolConfigEntry
 from ..device_registry import DeviceIdentifier
 from ..fluidra_api import FluidraPoolAPI
 from ._parsers import calculate_auto_speed_from_schedules, parse_dm24049704_schedule_format
@@ -37,6 +37,8 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.config_entry = config_entry  # Used for HA device cleanup.
         # Track scheduler entities per device for cleanup.
         self._previous_schedule_entities: dict[str, int] = {}
+        # Consecutive polls each registry device has been missing (stale-devices).
+        self._missing_device_counts: dict[str, int] = {}
         # Skip heavy polling on first update for faster startup.
         self._first_update = True
 
@@ -69,7 +71,13 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return [{"id": pool_id, **pool_data} for pool_id, pool_data in self.data.items()]
 
     async def _cleanup_removed_devices(self, current_device_ids: set[str]) -> None:
-        """Remove devices and entities that no longer exist in Fluidra API."""
+        """Purge devices/entities that have disappeared from the Fluidra API.
+
+        A device is only removed once it has been absent from
+        STALE_DEVICE_THRESHOLD consecutive successful polls, so a transient
+        partial cloud response cannot wipe devices, entities and their history
+        on a single hiccup.
+        """
         if not self.config_entry:
             return
 
@@ -78,6 +86,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_registry = er.async_get(self.hass)
 
             devices_to_check = dr.async_entries_for_config_entry(device_registry, self.config_entry.entry_id)
+            seen_ids: set[str] = set()
 
             for device_entry in devices_to_check:
                 device_id = None
@@ -93,15 +102,32 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if device_entry.model == "Pool":
                     continue
 
-                if device_id not in current_device_ids:
-                    entities_to_remove = er.async_entries_for_device(
-                        entity_registry, device_entry.id, include_disabled_entities=True
-                    )
+                seen_ids.add(device_id)
 
-                    for entity_entry in entities_to_remove:
-                        entity_registry.async_remove(entity_entry.entity_id)
+                if device_id in current_device_ids:
+                    # Device present again — clear any pending strike.
+                    self._missing_device_counts.pop(device_id, None)
+                    continue
 
-                    device_registry.async_remove_device(device_entry.id)
+                # Absent this poll: count consecutive misses and purge only once
+                # the device has been gone long enough to rule out a transient gap.
+                misses = self._missing_device_counts.get(device_id, 0) + 1
+                if misses < STALE_DEVICE_THRESHOLD:
+                    self._missing_device_counts[device_id] = misses
+                    continue
+
+                self._missing_device_counts.pop(device_id, None)
+                entities_to_remove = er.async_entries_for_device(
+                    entity_registry, device_entry.id, include_disabled_entities=True
+                )
+                for entity_entry in entities_to_remove:
+                    entity_registry.async_remove(entity_entry.entity_id)
+                device_registry.async_remove_device(device_entry.id)
+
+            # Drop strike counters for devices no longer in the registry.
+            self._missing_device_counts = {
+                did: count for did, count in self._missing_device_counts.items() if did in seen_ids
+            }
 
         except Exception as err:  # best-effort cleanup must never fail the poll
             # async_remove_device can raise a bare KeyError when a device is

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -278,6 +278,34 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=86,
     ),
+    "lc25024524_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # tecnoLC2 chlorinator — Issue #73 (@Ausstriken). LC25024524.nn_1 fell back to the
+        # generic profile, which read c172 (water temperature) as pH (÷100 → 3.16). Standard
+        # tecnoLC2 layout (same as the LC iSALT siblings), confirmed against the Fluidra app:
+        # c165 = pH (7.3), c170 = ORP (659 mV — c177 is the uncalibrated raw value),
+        # c172 = water temperature (×10, 31.6 °C), c174 = salinity (5.4 g/L).
+        identifier_patterns=["LC25024524*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "chlorination_level": 10,
+            "ph_setpoint": 16,
+            "orp_setpoint": 20,
+            "boost_mode": 103,
+            "skip_mode_select": True,
+            "sensors": {
+                "ph": 165,  # pH measured (÷100).
+                "orp": 170,  # ORP measured (mV) — matches the app (c177 is uncalibrated).
+                "temperature": 172,  # Water temperature (°C × 10).
+                "salinity": 174,  # Salinity (g/L × 100).
+            },
+            "specific_components": [10, 16, 20, 103, 165, 170, 172, 174],
+        },
+        priority=86,
+    ),
     "cc25024927_chlorinator": DeviceConfig(
         device_type="chlorinator",
         # AstralPool Clear Connect Escalable (model 77020) — Issue #70 (@VICTOR28N).

--- a/custom_components/fluidra_pool/light.py
+++ b/custom_components/fluidra_pool/light.py
@@ -40,26 +40,51 @@ async def async_setup_entry(
     entry: FluidraPoolConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool light entities."""
+    """Set up Fluidra Pool light entities, including devices added later."""
     coordinator = entry.runtime_data.coordinator
 
     if not coordinator.data:
         await coordinator.async_config_entry_first_refresh()
 
-    entities: list[FluidraLight] = []
-    if coordinator.data:
-        for pool_id, pool in coordinator.data.items():
+    known_devices: set[str] = set()
+
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create light entities for any device not seen yet (dynamic-devices)."""
+        entities: list[FluidraLight] = []
+
+        for pool in pools:
+            pool_id = pool["id"]
+
             for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
                 device_type = device.get("type", "")
                 family = device.get("family", "").lower()
 
                 if device_type == "light" or "light" in family:
-                    device_id = device.get("device_id")
-                    if not device_id:
-                        continue
                     entities.append(FluidraLight(coordinator, coordinator.api, pool_id, device_id))
 
-    async_add_entities(entities)
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (consistent with the other platforms).
+    pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
+    _add_entities(pools)
+
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
+
+    entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))
 
 
 class FluidraLight(FluidraPoolControlEntity, LightEntity):

--- a/custom_components/fluidra_pool/manifest.json
+++ b/custom_components/fluidra_pool/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/foXaCe/fluidra-pool/issues",
   "loggers": ["custom_components.fluidra_pool"],
-  "quality_scale": "silver",
+  "quality_scale": "platinum",
   "requirements": ["aiohttp>=3.11.0"],
   "version": "2.42.2"
 }

--- a/custom_components/fluidra_pool/number.py
+++ b/custom_components/fluidra_pool/number.py
@@ -31,41 +31,62 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool number entities."""
+    """Set up Fluidra Pool number entities, including devices added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
 
-    entities: list[NumberEntity] = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create number entities for any device not seen yet (dynamic-devices)."""
+        entities: list[NumberEntity] = []
 
-    # Use cached pools data instead of API call for faster startup
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                config = DeviceIdentifier.identify_device(device)
+                device_type = config.device_type if config else device.get("type", "")
+
+                # Chlorinator chlorination level — skip read-only probes (e.g. Blue
+                # Connect) that declare no "number" entity and do not dose.
+                if device_type == "chlorinator" and DeviceIdentifier.should_create_entity(device, "number"):
+                    entities.append(FluidraChlorinatorLevelNumber(coordinator, coordinator.api, pool_id, device_id))
+                    # Only add pH/ORP setpoints if the device has these features
+                    if DeviceIdentifier.get_feature(device, "ph_setpoint"):
+                        entities.append(FluidraChlorinatorPhSetpoint(coordinator, coordinator.api, pool_id, device_id))
+                    if DeviceIdentifier.get_feature(device, "orp_setpoint"):
+                        entities.append(FluidraChlorinatorOrpSetpoint(coordinator, coordinator.api, pool_id, device_id))
+
+                if device_type == DEVICE_TYPE_PUMP:
+                    # Groupe Réglages - Contrôles de vitesse temporairement désactivés
+                    pass
+
+                # LumiPlus Connect effect speed control
+                if device_type == "light":
+                    entities.append(FluidraLightEffectSpeed(coordinator, coordinator.api, pool_id, device_id))
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
     pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
-            if not device_id:
-                continue
+    _add_entities(pools)
 
-            config = DeviceIdentifier.identify_device(device)
-            device_type = config.device_type if config else device.get("type", "")
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
 
-            # Chlorinator chlorination level — skip read-only probes (e.g. Blue
-            # Connect) that declare no "number" entity and do not dose.
-            if device_type == "chlorinator" and DeviceIdentifier.should_create_entity(device, "number"):
-                entities.append(FluidraChlorinatorLevelNumber(coordinator, coordinator.api, pool["id"], device_id))
-                # Only add pH/ORP setpoints if the device has these features
-                if DeviceIdentifier.get_feature(device, "ph_setpoint"):
-                    entities.append(FluidraChlorinatorPhSetpoint(coordinator, coordinator.api, pool["id"], device_id))
-                if DeviceIdentifier.get_feature(device, "orp_setpoint"):
-                    entities.append(FluidraChlorinatorOrpSetpoint(coordinator, coordinator.api, pool["id"], device_id))
-
-            if device_type == DEVICE_TYPE_PUMP:
-                # Groupe Réglages - Contrôles de vitesse temporairement désactivés
-                pass
-
-            # LumiPlus Connect effect speed control
-            if device_type == "light":
-                entities.append(FluidraLightEffectSpeed(coordinator, coordinator.api, pool["id"], device_id))
-
-    async_add_entities(entities)
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))
 
 
 class FluidraChlorinatorLevelNumber(FluidraPoolControlEntity, NumberEntity):

--- a/custom_components/fluidra_pool/quality_scale.yaml
+++ b/custom_components/fluidra_pool/quality_scale.yaml
@@ -49,9 +49,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices:
-    status: todo
-    comment: Newly-added pool devices require a reload; dynamic add/remove not yet implemented.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -60,9 +58,7 @@ rules:
   icon-translations: done
   reconfiguration-flow: done
   repair-issues: done
-  stale-devices:
-    status: todo
-    comment: Removed pool devices are not automatically purged from the device registry.
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/custom_components/fluidra_pool/select/__init__.py
+++ b/custom_components/fluidra_pool/select/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.core import callback
 
 from ..const import FluidraPoolConfigEntry
 from ..device_registry import DeviceIdentifier
@@ -34,73 +35,94 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Fluidra Pool select entities."""
+    """Set up Fluidra Pool select entities, including devices added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
 
-    entities: list[SelectEntity] = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create entities for any device not seen yet (dynamic-devices)."""
+        entities: list[SelectEntity] = []
 
-    # Use cached pools data instead of API call for faster startup
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                config = DeviceIdentifier.identify_device(device)
+                device_type = config.device_type if config else device.get("type", "")
+
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                # Chlorinator mode select (OFF/ON/AUTO) — skip for variants without mode select (e.g. CC24033907).
+                if device_type == "chlorinator":
+                    skip_mode = DeviceIdentifier.has_feature(device, "skip_mode_select")
+                    if not skip_mode:
+                        entities.append(FluidraChlorinatorModeSelect(coordinator, coordinator.api, pool_id, device_id))
+
+                # Heat pumps don't expose speed or schedule controls.
+                if DeviceIdentifier.has_feature(device, "skip_schedules"):
+                    continue
+
+                if (
+                    device_type == "pump"
+                    and DeviceIdentifier.should_create_entity(device, "select")
+                    and device.get("variable_speed")
+                ):
+                    entities.append(FluidraPumpSpeedSelect(coordinator, coordinator.api, pool_id, device_id))
+
+                if (
+                    device_type == "pump"
+                    and DeviceIdentifier.should_create_entity(device, "select")
+                    and device.get("schedule_data")
+                ):
+                    # Pumps expose 8 schedule slots.
+                    for schedule_id in ["1", "2", "3", "4", "5", "6", "7", "8"]:
+                        entities.append(
+                            FluidraScheduleModeSelect(
+                                coordinator,
+                                coordinator.api,
+                                pool_id,
+                                device_id,
+                                schedule_id,
+                            )
+                        )
+
+                if device_type == "light":
+                    effect_component = DeviceIdentifier.get_feature(device, "effect_select")
+                    if effect_component:
+                        entities.append(FluidraLightEffectSelect(coordinator, coordinator.api, pool_id, device_id))
+
+                if device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "schedule_component"):
+                    schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 3)
+                    for i in range(1, schedule_count + 1):
+                        schedule_id = str(i)
+                        entities.append(
+                            FluidraChlorinatorScheduleSpeedSelect(
+                                coordinator,
+                                coordinator.api,
+                                pool_id,
+                                device_id,
+                                schedule_id,
+                            )
+                        )
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
     pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
-            config = DeviceIdentifier.identify_device(device)
-            device_type = config.device_type if config else device.get("type", "")
+    _add_entities(pools)
 
-            if not device_id:
-                continue
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
 
-            # Chlorinator mode select (OFF/ON/AUTO) — skip for variants without mode select (e.g. CC24033907).
-            if device_type == "chlorinator":
-                skip_mode = DeviceIdentifier.has_feature(device, "skip_mode_select")
-                if not skip_mode:
-                    entities.append(FluidraChlorinatorModeSelect(coordinator, coordinator.api, pool["id"], device_id))
-
-            # Heat pumps don't expose speed or schedule controls.
-            if DeviceIdentifier.has_feature(device, "skip_schedules"):
-                continue
-
-            if (
-                device_type == "pump"
-                and DeviceIdentifier.should_create_entity(device, "select")
-                and device.get("variable_speed")
-            ):
-                entities.append(FluidraPumpSpeedSelect(coordinator, coordinator.api, pool["id"], device_id))
-
-            if (
-                device_type == "pump"
-                and DeviceIdentifier.should_create_entity(device, "select")
-                and device.get("schedule_data")
-            ):
-                # Pumps expose 8 schedule slots.
-                for schedule_id in ["1", "2", "3", "4", "5", "6", "7", "8"]:
-                    entities.append(
-                        FluidraScheduleModeSelect(
-                            coordinator,
-                            coordinator.api,
-                            pool["id"],
-                            device_id,
-                            schedule_id,
-                        )
-                    )
-
-            if device_type == "light":
-                effect_component = DeviceIdentifier.get_feature(device, "effect_select")
-                if effect_component:
-                    entities.append(FluidraLightEffectSelect(coordinator, coordinator.api, pool["id"], device_id))
-
-            if device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "schedule_component"):
-                schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 3)
-                for i in range(1, schedule_count + 1):
-                    schedule_id = str(i)
-                    entities.append(
-                        FluidraChlorinatorScheduleSpeedSelect(
-                            coordinator,
-                            coordinator.api,
-                            pool["id"],
-                            device_id,
-                            schedule_id,
-                        )
-                    )
-
-    async_add_entities(entities)
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import callback
 
 from ..const import FluidraPoolConfigEntry
 from ..device_registry import DeviceIdentifier
@@ -54,82 +55,105 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool sensor entities."""
+    """Set up Fluidra Pool sensor entities, including devices/pools added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
+    known_pools: set[str] = set()
 
-    entities: list[SensorEntity] = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create entities for any pool/device not seen yet (dynamic-devices)."""
+        entities: list[SensorEntity] = []
 
-    # Use cached pools data instead of API call for faster startup
-    pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
+        for pool in pools:
+            pool_id = pool["id"]
 
-            if not device_id:
-                continue
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
 
-            # Use device registry to determine which sensors to create
-            if DeviceIdentifier.should_create_entity(device, "sensor_info"):
-                entities.append(FluidraDeviceInfoSensor(coordinator, coordinator.api, pool["id"], device_id))
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
 
-            if DeviceIdentifier.should_create_entity(device, "sensor_schedule"):
-                entities.append(FluidraPumpScheduleSensor(coordinator, coordinator.api, pool["id"], device_id))
+                # Use device registry to determine which sensors to create
+                if DeviceIdentifier.should_create_entity(device, "sensor_info"):
+                    entities.append(FluidraDeviceInfoSensor(coordinator, coordinator.api, pool_id, device_id))
 
-            if DeviceIdentifier.should_create_entity(device, "sensor_speed"):
-                entities.append(FluidraPumpSpeedSensor(coordinator, coordinator.api, pool["id"], device_id))
+                if DeviceIdentifier.should_create_entity(device, "sensor_schedule"):
+                    entities.append(FluidraPumpScheduleSensor(coordinator, coordinator.api, pool_id, device_id))
 
-            if DeviceIdentifier.should_create_entity(device, "sensor_temperature"):
-                # Temperature sensors for heaters / heat pumps.
-                if "target_temperature" in device:
-                    entities.append(
-                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "target")
-                    )
-                # Z550iQ+ heat pump specific temperature sensors
-                if DeviceIdentifier.has_feature(device, "z550_mode"):
-                    entities.append(
-                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "water")
-                    )
-                    entities.append(
-                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "air")
-                    )
-                # Z260iQ heat pump specific temperature sensors
-                if DeviceIdentifier.has_feature(device, "z260iq_mode"):
-                    entities.append(
-                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "water")
-                    )
-                    entities.append(
-                        FluidraTemperatureSensor(coordinator, coordinator.api, pool["id"], device_id, "air")
-                    )
+                if DeviceIdentifier.should_create_entity(device, "sensor_speed"):
+                    entities.append(FluidraPumpSpeedSensor(coordinator, coordinator.api, pool_id, device_id))
 
-            if DeviceIdentifier.should_create_entity(device, "sensor_brightness"):
-                entities.append(FluidraLightBrightnessSensor(coordinator, coordinator.api, pool["id"], device_id))
-
-            if DeviceIdentifier.should_create_entity(device, "sensor_running_hours"):
-                entities.append(FluidraRunningHoursSensor(coordinator, coordinator.api, pool["id"], device_id))
-
-            # Chlorinator sensors - create based on sensors_config from device registry
-            config = DeviceIdentifier.identify_device(device)
-            device_type = config.device_type if config else device.get("type", "")
-            if device_type == "chlorinator":
-                sensors_config = DeviceIdentifier.get_feature(device, "sensors", {})
-
-                for sensor_type in ("ph", "orp", "free_chlorine", "temperature", "salinity", "chlorination_actual"):
-                    if sensor_type in sensors_config:
+                if DeviceIdentifier.should_create_entity(device, "sensor_temperature"):
+                    # Temperature sensors for heaters / heat pumps.
+                    if "target_temperature" in device:
                         entities.append(
-                            FluidraChlorinatorSensor(
-                                coordinator,
-                                coordinator.api,
-                                pool["id"],
-                                device_id,
-                                sensor_type,
-                                sensors_config[sensor_type],
-                            )
+                            FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "target")
+                        )
+                    # Z550iQ+ heat pump specific temperature sensors
+                    if DeviceIdentifier.has_feature(device, "z550_mode"):
+                        entities.append(
+                            FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "water")
+                        )
+                        entities.append(
+                            FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "air")
+                        )
+                    # Z260iQ heat pump specific temperature sensors
+                    if DeviceIdentifier.has_feature(device, "z260iq_mode"):
+                        entities.append(
+                            FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "water")
+                        )
+                        entities.append(
+                            FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "air")
                         )
 
-        # Pool-level sensors (not tied to a specific device).
-        entities.append(FluidraPoolWeatherSensor(coordinator, coordinator.api, pool["id"]))
-        entities.append(FluidraPoolStatusSensor(coordinator, coordinator.api, pool["id"]))
-        entities.append(FluidraPoolLocationSensor(coordinator, coordinator.api, pool["id"]))
-        entities.append(FluidraPoolWaterQualitySensor(coordinator, coordinator.api, pool["id"]))
+                if DeviceIdentifier.should_create_entity(device, "sensor_brightness"):
+                    entities.append(FluidraLightBrightnessSensor(coordinator, coordinator.api, pool_id, device_id))
 
-    async_add_entities(entities)
+                if DeviceIdentifier.should_create_entity(device, "sensor_running_hours"):
+                    entities.append(FluidraRunningHoursSensor(coordinator, coordinator.api, pool_id, device_id))
+
+                # Chlorinator sensors - create based on sensors_config from device registry
+                config = DeviceIdentifier.identify_device(device)
+                device_type = config.device_type if config else device.get("type", "")
+                if device_type == "chlorinator":
+                    sensors_config = DeviceIdentifier.get_feature(device, "sensors", {})
+
+                    for sensor_type in ("ph", "orp", "free_chlorine", "temperature", "salinity", "chlorination_actual"):
+                        if sensor_type in sensors_config:
+                            entities.append(
+                                FluidraChlorinatorSensor(
+                                    coordinator,
+                                    coordinator.api,
+                                    pool_id,
+                                    device_id,
+                                    sensor_type,
+                                    sensors_config[sensor_type],
+                                )
+                            )
+
+            # Pool-level sensors (not tied to a specific device).
+            if pool_id not in known_pools:
+                known_pools.add(pool_id)
+                entities.append(FluidraPoolWeatherSensor(coordinator, coordinator.api, pool_id))
+                entities.append(FluidraPoolStatusSensor(coordinator, coordinator.api, pool_id))
+                entities.append(FluidraPoolLocationSensor(coordinator, coordinator.api, pool_id))
+                entities.append(FluidraPoolWaterQualitySensor(coordinator, coordinator.api, pool_id))
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
+    pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
+    _add_entities(pools)
+
+    # Add entities for devices/pools that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))

--- a/custom_components/fluidra_pool/switch/__init__.py
+++ b/custom_components/fluidra_pool/switch/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import callback
 
 from ..const import FluidraPoolConfigEntry
 from ..device_registry import DeviceIdentifier
@@ -38,47 +39,67 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool switch entities."""
+    """Set up Fluidra Pool switch entities, including devices added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
 
-    entities: list[SwitchEntity] = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create switches for any device not seen yet (dynamic-devices)."""
+        entities: list[SwitchEntity] = []
 
-    # Use cached pools data instead of API call for faster startup
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                if DeviceIdentifier.should_create_entity(device, "switch"):
+                    device_config = DeviceIdentifier.identify_device(device)
+                    if device_config:
+                        device_type = device_config.device_type
+
+                        if device_type == "heat_pump":
+                            entities.append(FluidraHeatPumpSwitch(coordinator, coordinator.api, pool_id, device_id))
+                        elif device_type == "pump":
+                            entities.append(FluidraPumpSwitch(coordinator, coordinator.api, pool_id, device_id))
+                        elif device_type == "heater":
+                            entities.append(FluidraHeaterSwitch(coordinator, coordinator.api, pool_id, device_id))
+                        elif device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "on_off_component"):
+                            entities.append(FluidraChlorinatorSwitch(coordinator, coordinator.api, pool_id, device_id))
+
+                if DeviceIdentifier.should_create_entity(device, "switch_auto") and not DeviceIdentifier.has_feature(
+                    device, "skip_auto_mode"
+                ):
+                    entities.append(FluidraAutoModeSwitch(coordinator, coordinator.api, pool_id, device_id))
+
+                if DeviceIdentifier.has_feature(device, "schedules"):
+                    schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 8)
+                    for schedule_id in [str(i) for i in range(1, schedule_count + 1)]:
+                        entities.append(
+                            FluidraScheduleEnableSwitch(coordinator, coordinator.api, pool_id, device_id, schedule_id)
+                        )
+
+                if DeviceIdentifier.has_feature(device, "boost_mode"):
+                    entities.append(FluidraChlorinatorBoostSwitch(coordinator, coordinator.api, pool_id, device_id))
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
     pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
+    _add_entities(pools)
 
-            if not device_id:
-                continue
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
 
-            if DeviceIdentifier.should_create_entity(device, "switch"):
-                device_config = DeviceIdentifier.identify_device(device)
-                if device_config:
-                    device_type = device_config.device_type
-
-                    if device_type == "heat_pump":
-                        entities.append(FluidraHeatPumpSwitch(coordinator, coordinator.api, pool["id"], device_id))
-                    elif device_type == "pump":
-                        entities.append(FluidraPumpSwitch(coordinator, coordinator.api, pool["id"], device_id))
-                    elif device_type == "heater":
-                        entities.append(FluidraHeaterSwitch(coordinator, coordinator.api, pool["id"], device_id))
-                    elif device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "on_off_component"):
-                        entities.append(FluidraChlorinatorSwitch(coordinator, coordinator.api, pool["id"], device_id))
-
-            if DeviceIdentifier.should_create_entity(device, "switch_auto") and not DeviceIdentifier.has_feature(
-                device, "skip_auto_mode"
-            ):
-                entities.append(FluidraAutoModeSwitch(coordinator, coordinator.api, pool["id"], device_id))
-
-            if DeviceIdentifier.has_feature(device, "schedules"):
-                schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 8)
-                for schedule_id in [str(i) for i in range(1, schedule_count + 1)]:
-                    entities.append(
-                        FluidraScheduleEnableSwitch(coordinator, coordinator.api, pool["id"], device_id, schedule_id)
-                    )
-
-            if DeviceIdentifier.has_feature(device, "boost_mode"):
-                entities.append(FluidraChlorinatorBoostSwitch(coordinator, coordinator.api, pool["id"], device_id))
-
-    async_add_entities(entities)
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))

--- a/custom_components/fluidra_pool/time/__init__.py
+++ b/custom_components/fluidra_pool/time/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.time import TimeEntity
+from homeassistant.core import callback
 
 from ..const import FluidraPoolConfigEntry
 from ..device_registry import DeviceIdentifier
@@ -39,69 +40,94 @@ async def async_setup_entry(
     config_entry: FluidraPoolConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Fluidra Pool time entities."""
+    """Set up Fluidra Pool time entities, including devices added later."""
     coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
 
-    entities: list[TimeEntity] = []
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create entities for any device not seen yet (dynamic-devices)."""
+        entities: list[TimeEntity] = []
 
-    # Use cached pools data instead of API call for faster startup.
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                config = DeviceIdentifier.identify_device(device)
+                device_type = config.device_type if config else device.get("type", "")
+
+                # Heat pumps don't expose schedule controls.
+                if DeviceIdentifier.has_feature(device, "skip_schedules"):
+                    continue
+
+                if device_type == "light":
+                    # LumiPlus Connect lights — only create entities for existing schedules.
+                    schedule_data = []
+                    if coordinator.data:
+                        pool_data = coordinator.data.get(pool_id, {})
+                        for dev in pool_data.get("devices", []):
+                            if dev.get("device_id") == device_id:
+                                schedule_data = dev.get("schedule_data", [])
+                                break
+
+                    if schedule_data:
+                        for schedule in schedule_data:
+                            schedule_id = str(schedule.get("id", ""))
+                            if schedule_id:
+                                entities.append(
+                                    FluidraLightScheduleStartTimeEntity(
+                                        coordinator, coordinator.api, pool_id, device_id, schedule_id
+                                    )
+                                )
+                                entities.append(
+                                    FluidraLightScheduleEndTimeEntity(
+                                        coordinator, coordinator.api, pool_id, device_id, schedule_id
+                                    )
+                                )
+                elif device_type == "pump" and DeviceIdentifier.should_create_entity(device, "time"):
+                    # Pumps: 8 schedulers on component 20.
+                    for schedule_id in ["1", "2", "3", "4", "5", "6", "7", "8"]:
+                        entities.append(
+                            FluidraScheduleStartTimeEntity(
+                                coordinator, coordinator.api, pool_id, device_id, schedule_id
+                            )
+                        )
+                        entities.append(
+                            FluidraScheduleEndTimeEntity(coordinator, coordinator.api, pool_id, device_id, schedule_id)
+                        )
+                elif device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "schedules"):
+                    # Chlorinators with schedules (e.g., DM24049704).
+                    schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 3)
+                    for i in range(1, schedule_count + 1):
+                        schedule_id = str(i)
+                        entities.append(
+                            FluidraScheduleStartTimeEntity(
+                                coordinator, coordinator.api, pool_id, device_id, schedule_id
+                            )
+                        )
+                        entities.append(
+                            FluidraScheduleEndTimeEntity(coordinator, coordinator.api, pool_id, device_id, schedule_id)
+                        )
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
     pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
-    for pool in pools:
-        for device in pool["devices"]:
-            device_id = device.get("device_id")
-            config = DeviceIdentifier.identify_device(device)
-            device_type = config.device_type if config else device.get("type", "")
+    _add_entities(pools)
 
-            if not device_id:
-                continue
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
 
-            # Heat pumps don't expose schedule controls.
-            if DeviceIdentifier.has_feature(device, "skip_schedules"):
-                continue
-
-            if device_type == "light":
-                # LumiPlus Connect lights — only create entities for existing schedules.
-                schedule_data = []
-                if coordinator.data:
-                    pool_data = coordinator.data.get(pool["id"], {})
-                    for dev in pool_data.get("devices", []):
-                        if dev.get("device_id") == device_id:
-                            schedule_data = dev.get("schedule_data", [])
-                            break
-
-                if schedule_data:
-                    for schedule in schedule_data:
-                        schedule_id = str(schedule.get("id", ""))
-                        if schedule_id:
-                            entities.append(
-                                FluidraLightScheduleStartTimeEntity(
-                                    coordinator, coordinator.api, pool["id"], device_id, schedule_id
-                                )
-                            )
-                            entities.append(
-                                FluidraLightScheduleEndTimeEntity(
-                                    coordinator, coordinator.api, pool["id"], device_id, schedule_id
-                                )
-                            )
-            elif device_type == "pump" and DeviceIdentifier.should_create_entity(device, "time"):
-                # Pumps: 8 schedulers on component 20.
-                for schedule_id in ["1", "2", "3", "4", "5", "6", "7", "8"]:
-                    entities.append(
-                        FluidraScheduleStartTimeEntity(coordinator, coordinator.api, pool["id"], device_id, schedule_id)
-                    )
-                    entities.append(
-                        FluidraScheduleEndTimeEntity(coordinator, coordinator.api, pool["id"], device_id, schedule_id)
-                    )
-            elif device_type == "chlorinator" and DeviceIdentifier.has_feature(device, "schedules"):
-                # Chlorinators with schedules (e.g., DM24049704).
-                schedule_count = DeviceIdentifier.get_feature(device, "schedule_count", 3)
-                for i in range(1, schedule_count + 1):
-                    schedule_id = str(i)
-                    entities.append(
-                        FluidraScheduleStartTimeEntity(coordinator, coordinator.api, pool["id"], device_id, schedule_id)
-                    )
-                    entities.append(
-                        FluidraScheduleEndTimeEntity(coordinator, coordinator.api, pool["id"], device_id, schedule_id)
-                    )
-
-    async_add_entities(entities)
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))

--- a/tests/test_climate_full.py
+++ b/tests/test_climate_full.py
@@ -892,7 +892,10 @@ async def test_async_setup_entry_creates_climate_for_heat_pump() -> None:
         cached_pools=[{"id": POOL_ID, "devices": [hp, other]}],
         get_pools=AsyncMock(return_value=[]),
     )
-    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
 
     added: list = []
 
@@ -914,7 +917,10 @@ async def test_async_setup_entry_falls_back_to_get_pools() -> None:
         cached_pools=[],
         get_pools=AsyncMock(return_value=[{"id": POOL_ID, "devices": [hp]}]),
     )
-    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
 
     added: list = []
     async_add = MagicMock(side_effect=lambda e, *a, **k: added.extend(list(e)))
@@ -932,9 +938,44 @@ async def test_async_setup_entry_no_climate_entities() -> None:
         cached_pools=[{"id": POOL_ID, "devices": [pump]}],
         get_pools=AsyncMock(return_value=[]),
     )
-    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
 
     added: list = []
     async_add = MagicMock(side_effect=lambda e, *a, **k: added.extend(list(e)))
     await async_setup_entry(MagicMock(), entry, async_add)
     assert added == []
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a heat pump appearing on a later poll is wired without a reload."""
+    hp1 = _pin("HP-DYN-1", entities=["climate"])
+    pool = {"id": POOL_ID, "devices": [hp1]}
+    coordinator = MagicMock()
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, "devices": pool["devices"]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda e, *a, **k: added.extend(list(e)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("HP-DYN-1" in u for u in uids_after_setup)
+    assert not any("HP-DYN-2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new heat pump shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_pin("HP-DYN-2", entities=["climate"]))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("HP-DYN-2" in u for u in new_uids), "only the newly-added device's entities are created"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
 from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
+from custom_components.fluidra_pool.const import STALE_DEVICE_THRESHOLD
 from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
 
 
@@ -205,14 +206,10 @@ class TestProcessComponentState:
 
 
 class TestCleanupRemovedDevices:
-    """Test _cleanup_removed_devices best-effort behaviour."""
+    """Test _cleanup_removed_devices confirmation-based purge (stale-devices)."""
 
-    async def test_cleanup_swallows_registry_keyerror(self, hass: HomeAssistant, mock_api: AsyncMock):
-        """A KeyError from async_remove_device must not propagate / fail the poll (coordinator-4).
-
-        The device registry's async_remove_device raises a bare KeyError when a
-        device was removed concurrently; the best-effort cleanup must absorb it.
-        """
+    @staticmethod
+    def _coord(hass: HomeAssistant, mock_api: AsyncMock) -> FluidraDataUpdateCoordinator:
         entry = MagicMock()
         entry.entry_id = "entry_1"
         entry.options = {}  # Keep the default scan interval (avoid a MagicMock timedelta).
@@ -220,16 +217,25 @@ class TestCleanupRemovedDevices:
         # The base DataUpdateCoordinator overwrites config_entry from a ContextVar that
         # isn't set in tests; pin it back so cleanup runs instead of early-returning.
         coord.config_entry = entry
+        return coord
 
+    @staticmethod
+    def _device_entry() -> MagicMock:
         device_entry = MagicMock()
         device_entry.id = "dev_reg_1"
         device_entry.model = "Pump"  # Not a "Pool" parent, so it is eligible for removal.
         device_entry.identifiers = {("fluidra_pool", "serial_gone")}
+        return device_entry
 
-        dev_reg = MagicMock()
-        dev_reg.async_remove_device.side_effect = KeyError("already removed")
-        ent_reg = MagicMock()
-
+    @staticmethod
+    async def _run(
+        coord: FluidraDataUpdateCoordinator,
+        current_device_ids: set[str],
+        *,
+        device_entry: MagicMock,
+        dev_reg: MagicMock,
+        ent_reg: MagicMock,
+    ) -> None:
         module = "custom_components.fluidra_pool.coordinator.coordinator"
         with (
             patch(f"{module}.dr.async_get", return_value=dev_reg),
@@ -237,8 +243,52 @@ class TestCleanupRemovedDevices:
             patch(f"{module}.er.async_get", return_value=ent_reg),
             patch(f"{module}.er.async_entries_for_device", return_value=[]),
         ):
-            # "serial_gone" is absent from the current set → removal is attempted and raises.
-            await coord._cleanup_removed_devices(current_device_ids={"still_here"})
+            await coord._cleanup_removed_devices(current_device_ids=current_device_ids)
+
+    async def test_cleanup_waits_for_threshold_before_purge(self, hass: HomeAssistant, mock_api: AsyncMock):
+        """A device must be absent for STALE_DEVICE_THRESHOLD polls before it is purged."""
+        coord = self._coord(hass, mock_api)
+        device_entry = self._device_entry()
+        dev_reg, ent_reg = MagicMock(), MagicMock()
+
+        # Absent for THRESHOLD-1 consecutive polls → not purged yet.
+        for _ in range(STALE_DEVICE_THRESHOLD - 1):
+            await self._run(coord, {"still_here"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
+        dev_reg.async_remove_device.assert_not_called()
+
+        # The THRESHOLD-th consecutive absence triggers the purge.
+        await self._run(coord, {"still_here"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
+        dev_reg.async_remove_device.assert_called_once_with("dev_reg_1")
+
+    async def test_cleanup_resets_strikes_when_device_returns(self, hass: HomeAssistant, mock_api: AsyncMock):
+        """A device that reappears clears its strike count and is not purged."""
+        coord = self._coord(hass, mock_api)
+        device_entry = self._device_entry()
+        dev_reg, ent_reg = MagicMock(), MagicMock()
+
+        for _ in range(STALE_DEVICE_THRESHOLD - 1):
+            await self._run(coord, {"still_here"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
+        # Device is present again → strike count resets.
+        await self._run(coord, {"serial_gone"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
+        # A fresh absence is only the first strike again → still not purged.
+        await self._run(coord, {"still_here"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
+
+        dev_reg.async_remove_device.assert_not_called()
+
+    async def test_cleanup_swallows_registry_keyerror(self, hass: HomeAssistant, mock_api: AsyncMock):
+        """A KeyError from async_remove_device must not propagate / fail the poll (coordinator-4).
+
+        The device registry's async_remove_device raises a bare KeyError when a
+        device was removed concurrently; the best-effort cleanup must absorb it.
+        """
+        coord = self._coord(hass, mock_api)
+        device_entry = self._device_entry()
+        dev_reg, ent_reg = MagicMock(), MagicMock()
+        dev_reg.async_remove_device.side_effect = KeyError("already removed")
+        # Pre-age the device to the brink so a single poll triggers the removal.
+        coord._missing_device_counts["serial_gone"] = STALE_DEVICE_THRESHOLD - 1
+
+        await self._run(coord, {"still_here"}, device_entry=device_entry, dev_reg=dev_reg, ent_reg=ent_reg)
 
         dev_reg.async_remove_device.assert_called_once_with("dev_reg_1")
 

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -165,6 +165,25 @@ class TestDeviceConfigRegistry:
         assert sensors["temperature"] == 172
         assert sensors["salinity"] == 174
         assert config.features["chlorination_level"] == 10
+
+    def test_lc25024524_uses_teclc2_layout(self):
+        """tecnoLC2 chlorinator LC25024524 maps on the tecnoLC2 layout, not the generic profile (Issue #73)."""
+        config = DEVICE_CONFIGS["lc25024524_chlorinator"]
+        device = {
+            "device_id": "LC25024524.nn_1",
+            "name": "Chlorinator",
+            "family": "Chlorinators",
+            "type": "chlorinator",
+            "model": "Chlorinator",
+            "components": {"172": {"reportedValue": 316}},
+        }
+        assert DeviceIdentifier.identify_device(device) is config
+        sensors = config.features["sensors"]
+        # c172 (=31.6°C) is temperature, not pH as the generic config read (÷100 → 3.16).
+        assert sensors["ph"] == 165
+        assert sensors["orp"] == 170  # calibrated ORP (659 mV), not the raw c177 (720)
+        assert sensors["temperature"] == 172
+        assert sensors["salinity"] == 174
         assert config.features["ph_setpoint"] == 16
         # Same layout as the sibling Irripool iSALT profile.
         assert config.features["sensors"] == DEVICE_CONFIGS["lc24013306_chlorinator"].features["sensors"]

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -31,7 +31,6 @@ from custom_components.fluidra_pool import (
     _service_schedule_to_fluidra,
     async_migrate_entry,
     async_setup_entry,
-    async_unload_entry,
 )
 from custom_components.fluidra_pool.api_resilience import FluidraError, FluidraMFARequired
 from custom_components.fluidra_pool.const import DOMAIN
@@ -182,7 +181,8 @@ async def test_unload_entry_no_runtime_data(hass: HomeAssistant, mock_api: Async
     # Simulate runtime_data already torn down.
     entry.runtime_data = None
 
-    assert await async_unload_entry(hass, entry) is True
+    # Unload through HA so async_on_unload callbacks (coordinator listeners) fire.
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_RGBW_COLOR
@@ -14,7 +15,7 @@ from custom_components.fluidra_pool.const import (
     LUMIPLUS_COMPONENT_COLOR,
     LUMIPLUS_COMPONENT_POWER,
 )
-from custom_components.fluidra_pool.light import FluidraLight
+from custom_components.fluidra_pool.light import FluidraLight, async_setup_entry
 
 POOL_ID = "pool-1"
 DEVICE_ID = "LP24-001"
@@ -312,3 +313,43 @@ async def test_async_turn_off_raises_and_rolls_back_on_api_exception() -> None:
 
     assert light._optimistic_is_on is None
     light.coordinator.async_request_refresh.assert_not_awaited()
+
+
+# --- async_setup_entry ---------------------------------------------------
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a light appearing on a later poll is wired without a reload."""
+
+    def _light_device(device_id: str) -> dict:
+        return {"device_id": device_id, "name": "Light", "type": "light", "components": {}}
+
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [_light_device("LIGHT-1")]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool])
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("LIGHT-1" in u for u in uids_after_setup)
+    assert not any("LIGHT-2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new light shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_light_device("LIGHT-2"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("LIGHT-2" in u for u in new_uids), "only the newly-added device's entities are created"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -13,6 +13,7 @@ from custom_components.fluidra_pool.number import (
     FluidraChlorinatorOrpSetpoint,
     FluidraChlorinatorPhSetpoint,
     FluidraLightEffectSpeed,
+    async_setup_entry,
 )
 
 POOL_ID = "pool-1"
@@ -545,3 +546,43 @@ def test_light_effect_speed_extra_state_attributes() -> None:
         "device_id": "LP24-001",
         "speed_range": "1-8",
     }
+
+
+# --- async_setup_entry ---------------------------------------------------
+
+
+def _light_setup_device(device_id: str) -> dict:
+    return {"device_id": device_id, "name": "Pool Light", "type": "light", "online": True, "components": {}}
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a device appearing on a later poll is wired without a reload."""
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [_light_setup_device("LIGHT-1")]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("LIGHT-1" in u for u in uids_after_setup)
+    assert not any("LIGHT-2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new device shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_light_setup_device("LIGHT-2"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("LIGHT-2" in u for u in new_uids), "only the newly-added device's entities are created"

--- a/tests/test_platform_setups.py
+++ b/tests/test_platform_setups.py
@@ -125,7 +125,10 @@ def _coordinator(devices, *, data=None):
 
 
 def _entry(coordinator):
-    return SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    return SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
 
 
 async def _run(setup, coordinator):
@@ -577,5 +580,6 @@ async def test_light_setup_no_data_after_refresh_adds_nothing():
     coordinator.async_config_entry_first_refresh = AsyncMock()
     added, async_add = await _run(light_setup, coordinator)
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
-    async_add.assert_called_once()
+    # With no devices the platform now skips the empty async_add_entities call.
+    async_add.assert_not_called()
     assert added == []

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -13,6 +13,7 @@ from custom_components.fluidra_pool.select import (
     FluidraChlorinatorModeSelect,
     FluidraLightEffectSelect,
     FluidraPumpSpeedSelect,
+    async_setup_entry,
 )
 
 POOL_ID = "pool-1"
@@ -294,3 +295,54 @@ def test_light_effect_extra_state_attributes_missing_component() -> None:
     assert attrs["reported_value"] is None
     assert attrs["desired_value"] is None
     assert attrs["optimistic_option"] is None
+
+
+# --- async_setup_entry — dynamic-devices wiring ------------------------------
+
+
+def _pinned_pump(device_id: str) -> dict:
+    """Build a variable-speed pump device that yields a FluidraPumpSpeedSelect."""
+    device = _pinned_device(
+        device_id,
+        device_type="pump",
+        entities=["select"],
+        variable_speed=True,
+    )
+    # _pinned_device pins device_type="generic"/entities=[]; override the cache.
+    device["_identify_cache"]["config"].device_type = "pump"
+    device["_identify_cache"]["config"].entities = ["select"]
+    return device
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a device appearing on a later poll is wired without a reload."""
+    dev1 = _pinned_pump("dev1")
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [dev1]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("dev1" in u for u in uids_after_setup)
+    assert not any("dev2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new device shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_pinned_pump("dev2"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("dev2" in u for u in new_uids), "only the newly-added device's entities are created"

--- a/tests/test_sensor_full.py
+++ b/tests/test_sensor_full.py
@@ -987,7 +987,10 @@ def _setup_coordinator(devices: list[dict]) -> Any:
 
 
 async def _run_setup(coordinator: Any) -> list[Any]:
-    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
     added: list[Any] = []
 
     def _add(entities, *a, **k):
@@ -996,6 +999,40 @@ async def _run_setup(coordinator: Any) -> list[Any]:
     async_add = MagicMock(side_effect=_add)
     await async_setup_entry(MagicMock(), entry, async_add)
     return added
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a device appearing on a later poll is wired without a reload."""
+    dev1 = _pinned_device("dev1", entities=["sensor_info"], device_type="pump")
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [dev1]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("dev1" in u for u in uids_after_setup)
+    assert not any("dev2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new device shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_pinned_device("dev2", entities=["sensor_info"], device_type="pump"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("dev2" in u for u in new_uids), "only the newly-added device's entities are created"
 
 
 async def test_setup_creates_pool_level_sensors_always() -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,6 +13,7 @@ from custom_components.fluidra_pool.switch import (
     FluidraHeaterSwitch,
     FluidraPumpSwitch,
     FluidraScheduleEnableSwitch,
+    async_setup_entry,
 )
 
 POOL_ID = "pool-1"
@@ -305,3 +306,63 @@ async def test_schedule_switch_turn_off_keeps_optimistic_until_server_confirms()
     assert switch._pending_state is False
     switch._api.set_schedule.assert_awaited_once()
     switch.coordinator.async_request_refresh.assert_awaited_once()
+
+
+# --- async_setup_entry: dynamic-devices ----------------------------------
+
+
+def _pinned_pump(device_id: str) -> dict:
+    """A device pinned to a pump config so the platform creates a FluidraPumpSwitch."""
+    return {
+        "device_id": device_id,
+        "name": "Pump",
+        "family": "",
+        "type": "",
+        "model": "",
+        "online": True,
+        "components": {},
+        "_identify_cache": {
+            "key": (device_id, "", "", "", ""),
+            "config": SimpleNamespace(
+                device_type="pump",
+                features={},
+                entities=["switch"],
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+            ),
+        },
+    }
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a device appearing on a later poll is wired without a reload."""
+    dev1 = _pinned_pump("dev1")
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [dev1]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("dev1" in u for u in uids_after_setup)
+    assert not any("dev2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new device shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_pinned_pump("dev2"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("dev2" in u for u in new_uids), "only the newly-added device's entities are created"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -12,6 +12,7 @@ import pytest
 from custom_components.fluidra_pool.time import (
     FluidraScheduleEndTimeEntity,
     FluidraScheduleStartTimeEntity,
+    async_setup_entry,
     parse_schedule_time,
 )
 
@@ -175,3 +176,64 @@ async def test_schedule_start_async_set_value_no_op_without_schedule_data() -> N
 
     api.set_schedule.assert_not_called()
     assert entity._optimistic_value is None
+
+
+# --- async_setup_entry — dynamic-devices wiring ---
+
+
+def _pinned_pump(device_id: str) -> dict:
+    """Build a pump device with a pinned DeviceIdentifier cache exposing 'time'."""
+    return {
+        "device_id": device_id,
+        "name": "Pump",
+        "family": "",
+        "type": "",
+        "model": "",
+        "online": True,
+        "components": {},
+        "schedule_data": [],
+        "_identify_cache": {
+            "key": (device_id, "", "", "", ""),
+            "config": SimpleNamespace(
+                device_type="pump",
+                features={},
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=["time"],
+            ),
+        },
+    }
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a device appearing on a later poll is wired without a reload."""
+    dev1 = _pinned_pump("dev1")
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [dev1]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    uids_after_setup = {e.unique_id for e in added}
+    assert any("dev1" in u for u in uids_after_setup)
+    assert not any("dev2" in u for u in uids_after_setup)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+    # A new device shows up on a later poll; firing the listener must wire it.
+    pool["devices"].append(_pinned_pump("dev2"))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids, "new device entities should be added without a reload"
+    assert all("dev2" in u for u in new_uids), "only the newly-added device's entities are created"


### PR DESCRIPTION
## Summary
Brings the integration to **Platinum** quality scale and fixes a misread chlorinator from #73.

### Platinum (`51701a6`)
- **`dynamic-devices`** — every platform (sensor, switch, select, number, time, climate, light) adds newly-discovered pool devices on the next poll via a coordinator listener, **no reload required**. Initial setup behaviour unchanged.
- **`stale-devices`** — a removed device is purged only after `STALE_DEVICE_THRESHOLD` (3) consecutive successful polls, so a transient partial cloud response can no longer wipe devices/entities/history on one hiccup.
- **`CONFIG_SCHEMA`** — declared config-entry-only (silences the hassfest warning).
- Flipped `quality_scale` `dynamic-devices`/`stale-devices` to done; bumped `manifest.quality_scale` to **platinum** (all Bronze→Platinum rules met). `strict-typing` was enforced earlier this cycle.

### Fix #73 (`29fc525`)
- Chlorinator **`LC25024524`** (@Ausstriken) fell back to the generic profile (read c172 water-temp as pH → 3.16). New dedicated tecnoLC2 profile maps pH=c165, ORP=c170, temp=c172, salinity=c174 — confirmed against the Fluidra app.

## Verification
- ✅ **1269 tests** pass (Python 3.14 + HA 2026.6.4)
- ✅ `mypy --strict` clean, `ruff` check+format clean
- ✅ hassfest: 0 invalid, **platinum** validated
- ✅ HA dev: check_config OK, loads with 0 errors
- ✅ `unique_id` unchanged

Addresses #73 (@Ausstriken's LC25024524).