### PR TITLE
ci(security): restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN: every CI job only reads the checked-out repo.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
CodeQL (default setup) flagged 4 `actions/missing-workflow-permissions` alerts (severity **medium**): the `ci.yml` jobs (lint, validate, test, typing) ran with the default broad `GITHUB_TOKEN` scope.

## Fix
Add a workflow-level `permissions: contents: read` block — every CI job only reads the checked-out repo, so this is the least-privilege scope. No behavioural change.

`release.yml` (`contents: write`) and `stale.yml` (`issues`/`pull-requests: write`) already declared their blocks.

## Verification
- ✅ Resolves the 4 open CodeQL alerts (#12–#15)
- ✅ `ci.yml` parses as valid YAML; all 4 jobs still present