### PR TITLE
fix: widen Ei2 iQ Evo scan to find CLE/COU mode registers (Issue #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Zodiac Ei2 iQ Evo component scan widened** (Issue #104, @crdo78) — the `cc25102423` Evo profile now also scans c9/c13/c14/c103/c154 to locate the production-mode registers. This layout has no 0/1/2 Auto/Manual/Off selector (c20 is the ORP setpoint, 750 mV); production is driven by two binary mainboard features — CLE (External Chlorine Control, a remote on/off) and COU/COV (Pool Cover, low-production mode) — which weren't polled until now. They need to appear in a fresh capture pair (toggled once ON, once OFF) before they can be mapped as binary sensors/switches. No new entity yet.
+
 ## [2.43.5] - 2026-06-29
 
 ### Changed

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -412,7 +412,15 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "temperature": 172,  # Confirmed (17.6°C).
                 "salinity": 174,
             },
-            "specific_components": [10, 16, 20, 165, 170, 172, 174],
+            # c9/c13/c14/c103/c154 widen the scan to locate the production-mode
+            # registers on the Zodiac Ei2 iQ Evo (Issue #104, @crdo78): this layout
+            # has no 0/1/2 Auto/Manual/Off selector (c20 is the ORP setpoint, 750 mV),
+            # but two binary mainboard features — CLE (External Chlorine Control, a
+            # remote on/off dry-contact) and COU/COV (Pool Cover, low-production mode).
+            # They aren't polled yet, so they never reached the diagnostics. Keeping
+            # them in the scan surfaces the real registers in the next capture pair
+            # (toggled once with CLE/COU ON, once OFF) so they can be mapped reliably.
+            "specific_components": [9, 10, 13, 14, 16, 20, 103, 154, 165, 170, 172, 174],
         },
         priority=88,
     ),

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -149,6 +149,10 @@ class TestDeviceConfigRegistry:
         assert sensors["orp"] == 170  # 652 mV
         assert sensors["temperature"] == 172  # 28.1 °C
         assert sensors["salinity"] == 174  # 5.0 g/L
+        # Scan is widened to hunt the CLE / COU production-mode registers (Issue #104):
+        # c20 is the ORP setpoint, so there is no 0/1/2 mode on this Evo layout.
+        for candidate in (9, 13, 14, 103, 154):
+            assert candidate in config.features["specific_components"]
 
     def test_lc24009805_irripool_isalt_uses_teclc2_layout(self):
         """Irripool iSalt LC24009805 maps to the Irripool iSALT tecnoLC2 profile (Issue #73)."""


### PR DESCRIPTION
## Summary
Follow-up to #104. After the v2.43.3 fix, @crdo78 confirmed pH/ORP/temperature/salinity all read correctly, but flagged a regression: the Auto/Manual/Off selector disappeared (the Evo profile sets `skip_mode_select: True`).

Investigation (his diagnostics + the official Ei2 iQ Evo manual) shows this layout has **no 0/1/2 mode selector** — `c20` is purely the ORP setpoint (750 mV). The selector he had on the generic profile was reading c20 and mapping 750 → `off` permanently (and writing to it would have clobbered the ORP setpoint). Production is instead driven by two binary mainboard features:
- **CLE** — External Chlorine Control (remote on/off dry-contact)
- **COU/COV** — Pool Cover (low-production mode)

These registers aren't polled yet, so they never reached the diagnostics.

## Change
Widen the `cc25102423` Evo profile `specific_components` to also scan **c9, c13, c14, c103, c154** (likely homes for CLE/COU on tecnoLC2). No new entity is created and c20 stays the ORP setpoint — this only surfaces the registers in the next diagnostics capture so they can be mapped reliably (as `binary_sensor`/`switch`) once @crdo78 sends a CLE/COU ON vs OFF capture pair.

## Verification
- ✅ 64 device_registry tests pass (extended `test_cc25021136_zodiac_ei2_iq_evo_uses_teclc2_layout` to assert the new scan candidates)
- ✅ 195 tests across device_registry/coordinator/select/switch pass
- ✅ `ruff` check+format clean, `mypy --strict` clean

Keeps #104 open until the capture pair lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded device detection coverage for Zodiac Ei2 iQ Evo setups to include additional component candidates when identifying production-mode registers.
  * Improved validation so the broader scan set is now checked automatically in tests.

* **Documentation**
  * Updated the changelog with a note about the widened scan coverage and the need for a fresh capture pair before the on/off mapping can be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->