### PR TITLE
fix: stop padding pump schedules to 8 slots (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Editing a pump schedule from its entity page** (time / switch / select) no longer fails with `OVERLAP in sched` (Issue #105, @ihadx) — the schedule write no longer pads pump schedules to 8 slots with identical placeholder windows; it now sends only the configured schedules, matching the `fluidra_pool.set_schedule` service and the official app.
+
 ## [2.43.1] - 2026-06-24
 
 ### Added

--- a/custom_components/fluidra_pool/select/schedule.py
+++ b/custom_components/fluidra_pool/select/schedule.py
@@ -116,20 +116,8 @@ class FluidraScheduleModeSelect(FluidraPoolControlEntity, SelectEntity):
                 }
                 updated_schedules.append(scheduler)
 
-            # Pump conventions require 8 slots — pad with safe defaults.
-            while len(updated_schedules) < 8:
-                missing_id = len(updated_schedules) + 1
-                updated_schedules.append(
-                    {
-                        "id": missing_id,
-                        "groupId": missing_id,
-                        "enabled": False,
-                        "startTime": "00 00 * * 1,2,3,4,5,6,7",
-                        "endTime": "00 01 * * 1,2,3,4,5,6,7",
-                        "startActions": {"operationName": "0"},
-                    }
-                )
-
+            # No padding — Fluidra fills the remaining slots; padding to 8 with
+            # identical placeholder windows is rejected as "OVERLAP in sched" (Issue #105).
             success = await self._api.set_schedule(self._device_id, updated_schedules)
             if not success:
                 raise HomeAssistantError(

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -134,20 +134,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                 }
                 updated_schedules.append(scheduler)
 
-            # Pad pump schedules to exactly 8 slots — mobile app convention.
-            while schedule_component == 20 and len(updated_schedules) < 8:
-                missing_id = len(updated_schedules) + 1
-                updated_schedules.append(
-                    {
-                        "id": missing_id,
-                        "groupId": missing_id,
-                        "enabled": missing_id == int(self._schedule_id),
-                        "startTime": "00 00 * * 1,2,3,4,5,6,7",
-                        "endTime": "00 01 * * 1,2,3,4,5,6,7",
-                        "startActions": {"operationName": "0"},
-                    }
-                )
-
+            # No padding — Fluidra fills the remaining slots; padding to 8 with
+            # identical placeholder windows is rejected as "OVERLAP in sched" (Issue #105).
             success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=schedule_component)
             if success:
                 # Keep optimistic state until is_on observes server confirmation
@@ -198,19 +186,7 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                 }
                 updated_schedules.append(scheduler)
 
-            while schedule_component == 20 and len(updated_schedules) < 8:
-                missing_id = len(updated_schedules) + 1
-                updated_schedules.append(
-                    {
-                        "id": missing_id,
-                        "groupId": missing_id,
-                        "enabled": False,
-                        "startTime": "00 00 * * 1,2,3,4,5,6,7",
-                        "endTime": "00 01 * * 1,2,3,4,5,6,7",
-                        "startActions": {"operationName": "0"},
-                    }
-                )
-
+            # No padding — see the OVERLAP-in-sched note in async_turn_on (Issue #105).
             success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=schedule_component)
             if success:
                 await self.coordinator.async_request_refresh()

--- a/custom_components/fluidra_pool/time/schedule.py
+++ b/custom_components/fluidra_pool/time/schedule.py
@@ -140,21 +140,10 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
 
             component_id = self._get_schedule_component()
 
