### PR TITLE
fix: chlorinator profiles CC26028741/CC25008731 + Clear Connect 12 scan (Issues #116, #117, #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.43.5] - 2026-06-29
+
 ### Changed
 - **Clear Connect 12 component scan widened** (Issue #109, @christian123125) — the `CC25019224`/`CC25009932` profile now also scans c9/c103/c154 to locate the cell production-state register for a future `binary_sensor`. The resting/producing diagnostics showed no on/off flip among the currently-mapped components (c10 only ranges 50→100), so the actual-production register — not polled until now — needs to appear in a fresh capture pair before the sensor can be mapped reliably. No new entity yet.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Clear Connect 12 component scan widened** (Issue #109, @christian123125) — the `CC25019224`/`CC25009932` profile now also scans c9/c103/c154 to locate the cell production-state register for a future `binary_sensor`. The resting/producing diagnostics showed no on/off flip among the currently-mapped components (c10 only ranges 50→100), so the actual-production register — not polled until now — needs to appear in a fresh capture pair before the sensor can be mapped reliably. No new entity yet.
+
 ### Fixed
 - **AstralPool Energy Connect chlorinator `CC25008731`** (Issue #117, @yannickuhrig1) — the unit fell back to the generic profile, which read the water temperature (c172) as pH (2.88 instead of 28.8 °C) and left measured pH/ORP equal to their setpoints. Added to the Energy Connect tecnoLC2 profile so pH (c165), ORP (c170, calibrated), temperature (c172) and salinity (c174) all match the Fluidra app.
 - **Zodiac GenSalt OE iQ pH 12 Evo chlorinator** (Issue #116, @elefantomas) — the `CC26028741` unit fell back to the generic profile, which read the water temperature (c172) as pH (3.07 instead of 30.7 °C) and missed salinity/ORP. Added to the GenSalt OE iQ profile so pH (c165), ORP (c170), temperature (c172) and salinity (c174) all match the Fluidra app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **AstralPool Energy Connect chlorinator `CC25008731`** (Issue #117, @yannickuhrig1) — the unit fell back to the generic profile, which read the water temperature (c172) as pH (2.88 instead of 28.8 °C) and left measured pH/ORP equal to their setpoints. Added to the Energy Connect tecnoLC2 profile so pH (c165), ORP (c170, calibrated), temperature (c172) and salinity (c174) all match the Fluidra app.
 - **Zodiac GenSalt OE iQ pH 12 Evo chlorinator** (Issue #116, @elefantomas) — the `CC26028741` unit fell back to the generic profile, which read the water temperature (c172) as pH (3.07 instead of 30.7 °C) and missed salinity/ORP. Added to the GenSalt OE iQ profile so pH (c165), ORP (c170), temperature (c172) and salinity (c174) all match the Fluidra app.
 
 ## [2.43.4] - 2026-06-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Zodiac GenSalt OE iQ pH 12 Evo chlorinator** (Issue #116, @elefantomas) — the `CC26028741` unit fell back to the generic profile, which read the water temperature (c172) as pH (3.07 instead of 30.7 °C) and missed salinity/ORP. Added to the GenSalt OE iQ profile so pH (c165), ORP (c170), temperature (c172) and salinity (c174) all match the Fluidra app.
+
 ## [2.43.4] - 2026-06-29
 
 ### Fixed

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -135,7 +135,11 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # read it as pH 2.46), c165 = pH, c170 = ORP, c174 = salinity. chlorination /
         # boost / salinity only report while the unit is running.
         # CC25010924 — same Energy Connect (pH + ORP), pending @pitch110's confirmation.
-        identifier_patterns=["CC24047102*", "CC25010924*"],
+        # CC25008731 (Issue #117, @yannickuhrig1) — same standard tecnoLC2 layout: the
+        # generic profile read c172 (28.8 °C) as pH 2.88 and left pH/ORP equal to their
+        # setpoints. Confirmed against the app: c172 = water temperature, c165 = pH (7.1),
+        # c170 = calibrated ORP (743 mV — c177 = 765 is the uncalibrated raw value).
+        identifier_patterns=["CC24047102*", "CC25010924*", "CC25008731*"],
         family_patterns=["chlorinator"],
         components_range=25,
         required_components=[0, 1, 2, 3],

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -437,7 +437,13 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "temperature": 172,  # 260 = 26.0°C.
                 "salinity": 174,  # 627 = 6.27 g/L.
             },
-            "specific_components": [10, 16, 20, 165, 170, 172, 174],
+            # c9/c103/c154 widen the scan to hunt the cell production state for a
+            # future binary_sensor (Issue #109): the resting/producing captures show
+            # no 0/1 flip among the mapped components (c10 only goes 50→100, never 0),
+            # and c154 — the actual-production register on sibling tecnoLC2 units — is
+            # not polled yet, so it never reached the diagnostics. Keeping them in the
+            # scan surfaces the real flip in the next producing/resting capture pair.
+            "specific_components": [9, 10, 16, 20, 103, 154, 165, 170, 172, 174],
         },
         priority=87,
     ),

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -44,7 +44,10 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # (×10 — the generic config wrongly read c172 as pH → 2.9), c174 = salinity,
         # c170 = ORP measured (matches the app; c177 is a close but uncalibrated raw
         # value, ~50 mV off), c20 = ORP setpoint.
-        identifier_patterns=["CC25052635*", "CC25046312*"],
+        # CC26028741 (Issue #116, @elefantomas) is the same GenSalt OE iQ pH 12 Evo that
+        # fell back to the generic profile (read c172 water temperature as pH → 3.07, and
+        # missed c165/c170/c174 so salinity/temperature showed 0).
+        identifier_patterns=["CC25052635*", "CC25046312*", "CC26028741*"],
         family_patterns=["chlorinator"],
         components_range=25,
         required_components=[0, 1, 2, 3],

--- a/custom_components/fluidra_pool/manifest.json
+++ b/custom_components/fluidra_pool/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.fluidra_pool"],
   "quality_scale": "platinum",
   "requirements": ["aiohttp>=3.11.0"],
-  "version": "2.43.4"
+  "version": "2.43.5"
 }

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -207,9 +207,10 @@ class TestDeviceConfigRegistry:
         assert config.features["sensors"] == DEVICE_CONFIGS["lc24013306_chlorinator"].features["sensors"]
 
     def test_cc24047102_energy_connect_uses_teclc2_layout(self):
-        """AstralPool Energy Connect serials map on the tecnoLC2 layout (Issue #85)."""
+        """AstralPool Energy Connect serials map on the tecnoLC2 layout (Issues #85, #117)."""
         config = DEVICE_CONFIGS["cc24047102_chlorinator"]
-        for serial in ("CC24047102.nn_1", "CC25010924.nn_1"):
+        # CC25008731 (#117) is the same layout — c172 = 28.8°C, not pH 2.88 as the generic read.
+        for serial in ("CC24047102.nn_1", "CC25010924.nn_1", "CC25008731.nn_1"):
             device = {
                 "device_id": serial,
                 "name": "Chlorinator",

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -100,7 +100,7 @@ class TestDeviceConfigRegistry:
         Different units carry different cloud serials for the same model, so both
         reported serials must resolve to the dedicated profile.
         """
-        for serial in ("CC25052635.nn_1", "CC25046312.nn_1"):
+        for serial in ("CC25052635.nn_1", "CC25046312.nn_1", "CC26028741.nn_1"):
             device = {
                 "device_id": serial,
                 "name": "Chlorinator",

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -310,6 +310,20 @@ class TestDeviceConfigRegistry:
         }
         assert DeviceIdentifier.identify_device(device) is config
 
+    def test_cc25019224_scans_production_state_candidates(self):
+        """The Clear Connect 12 profile scans the cell-production candidates (Issue #109).
+
+        The resting/producing diagnostics showed no 0/1 flip among the mapped
+        components, so c9/c103/c154 are added to the scan to surface the real
+        production register in the next capture pair (without creating entities).
+        """
+        config = DEVICE_CONFIGS["cc25019224_chlorinator"]
+        specific = config.features["specific_components"]
+        for candidate in (9, 103, 154):
+            assert candidate in specific, candidate
+        # No sensor/binary_sensor is mapped to them yet — scan only.
+        assert "chlorination_actual" not in config.features["sensors"]
+
     def test_gre_swga_config_has_salinity_and_no_orp(self):
         """Gre SWGA chlorinators (incl. SWGA40) expose salinity, no ORP, matched per-serial (Issue #76)."""
         config = DEVICE_CONFIGS["lc25050627_chlorinator"]


### PR DESCRIPTION
## Summary
Three chlorinator device-registry fixes + the v2.43.5 release. All three units fell back to the generic bridged profile (legacy layout: c172 read as pH, sensors collapsing onto setpoints).

## Changes
- **Issue #116** (@elefantomas) — `CC26028741` Zodiac GenSalt OE iQ pH 12 Evo → added to the `cc25052635` tecnoLC2 profile. Fixes pH 3.07→7.0, temperature 0→30.7 °C, salinity.
- **Issue #117** (@yannickuhrig1) — `CC25008731` AstralPool Energy Connect → added to the `cc24047102` tecnoLC2 profile. Fixes pH 2.88→7.1 (c172 is temperature 28.8 °C), ORP onto calibrated c170 (743 mV, not raw c177=765).
- **Issue #109** (@christian123125) — Clear Connect 12 scan widened to c9/c103/c154 to locate the cell production-state register for a future `binary_sensor`. The resting/producing captures showed no on/off flip among the mapped components (c10 only goes 50→100), so the real register needs to surface in a fresh capture pair first. **No new entity yet.**

## Verification
- ✅ 1276 tests pass (extended `test_cc25052635_*` / `test_cc24047102_*`, new `test_cc25019224_scans_production_state_candidates`)
- ✅ ruff check + format, bandit, codespell clean (pre-commit)

Releases **v2.43.5** (tag included). Issues #116/#117 kept open until reporters confirm after the release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded device recognition for additional chlorinator models, improving setup and automatic mapping for more units.

* **Bug Fixes**
  * Corrected sensor readings for Energy Connect and Zodiac GenSalt OE iQ chlorinators when they use the generic profile, so pH, ORP, temperature, and salinity now match the app.
  * Improved scanning for Clear Connect 12 devices to better detect upcoming cell status data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->