### PR TITLE
fix: add Gre HPGIC heat pump profile (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Gre HPGIC heat pump** (Issue #92, @sterubbg) — dedicated device profile so it's recognised on its own instead of matching the LG Eco Elyo by serial coincidence (its cloud serial is LG-prefixed). ON/OFF, mode and target temperature read from the correct components, and the component scan is widened to surface the remaining sensors.
+
 ## [2.43.0] - 2026-06-24
 
 ### Added

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -125,4 +125,32 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=96,  # Higher than z250iq.
     ),
+    "hpgic_gre_heat_pump": DeviceConfig(
+        device_type="heat_pump",
+        # Gre HPGIC full-inverter heat pump — Issue #92 (@sterubbg). Its cloud
+        # serial is LG-prefixed (e.g. LG25363734), so it was matching the LG Eco
+        # Elyo profile by coincidence (LG* → priority 100). Match it by model/name
+        # instead and win the tie with a higher priority. No family_patterns: a
+        # bare "heat pump" match would steal genuinely-unknown heat pumps from the
+        # generic fallback. comp7 here is CXWAB (the LG Eco Elyo signature is
+        # BXWAA). Confirmed layout from the reporter's diagnostics: c13 ON/OFF
+        # (1=ON), c14 mode (0=Smart Heating), c15 target temperature (×10,
+        # 300=30.0°C), c19 water temperature (×10). The scan is widened beyond the
+        # narrow LG set to surface the remaining components — the app's "current
+        # temperature" sits on one the LG scan never read.
+        name_patterns=["hpgic"],
+        model_patterns=["hpgic"],
+        components_range=5,
+        required_components=[0, 1, 2, 3],
+        entities=["climate", "switch", "sensor_info"],
+        features={
+            "preset_modes": True,
+            "temperature_control": True,
+            "hvac_modes": ["off", "heat"],
+            "skip_auto_mode": True,
+            "skip_schedules": True,
+            "specific_components": [7, 13, 14, 15, 17, 19, 28, 67, 81, 82],
+        },
+        priority=101,
+    ),
 }

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -382,6 +382,21 @@ class TestIdentifyDevice:
         assert config is not None
         assert config.device_type == "heat_pump"
 
+    def test_hpgic_gre_identified_over_lg_eco_elyo(self):
+        """Gre HPGIC heat pump (LG-prefixed serial) matches its own profile, not LG Eco Elyo (Issue #92)."""
+        device = {
+            "device_id": "LG25363734.nn_1",  # LG-prefixed → would score 60 on lg_heat_pump
+            "name": "HPGIC GRE",
+            "family": "Heat Pumps",
+            "model": "HPGIC GRE",
+            "type": "heat_pump",
+            "components": {"7": {"reportedValue": "CXWAB0103544325004"}},  # LG Eco Elyo is BXWAA
+        }
+        config = DeviceIdentifier.identify_device(device)
+        assert config is DEVICE_CONFIGS["hpgic_gre_heat_pump"]
+        # Confirmed mapping (c13/c14/c15/c19) + widened scan to surface the current-temp component.
+        assert config.features["specific_components"] == [7, 13, 14, 15, 17, 19, 28, 67, 81, 82]
+
     def test_identify_pump_by_id(self):
         device = {
             "device_id": "E30-12345",


### PR DESCRIPTION
## Summary
The **Gre HPGIC** heat pump (@sterubbg, #92) has an LG-prefixed cloud serial (`LG25363734`), so it was matching the **LG Eco Elyo** profile by coincidence (its comp7 signature is `CXWAB`, the Eco Elyo's is `BXWAA`).

Adds a dedicated **`hpgic_gre_heat_pump`** profile:
- Matched by **model/name `hpgic`** (priority 101 to win the tie against the LG profile). **No `family_patterns`** — a bare "heat pump" match would steal genuinely-unknown heat pumps from the generic fallback.
- Confirmed layout from the reporter's diagnostics: **c13** ON/OFF, **c14** mode (0=Smart Heating), **c15** target temperature (×10 → 30 °C), **c19** water temperature (×10).
- Component scan widened to `[7,13,14,15,17,19,28,67,81,82]` to surface the remaining sensors (the app's *current temperature* sits on a component the narrow LG scan never read).

## Verification
- ✅ 1270 tests pass (new `test_hpgic_gre_identified_over_lg_eco_elyo`; LG Eco Elyo and unknown-heat-pump→generic still pass → no regression)
- ✅ `mypy --strict`, `ruff` check+format clean
- ✅ HA dev check_config OK

Addresses #92 (@sterubbg). Current-temperature mapping + command confirmation pending a fresh diagnostics after release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gre HPGIC heat pumps with a dedicated device profile.
  * Improved device recognition so these heat pumps are identified correctly, with ON/OFF, mode, target temperature, and more sensors surfaced properly.

* **Bug Fixes**
  * Prevented certain HPGIC devices from being misidentified as a different heat pump model when serial numbers happen to overlap.
  * Expanded device scanning to detect the full set of available components more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->