### PR TITLE
chore(renovate): widen dependency-update scope

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,53 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 4,
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies", "security"],
+    "schedule": ["at any time"]
+  },
+  "customManagers": [
+    {
+      "description": "Track the requirements pinned in the Home Assistant manifest (e.g. aiohttp)",
+      "customType": "regex",
+      "managerFilePatterns": ["/^custom_components/fluidra_pool/manifest\\.json$/"],
+      "matchStrings": [
+        "\"(?<depName>[A-Za-z0-9._-]+)(?<currentValue>(?:>=|==|<=|~=|!=|>|<)[0-9][0-9A-Za-z.\\-]*)\""
+      ],
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions and automerge them once CI is green",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+      "automerge": true
+    },
+    {
+      "description": "Group test/CI dependencies; automerge non-major bumps (CI is the guardrail)",
+      "matchManagers": ["pip_requirements"],
+      "matchFileNames": ["requirements_test.txt"],
+      "groupName": "test dependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Bump the floor of HA manifest requirements; keep these as reviewed PRs (no automerge)",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["custom_components/fluidra_pool/manifest.json"],
+      "rangeStrategy": "bump",
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Expands the Renovate config from the bare `config:recommended` preset to cover more of the project's dependency surface, with safe automerge for low-risk bumps.

## Changes
- **Pin GitHub Action digests** (`helpers:pinGitHubActionDigests`) — pins every action to its commit SHA (supply-chain hardening) and, crucially, lets Renovate finally track `hacs/action@main` and `home-assistant/actions/hassfest@master`, which branch refs never updated before.
- **Cover `manifest.json` requirements** — a custom regex manager tracks the PyPI requirements pinned in `custom_components/fluidra_pool/manifest.json` (currently `aiohttp>=3.11.0`), a Home-Assistant-specific format Renovate doesn't parse natively. `rangeStrategy: bump`, reviewed manually (no automerge) since it affects the integration runtime.
- **Safe automerge** — GitHub Actions (minor/patch/digest) and test deps in `requirements_test.txt` (minor/patch) automerge once CI is green; major bumps stay manual. CI (tests ≥90%, `mypy --strict`, hassfest, HACS) is the guardrail.
- **Grouping + housekeeping** — groups `github-actions` and `test dependencies` to cut PR noise, enables the Dependency Dashboard, weekly schedule (Mon before 6am, Europe/Paris), `prHourlyLimit: 4`, `dependencies` label, and real-time security-vulnerability PRs.

## Notes
- pre-commit hooks are intentionally **not** added — they're already kept current by pre-commit.ci's weekly autoupdate (avoids duplicate PRs).
- The `dependencies` label doesn't exist in the repo yet; Renovate creates it automatically if it has permission.
- Validated with `renovate-config-validator` ✅ and the custom regex was tested against `manifest.json` (matches `aiohttp>=3.11.0`, no false positives).
- Expect a one-off "Pin dependencies" PR (action SHAs) on the next Renovate run.