### PR TITLE
feat: add chlorinator producing binary sensor (Issue #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Chlorinator "Producing" binary sensor** (Issue #109, @christian123125) — a new `binary_sensor.chlorinator_producing` reports whether the cell is actively producing chlorine. A resting/producing capture pair on the Clear Connect Evo 12 (`CC25019224`/`CC25009932`) confirmed component 154 is the real production register: it flips 0 (idle) → 100 (producing) with the ORP hysteresis, while the configured chlorination level (c10) stays at 100 %. Exposed with the `running` device class so it overlays cleanly on ORP history graphs.
+
 ## [2.43.6] - 2026-06-30
 
 ### Changed

--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -44,6 +44,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS: Final = [
     Platform.SWITCH,
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,  # Pour l'état de production de la cellule de chloration
     Platform.SELECT,  # Pour modes d'opération pompe (OFF/ON/AUTO/TURBO)
     Platform.NUMBER,  # Pour contrôle vitesse pompe E30iQ (0-100%)
     Platform.TIME,  # Pour édition des heures de programmation

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -1,0 +1,177 @@
+"""Binary sensor platform for Fluidra Pool integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, FluidraPoolConfigEntry
+from .device_registry import DeviceIdentifier
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import FluidraDataUpdateCoordinator
+    from .fluidra_api import FluidraPoolAPI
+
+PARALLEL_UPDATES = 0  # Coordinator handles all updates
+
+
+class FluidraChlorinatorProducingBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor for the chlorinator cell active-production state.
+
+    In ORP/CLI regulation the cell cycles on and off around the setpoint: the
+    production register (configured via the ``cell_production_state`` feature)
+    reads ``0`` when the cell is idle and a non-zero production percentage when
+    it is actively producing chlorine (Issue #109).
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        component_id: int,
+    ) -> None:
+        """Initialize the chlorinator producing binary sensor."""
+        super().__init__(coordinator)
+        self._api = api
+        self._pool_id = pool_id
+        self._device_id = device_id
+        self._component_id = component_id
+
+        self._attr_unique_id = f"fluidra_{self._device_id}_producing"
+        self._attr_translation_key = "chlorinator_producing"
+
+    @property
+    def device_data(self) -> dict[str, Any]:
+        """Get device data from coordinator."""
+        if self.coordinator.data is None:
+            return {}
+        pool: dict[str, Any] | None = self.coordinator.data.get(self._pool_id)
+        if pool:
+            devices: list[dict[str, Any]] = pool.get("devices", [])
+            for device in devices:
+                if device.get("device_id") == self._device_id:
+                    return device
+        return {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+            model="Chlorinator",
+            via_device=(DOMAIN, self._pool_id),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available.
+
+        Mirrors the chlorinator sensors: bridged children can report
+        ``online=False`` even while polling succeeds, so use the presence of
+        fresh component data as the availability signal instead (Issue #63).
+        """
+        return self.coordinator.last_update_success and bool(self.device_data.get("components"))
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the cell is actively producing."""
+        components = self.device_data.get("components", {})
+        component_data = components.get(str(self._component_id), {})
+        raw_value = component_data.get("reportedValue")
+
+        if raw_value is None:
+            return None
+
+        try:
+            return float(raw_value) > 0
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        components = self.device_data.get("components", {})
+        component_data = components.get(str(self._component_id), {})
+
+        return {
+            "component_id": self._component_id,
+            "raw_value": component_data.get("reportedValue"),
+            "device_id": self._device_id,
+        }
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FluidraPoolConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Fluidra Pool binary sensors, including devices added later."""
+    coordinator = config_entry.runtime_data.coordinator
+    known_devices: set[str] = set()
+
+    @callback
+    def _add_entities(pools: list[dict[str, Any]]) -> None:
+        """Create entities for any device not seen yet (dynamic-devices)."""
+        entities: list[BinarySensorEntity] = []
+
+        for pool in pools:
+            pool_id = pool["id"]
+
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if not device_id:
+                    continue
+
+                key = f"{pool_id}_{device_id}"
+                if key in known_devices:
+                    continue
+                known_devices.add(key)
+
+                config = DeviceIdentifier.identify_device(device)
+                device_type = config.device_type if config else device.get("type", "")
+                if device_type != "chlorinator":
+                    continue
+
+                production_component = DeviceIdentifier.get_feature(device, "cell_production_state")
+                if production_component is not None:
+                    entities.append(
+                        FluidraChlorinatorProducingBinarySensor(
+                            coordinator,
+                            coordinator.api,
+                            pool_id,
+                            device_id,
+                            production_component,
+                        )
+                    )
+
+        if entities:
+            async_add_entities(entities)
+
+    # Initial setup from the cached discovery (fast startup, unchanged behaviour).
+    pools = coordinator.api.cached_pools or await coordinator.api.get_pools()
+    _add_entities(pools)
+
+    # Add entities for devices that appear on later polls, without a reload.
+    @callback
+    def _on_coordinator_update() -> None:
+        _add_entities(coordinator.get_pools_from_data())
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_on_coordinator_update))

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -445,12 +445,12 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "temperature": 172,  # 260 = 26.0°C.
                 "salinity": 174,  # 627 = 6.27 g/L.
             },
