### PR TITLE
fix: treat ORP=0 as no probe on Zodiac eXO iQ LS (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Zodiac eXO iQ LS ORP always 0** (Issue #111, @felisida) — the eXO iQ LS ships without an ORP probe (an optional Dual Link add-on), so component 63 stays a flat `0`. An immersed redox probe never reads exactly 0 mV, so the ORP sensor now reports "unknown" instead of a misleading `0 mV`, and surfaces a real value automatically if a probe is added later. pH, temperature and salinity are unaffected.
+
 ## [2.43.3] - 2026-06-27
 
 ### Fixed

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -160,10 +160,19 @@ class FluidraChlorinatorSensor(CoordinatorEntity, SensorEntity):
 
         try:
             value: float = float(raw_value) / self._divisor
-            return value
         except (ValueError, TypeError):
             _LOGGER.debug("Failed to parse sensor value %s for component %s", raw_value, self._component_id)
             return None
+
+        # An ORP (redox) probe immersed in water always reads a non-zero mV
+        # potential, so a flat 0 means no probe is connected — e.g. the Zodiac
+        # eXO iQ LS, where the ORP probe is an optional Dual Link add-on (Issue
+        # #111). Report "unknown" instead of a misleading 0 mV; the entity
+        # surfaces a real value automatically if a probe is added later.
+        if self._sensor_type == "orp" and value == 0:
+            return None
+
+        return value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -254,3 +254,28 @@ def test_chlorinator_sensor_unavailable_when_no_components() -> None:
     device = _pinned_device(DEVICE_ID, components={})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
     assert sensor.available is False
+
+
+def test_chlorinator_orp_zero_reads_unknown() -> None:
+    """A flat 0 mV ORP means no probe is connected (eXO iQ LS) — Issue #111.
+
+    An immersed redox probe never reads exactly 0 mV, so the sensor reports
+    None ("unknown") instead of a misleading 0.
+    """
+    device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
+    assert sensor.native_value is None
+
+
+def test_chlorinator_orp_nonzero_reads_value() -> None:
+    """A real ORP reading is still reported unchanged (regression guard for #111)."""
+    device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 738}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
+    assert sensor.native_value == pytest.approx(738.0)
+
+
+def test_chlorinator_zero_non_orp_sensor_still_reads_zero() -> None:
+    """The zero-suppression is ORP-only: other sensors keep a legitimate 0 reading."""
+    device = _pinned_device(DEVICE_ID, components={"178": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "free_chlorine", 178)
+    assert sensor.native_value == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
On the Zodiac **eXO iQ LS** (@felisida), the ORP sensor was permanently stuck at `0`, while pH, temperature and salinity all read correctly.

The reporter's diagnostics show the cause: the eXO iQ LS ships **without an ORP probe** (it's an optional Dual Link add-on), so component 63 stays a flat `0`. The component timestamps confirm it — ORP (c63) was last updated on June 22, frozen at `0`, while pH (c62) and temperature (c64) refreshed on June 28:

| Component | Reading | Value | Last update |
|-----------|---------|-------|-------------|
| 62 | pH | 6.6 | Jun 28 ✅ |
| 64 | Temperature | 28 °C | Jun 28 ✅ |
| 36 | Salinity | 2.75 g/L | Jun 22 |
| **63** | **ORP** | **0** | **Jun 22 (frozen)** |

## Fix
An immersed redox probe always reads a non-zero mV potential (typically 400–800 mV), so a flat `0` is a reliable "no probe" signal. The ORP sensor now reports **unknown** instead of a misleading `0 mV`. The suppression is ORP-only — other sensors keep a legitimate `0` reading — and the entity surfaces a real value automatically if a probe is added later.

## Verification
- ✅ 1275 tests pass (3 new regression tests: ORP=0 → unknown, ORP≠0 → value, free-chlorine=0 stays 0)
- ✅ `mypy --strict`, `ruff` check + format clean

Addresses #111.