### PR TITLE
fix: add CC25021136 Zodiac Ei2 iQ Evo chlorinator profile (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Zodiac Ei2 iQ Evo chlorinator** (Issue #104, @crdo78) — the `CC25021136` Evo unit fell back to the generic profile, leaving pH and ORP "Unavailable". Added to the tecnoLC2 Evo profile so pH (c165), ORP (c170), temperature (c172) and salinity (c174) all read correctly.
+
 ## [2.43.2] - 2026-06-24
 
 ### Fixed

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -382,13 +382,14 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     ),
     "cc25102423_chlorinator": DeviceConfig(
         device_type="chlorinator",
-        # tecnoLC2 "Evo" profile, with ORP + ORP setpoint — Issues #63, #73.
+        # tecnoLC2 "Evo" profile, with ORP + ORP setpoint — Issues #63, #73, #104.
         # The same layout ships under several rebadged names; the API exposes no
         # model field, so add serials as users confirm them:
         #   CC25102423 / CC25106623 — Astralpool Clear Connect Evo21 (@DarkSuperT)
         #   CC25066724              — Astralpool Clear Connect Evo12 (@valentinval90)
         #   LC26033146              — IBASEL Evoflex 30 7g/H (@FoxP)
-        identifier_patterns=["CC25102423.nn_*", "CC25066724*", "CC25106623*", "LC26033146*"],
+        #   CC25021136              — Zodiac Ei2 iQ Evo (@crdo78) — confirmed c165/170/172/174
+        identifier_patterns=["CC25102423.nn_*", "CC25066724*", "CC25106623*", "LC26033146*", "CC25021136*"],
         family_patterns=["chlorinator"],
         components_range=25,
         required_components=[0, 1, 2, 3],

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -132,6 +132,24 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         assert config.features["orp_setpoint"] == 20  # this variant exposes the ORP setpoint (c20 = 750)
 
+    def test_cc25021136_zodiac_ei2_iq_evo_uses_teclc2_layout(self):
+        """Zodiac Ei2 iQ Evo (CC25021136) maps to the tecnoLC2 Evo profile, not the generic one (Issue #104)."""
+        config = DEVICE_CONFIGS["cc25102423_chlorinator"]
+        device = {
+            "device_id": "CC25021136.nn_1",
+            "name": "Chlorinator",
+            "family": "Chlorinators",
+            "type": "chlorinator",
+            "model": "Chlorinator",
+            "components": {"165": {"reportedValue": 684}, "170": {"reportedValue": 652}},
+        }
+        assert DeviceIdentifier.identify_device(device) is config
+        sensors = config.features["sensors"]
+        assert sensors["ph"] == 165  # 6.8, confirmed against the app
+        assert sensors["orp"] == 170  # 652 mV
+        assert sensors["temperature"] == 172  # 28.1 °C
+        assert sensors["salinity"] == 174  # 5.0 g/L
+
     def test_lc24009805_irripool_isalt_uses_teclc2_layout(self):
         """Irripool iSalt LC24009805 maps to the Irripool iSALT tecnoLC2 profile (Issue #73)."""
         config = DEVICE_CONFIGS["lc24013306_chlorinator"]


### PR DESCRIPTION
## Summary
The Zodiac Ei2 iQ Evo (`CC25021136`, @crdo78) fell back to the generic chlorinator profile (legacy layout, pH=c172 / ORP=c177), so **pH and ORP showed Unavailable**.

The reporter's diagnostics confirm a **standard tecnoLC2 Evo** layout (and they verified the fix locally), all values matching the Fluidra app:
- pH **c165** (6.8), ORP **c170** (652 mV), temperature **c172** (28.1 °C), salinity **c174** (5.0 g/L)
- chlorination **c10**, pH setpoint **c16**, ORP setpoint **c20**; no free-chlorine sensor

## Fix
Add `CC25021136*` to the existing `cc25102423` tecnoLC2 Evo profile (exact same layout).

## Verification
- ✅ 1272 tests pass (new `test_cc25021136_zodiac_ei2_iq_evo_uses_teclc2_layout`; generic-fallback and other profiles unaffected)
- ✅ `mypy --strict`, `ruff` check+format clean · HA dev check_config OK

Addresses #104 (kept open until @crdo78 confirms after the release).