-            # c9/c103/c154 widen the scan to hunt the cell production state for a
-            # future binary_sensor (Issue #109): the resting/producing captures show
-            # no 0/1 flip among the mapped components (c10 only goes 50→100, never 0),
-            # and c154 — the actual-production register on sibling tecnoLC2 units — is
-            # not polled yet, so it never reached the diagnostics. Keeping them in the
-            # scan surfaces the real flip in the next producing/resting capture pair.
+            # c154 is the cell's actual-production register (Issue #109): a
+            # resting/producing capture pair confirmed it flips 0 (idle) → 100
+            # (producing) with the ORP hysteresis, while c10 stays at the
+            # configured level (100 %) and c9/c103 don't move. Exposed as the
+            # `binary_sensor.chlorinator_producing` running state.
+            "cell_production_state": 154,
             "specific_components": [9, 10, 16, 20, 103, 154, 165, 170, 172, 174],
         },
         priority=87,

--- a/custom_components/fluidra_pool/icons.json
+++ b/custom_components/fluidra_pool/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "default": "mdi:flash-off",
+        "state": {
+          "on": "mdi:flash"
+        }
+      }
+    },
     "climate": {
       "heat_pump": {
         "default": "mdi:heat-pump-outline",

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -58,6 +58,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "name": "Producing"
+      }
+    },
     "sensor": {
       "schedule_count": {
         "name": "Active Schedules"

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -47,6 +47,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "name": "Producing"
+      }
+    },
     "climate": {
       "heat_pump": {
         "name": "Heat Pump",

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -47,6 +47,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "name": "Produciendo"
+      }
+    },
     "climate": {
       "heat_pump": {
         "name": "Bomba de Calor",

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -47,6 +47,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "name": "En production"
+      }
+    },
     "climate": {
       "heat_pump": {
         "name": "Pompe à Chaleur",

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -47,6 +47,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "chlorinator_producing": {
+        "name": "A produzir"
+      }
+    },
     "climate": {
       "heat_pump": {
         "name": "Bomba de Calor",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,251 @@
+"""Tests for the binary_sensor platform (chlorinator cell production state)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.fluidra_pool.binary_sensor import (
+    FluidraChlorinatorProducingBinarySensor,
+    async_setup_entry,
+)
+from custom_components.fluidra_pool.const import DOMAIN
+from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS, DeviceIdentifier
+
+POOL_ID = "pool-1"
+DEVICE_ID = "TEST-DEV-001"
+PRODUCTION_COMPONENT = 154
+
+
+def _coord(devices: list[dict]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": devices}}
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _device(components: dict | None = None, **extra: Any) -> dict:
+    device = {
+        "device_id": DEVICE_ID,
+        "name": "Chlorinator",
+        "family": "Chlorinators",
+        "type": "chlorinator",
+        "model": "Chlorinator",
+        "online": True,
+        "components": components or {},
+    }
+    device.update(extra)
+    return device
+
+
+def _sensor(device: dict) -> FluidraChlorinatorProducingBinarySensor:
+    return FluidraChlorinatorProducingBinarySensor(
+        _coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, PRODUCTION_COMPONENT
+    )
+
+
+def test_is_on_true_when_producing() -> None:
+    """A non-zero production register means the cell is actively producing."""
+    device = _device(components={"154": {"reportedValue": 100}})
+    assert _sensor(device).is_on is True
+
+
+def test_is_on_false_when_idle() -> None:
+    """A zero production register means the cell is idle."""
+    device = _device(components={"154": {"reportedValue": 0}})
+    assert _sensor(device).is_on is False
+
+
+def test_is_on_none_when_no_reading() -> None:
+    """Missing reportedValue returns None (HA shows unavailable), not a stale off."""
+    device = _device(components={})
+    assert _sensor(device).is_on is None
+
+
+def test_is_on_none_on_non_numeric_value() -> None:
+    """Unparsable readings degrade gracefully to None."""
+    device = _device(components={"154": {"reportedValue": "n/a"}})
+    assert _sensor(device).is_on is None
+
+
+def test_available_when_components_present_even_if_offline() -> None:
+    """Bridged children mis-report online=False; availability follows component data (Issue #63)."""
+    device = _device(components={"154": {"reportedValue": 0}}, online=False)
+    assert _sensor(device).available is True
+
+
+def test_unavailable_when_no_components() -> None:
+    """Without any component data the sensor is unavailable."""
+    device = _device(components={})
+    assert _sensor(device).available is False
+
+
+def test_device_data_empty_when_coordinator_has_no_data() -> None:
+    """A coordinator with data=None yields empty device_data and a None reading."""
+    device = _device(components={"154": {"reportedValue": 100}})
+    sensor = _sensor(device)
+    sensor.coordinator.data = None
+    assert sensor.device_data == {}
+    assert sensor.is_on is None
+
+
+def test_device_data_empty_when_device_absent() -> None:
+    """A pool that doesn't contain this device_id yields empty device_data."""
+    other = _device(components={"154": {"reportedValue": 100}})
+    other["device_id"] = "OTHER-DEV"
+    sensor = FluidraChlorinatorProducingBinarySensor(
+        _coord([other]), SimpleNamespace(), POOL_ID, DEVICE_ID, PRODUCTION_COMPONENT
+    )
+    assert sensor.device_data == {}
+
+
+def test_device_info_uses_device_name_and_links_pool() -> None:
+    """device_info carries the device name and is wired to the pool via_device."""
+    device = _device(components={"154": {"reportedValue": 0}})
+    info = _sensor(device).device_info
+    assert info["name"] == "Chlorinator"
+    assert (DOMAIN, DEVICE_ID) in info["identifiers"]
+    assert info["via_device"] == (DOMAIN, POOL_ID)
+
+
+async def test_setup_ignores_non_chlorinator_devices() -> None:
+    """A non-chlorinator device never gets a producing binary sensor."""
+    pump = _pinned_chlorinator("pump1", production_component=154)
+    pump["type"] = "pump"
+    pump["_identify_cache"]["config"].device_type = "pump"
+    added, _, _ = await _run_setup([pump])
+    assert added == []
+
+
+def test_unique_id_and_attributes() -> None:
+    """Unique id is stable and attributes expose the raw register for debugging."""
+    device = _device(components={"154": {"reportedValue": 100}})
+    sensor = _sensor(device)
+    assert sensor.unique_id == f"fluidra_{DEVICE_ID}_producing"
+    attrs = sensor.extra_state_attributes
+    assert attrs["component_id"] == PRODUCTION_COMPONENT
+    assert attrs["raw_value"] == 100
+
+
+def test_clear_connect_evo12_profile_exposes_production_register() -> None:
+    """The CC25019224/CC25009932 profile maps the cell production state to c154 (Issue #109)."""
+    config = DEVICE_CONFIGS["cc25019224_chlorinator"]
+    assert config.features["cell_production_state"] == 154
+    assert 154 in config.features["specific_components"]
+
+    device = {
+        "device_id": "CC25009932.nn_1",
+        "name": "Chlorinator",
+        "family": "Chlorinators",
+        "type": "chlorinator",
+        "model": "Chlorinator",
+        "components": {"165": {"reportedValue": 731}},
+    }
+    assert DeviceIdentifier.identify_device(device) is config
+    assert DeviceIdentifier.get_feature(device, "cell_production_state") == 154
+
+
+# --- async_setup_entry — dynamic-devices wiring ------------------------------
+
+
+def _pinned_chlorinator(device_id: str, *, production_component: int | None) -> dict:
+    """Build a chlorinator with its identify cache pinned to a known feature set."""
+    features = {} if production_component is None else {"cell_production_state": production_component}
+    return {
+        "device_id": device_id,
+        "name": "Chlorinator",
+        "family": "Chlorinators",
+        "type": "chlorinator",
+        "model": "Chlorinator",
+        "online": True,
+        "components": {"154": {"reportedValue": 0}},
+        "_identify_cache": {
+            "key": (device_id, "Chlorinators", "Chlorinator", "chlorinator", ""),
+            "config": SimpleNamespace(
+                device_type="chlorinator",
+                features=features,
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=["sensor_info"],
+            ),
+        },
+    }
+
+
+async def _run_setup(devices: list[dict]) -> tuple[list[Any], list[Any], dict]:
+    pool = {"id": POOL_ID, "name": "Pool", "devices": devices}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    listeners: list[Any] = []
+    coordinator.async_add_listener = lambda cb: listeners.append(cb) or (lambda: None)
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+    return added, listeners, pool
+
+
+async def test_setup_creates_producing_sensor_only_when_feature_present() -> None:
+    """Only chlorinators that declare cell_production_state get a producing binary sensor."""
+    with_feature = _pinned_chlorinator("dev1", production_component=154)
+    without_feature = _pinned_chlorinator("dev2", production_component=None)
+    added, listeners, _ = await _run_setup([with_feature, without_feature])
+
+    uids = {e.unique_id for e in added}
+    assert "fluidra_dev1_producing" in uids
+    assert not any("dev2" in u for u in uids)
+    assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+
+async def test_setup_adds_new_device_dynamically() -> None:
+    """dynamic-devices: a chlorinator appearing on a later poll is wired without a reload."""
+    added, listeners, pool = await _run_setup([_pinned_chlorinator("dev1", production_component=154)])
+    uids_after_setup = {e.unique_id for e in added}
+
+    pool["devices"].append(_pinned_chlorinator("dev2", production_component=154))
+    listeners[0]()
+
+    new_uids = {e.unique_id for e in added} - uids_after_setup
+    assert new_uids == {"fluidra_dev2_producing"}
+
+
+async def test_setup_falls_back_to_get_pools_when_no_cache() -> None:
+    """With no cached discovery, setup awaits get_pools() for the initial entities."""
+    device = _pinned_chlorinator("dev1", production_component=154)
+    pool = {"id": POOL_ID, "name": "Pool", "devices": [device]}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=None, get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [pool]
+    coordinator.async_add_listener = lambda cb: lambda: None
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+
+    coordinator.api.get_pools.assert_awaited_once()
+    assert {e.unique_id for e in added} == {"fluidra_dev1_producing"}
+
+
+@pytest.mark.parametrize("device_id", ["", None])
+async def test_setup_skips_devices_without_id(device_id: Any) -> None:
+    """Devices missing a device_id are skipped (no crash, no entity)."""
+    device = _pinned_chlorinator("dev1", production_component=154)
+    device["device_id"] = device_id
+    added, _, _ = await _run_setup([device])
+    assert added == []


### PR DESCRIPTION
## Summary
Closes the feature request in #109: a `binary_sensor.chlorinator_producing` that reports whether the chlorinator cell is actively producing chlorine, for overlaying cell activity on ORP history graphs.

## How the register was found
@christian123125 supplied a clean resting/producing capture pair on v2.43.5 (Clear Connect Evo 12, `CC25019224`/`CC25009932`). Comparing the two states pinned down **component 154** as the real production register:

| State | c154 | c10 (configured level) | ORP vs setpoint |
|---|---|---|---|
| resting (13:35) | **0** | 100 % | 603 > 600 → cell off |
| producing (13:42) | **100** | 100 % | 602 < 607 → cell producing |

c154 flips 0 → 100 exactly with the ORP hysteresis, while c10 (the *configured* chlorination level) stays at 100 %. c9/c103 don't move, so they were ruled out.

## Change
- New **binary_sensor** platform (`binary_sensor.py`) — `FluidraChlorinatorProducingBinarySensor`, `running` device class, `is_on = c154 > 0`, dynamic-devices wiring and availability based on component presence (consistent with the chlorinator sensors, Issue #63).
- `Platform.BINARY_SENSOR` added to `PLATFORMS`.
- New `cell_production_state: 154` feature on the `cc25019224` profile (also already in the scan).
- Translations (en/es/fr/pt), `strings.json` and `icons.json` (mdi:flash / mdi:flash-off).

## Verification
- ✅ 1293 tests pass (new `tests/test_binary_sensor.py`, **100 % module coverage**)
- ✅ `ruff` check+format clean, `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chlorinator “Producing” binary sensor to show when chlorine is actively being produced.
  * The sensor is available in more languages, including English, Spanish, French, and Portuguese.
  * Added a matching icon with different states for producing vs. not producing.

* **Bug Fixes**
  * Improved detection and availability handling so the sensor reflects the latest chlorinator state more reliably.
  * New chlorinator devices can appear automatically without reloading the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->