-            # Pumps expect exactly 8 schedulers — pad with safe defaults.
-            if component_id == 20:
-                while len(updated_schedules) < 8:
-                    missing_id = len(updated_schedules) + 1
-                    updated_schedules.append(
-                        {
-                            "id": missing_id,
-                            "groupId": missing_id,
-                            "enabled": False,
-                            "startTime": "00 00 * * 1,2,3,4,5,6,7",
-                            "endTime": "00 01 * * 1,2,3,4,5,6,7",
-                            "startActions": {"operationName": "0"},
-                        }
-                    )
-
+            # Send only the configured schedules — no padding. Fluidra fills the
+            # remaining device slots itself; padding to 8 with identical placeholder
+            # windows is rejected as "OVERLAP in sched" (Issue #105), and a packet
+            # capture of the official app confirms it sends only the real entries.
             success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
             if not success:
                 self._optimistic_value = None
@@ -305,20 +294,7 @@ class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
 
             component_id = self._get_schedule_component()
 
-            if component_id == 20:
-                while len(updated_schedules) < 8:
-                    missing_id = len(updated_schedules) + 1
-                    updated_schedules.append(
-                        {
-                            "id": missing_id,
-                            "groupId": missing_id,
-                            "enabled": False,
-                            "startTime": "00 00 * * 1,2,3,4,5,6,7",
-                            "endTime": "00 01 * * 1,2,3,4,5,6,7",
-                            "startActions": {"operationName": "0"},
-                        }
-                    )
-
+            # No padding — see the OVERLAP-in-sched note in the slot editor above (Issue #105).
             success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
             if not success:
                 self._optimistic_value = None

--- a/tests/test_select_schedule.py
+++ b/tests/test_select_schedule.py
@@ -175,15 +175,15 @@ async def test_schedule_mode_select_updates_only_target_schedule() -> None:
 
     api.set_schedule.assert_awaited_once()
     sent_schedules = api.set_schedule.call_args.args[1]
-    # Padded to 8 slots for pumps.
-    assert len(sent_schedules) == 8
+    # No padding — only the configured schedules are sent (Issue #105).
+    assert len(sent_schedules) == 2
     op_by_id = {s["id"]: s["startActions"]["operationName"] for s in sent_schedules}
     assert op_by_id[1] == "0"  # Untouched.
     assert op_by_id[2] == "2"  # New mode.
 
 
-async def test_schedule_mode_select_pads_to_eight_slots() -> None:
-    """Pump schedules are always sent as exactly 8 slots."""
+async def test_schedule_mode_select_sends_only_configured_slots() -> None:
+    """Only the configured schedules are sent — no padding to 8 (Issue #105)."""
     device = _pump_device([{**SCHEDULE, "id": 1}])
     api = _api()
     select = FluidraScheduleModeSelect(_coord(device), api, POOL_ID, PUMP_ID, schedule_id="1")
@@ -192,8 +192,8 @@ async def test_schedule_mode_select_pads_to_eight_slots() -> None:
     await select.async_select_option("1")
 
     sent = api.set_schedule.call_args.args[1]
-    assert len(sent) == 8
-    assert {s["id"] for s in sent} == {1, 2, 3, 4, 5, 6, 7, 8}
+    assert len(sent) == 1
+    assert {s["id"] for s in sent} == {1}
 
 
 async def test_schedule_mode_select_refreshes_coordinator_on_success() -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -274,13 +274,13 @@ async def test_schedule_switch_turn_on_sets_only_target_schedule_enabled() -> No
     switch = _schedule_switch(schedules)
     await switch.async_turn_on()
 
-    # Single PUT to the schedule component with the same 8-slot shape.
+    # Single PUT to the schedule component — only the configured slots, no padding.
     switch._api.set_schedule.assert_awaited_once()
     args, kwargs = switch._api.set_schedule.call_args
     assert args[0] == DEVICE_ID
     sent_schedules = args[1]
     assert kwargs["component_id"] == 20
-    assert len(sent_schedules) == 8  # padded to 8 for pump component 20
+    assert len(sent_schedules) == 4  # only the configured slots, no padding (Issue #105)
     # Only id=4 should now be enabled.
     enabled_ids = {s["id"] for s in sent_schedules if s["enabled"]}
     assert enabled_ids == {1, 4}

--- a/tests/test_switch_pump_schedule_cov.py
+++ b/tests/test_switch_pump_schedule_cov.py
@@ -361,8 +361,8 @@ async def test_schedule_turn_off_sets_only_target_disabled() -> None:
     assert args[0] == DEVICE_ID
     sent = args[1]
     assert kwargs["component_id"] == 20
-    assert len(sent) == 8  # padded to 8 slots for pump component 20
-    # id=4 disabled, ids 1-3 still enabled, padded 5-8 disabled.
+    assert len(sent) == 4  # only the configured slots, no padding (Issue #105)
+    # id=4 disabled, ids 1-3 still enabled.
     by_id = {s["id"]: s["enabled"] for s in sent}
     assert by_id[4] is False
     assert by_id[1] is True

--- a/tests/test_time_schedule.py
+++ b/tests/test_time_schedule.py
@@ -223,12 +223,38 @@ async def test_start_time_set_value_updates_only_target_schedule() -> None:
 
     api.set_schedule.assert_awaited_once()
     sent = api.set_schedule.call_args.args[1]
-    assert len(sent) == 8  # Padded for pumps.
+    assert len(sent) == 2  # only the configured slots, no padding (Issue #105)
     start_by_id = {s["id"]: s["startTime"] for s in sent}
     # Slot 1 keeps its 8:30 start (re-formatted but same time).
     assert "30 8" in start_by_id[1] or "8 30" in start_by_id[1]
     # Slot 2 now starts at 13:00.
     assert start_by_id[2].startswith("0 13")
+
+
+async def test_pump_schedule_write_not_padded_with_overlapping_placeholders() -> None:
+    """Issue #105: fewer than 8 pump schedules must not be padded with identical
+    00:00-00:01 placeholder windows — Fluidra rejects those as "OVERLAP in sched"."""
+    schedules = [
+        {
+            "id": i,
+            "enabled": True,
+            "startTime": f"0 {6 + i} * * 1,2,3,4,5",
+            "endTime": f"0 {7 + i} * * 1,2,3,4,5",
+            "startActions": {"operationName": "1"},
+        }
+        for i in range(1, 4)  # three configured slots, fewer than eight
+    ]
+    device = _pump_device(schedules)
+    api = _api()
+    entity = FluidraScheduleStartTimeEntity(_coord(device), api, POOL_ID, PUMP_ID, schedule_id="1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(5, 0))
+
+    sent = api.set_schedule.call_args.args[1]
+    assert len(sent) == 3  # no padding to eight slots
+    windows = [(s["startTime"], s["endTime"]) for s in sent]
+    assert len(set(windows)) == len(windows)  # every window distinct → no overlap-inducing padding
 
 
 async def test_end_time_set_value_updates_only_target_schedule() -> None:


### PR DESCRIPTION
## Summary
Editing a pump schedule from a **time / switch / select** entity padded the write to 8 slots with **identical `00:00–00:01` placeholder windows**, which the Fluidra backend rejects:

```
HTTP 400 … Error: OVERLAP in sched
```

A packet capture of the official app (and the already-working `fluidra_pool.set_schedule` service) shows only the **configured** schedules are sent — no padding. Thanks @ihadx for the precise diagnosis.

## Fix
Drop the 8-slot padding in **all five paths** (the report only hit one):
- `time/schedule.py` ×2 (start/end editor)
- `switch/schedule.py` ×2 (turn on/off)
- `select/schedule.py` ×1 (mode select)

Each now sends exactly the configured schedules, matching `_service_schedule_to_fluidra`.

## Verification
- ✅ 1271 tests pass — 5 tests that asserted `len == 8` updated to the configured count; new regression test `test_pump_schedule_write_not_padded_with_overlapping_placeholders` (3 slots → no padding, all windows distinct)
- ✅ `mypy --strict`, `ruff` check+format clean
- ✅ HA dev check_config OK

Addresses #105 (kept open until @ihadx confirms after the release).
