### PR TITLE
fix: add LC24008202 Ducere 21 chlorinator profile (Issue #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Ducere 21 chlorinator `LC24008202`** (Issue #125, @onslope) — the unit fell back to the generic profile, which read the water temperature (c172) as pH. Dedicated tecnoLC2 profile (mapping supplied and validated by the reporter): pH (c165), ORP (c170), temperature (c172), salinity (c174), free chlorine (c178, probe-dependent), pH/ORP setpoints (c16/c20), boost (c103) and the cell-production register (c154) feeding the *producing* binary sensor.
+
 ## [2.45.0] - 2026-07-02
 
 ### Added

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -17,6 +17,7 @@ def _standard_tecnolc2(
     priority: int,
     boost_mode: int | None = None,
     free_chlorine: int | None = None,
+    cell_production_state: int | None = None,
 ) -> DeviceConfig:
     """Build a DeviceConfig for the standard tecnoLC2 chlorinator layout.
 
@@ -26,8 +27,9 @@ def _standard_tecnolc2(
     (÷100), c20 = ORP setpoint (mV), c103 = boost mode (when present),
     c165 = pH measured (÷100), c170 = ORP measured (mV), c172 = water
     temperature (°C × 10), c174 = salinity (g/L × 100), c178 = free chlorine
-    (mg/L, when present). The OFF/ON/AUTO mode select does not drive these
-    units (skip_mode_select).
+    (mg/L, when present), c154 = cell actual-production register (when
+    present — drives the `chlorinator_producing` binary sensor, Issue #109).
+    The OFF/ON/AUTO mode select does not drive these units (skip_mode_select).
     """
     features: dict[str, Any] = {
         "chlorination_level": 10,
@@ -46,6 +48,8 @@ def _standard_tecnolc2(
     if free_chlorine is not None:
         sensors["free_chlorine"] = free_chlorine
     features["sensors"] = sensors
+    if cell_production_state is not None:
+        features["cell_production_state"] = cell_production_state
 
     specific_components = [10, 16, 20]
     if boost_mode is not None:
@@ -53,6 +57,8 @@ def _standard_tecnolc2(
     specific_components.extend([165, 170, 172, 174])
     if free_chlorine is not None:
         specific_components.append(free_chlorine)
+    if cell_production_state is not None:
+        specific_components.append(cell_production_state)
     features["specific_components"] = specific_components
 
     return DeviceConfig(
@@ -208,6 +214,18 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         ["CC24033907*"],
         priority=85,
         boost_mode=103,
+    ),
+    # Ducere 21 (tecnoLC2) — Issue #125 (@onslope). The unit fell back to the
+    # generic profile whose legacy layout read c172 (water temperature) as pH.
+    # Mapping supplied and validated by the reporter: standard tecnoLC2 layout
+    # + boost on c103, free chlorine on c178 (probe-dependent — may stay empty)
+    # and the cell actual-production register on c154 (producing binary sensor).
+    "lc24008202_chlorinator": _standard_tecnolc2(
+        ["LC24008202*"],
+        priority=90,
+        boost_mode=103,
+        free_chlorine=178,
+        cell_production_state=154,
     ),
     "lc24008313_chlorinator": _standard_tecnolc2(
         ["LC24008313*"],  # Blauswim chlorinator (I.D. Electroquimica/Fluidra).

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -188,6 +188,32 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         assert config.features["chlorination_level"] == 10
 
+    def test_lc24008202_ducere21_uses_tecnolc2_layout(self):
+        """Ducere 21 LC24008202 maps on the tecnoLC2 layout, not the generic profile (Issue #125)."""
+        config = DEVICE_CONFIGS["lc24008202_chlorinator"]
+        device = {
+            "device_id": "LC24008202.nn_1",
+            "name": "Chlorinator",
+            "family": "Chlorinators",
+            "type": "chlorinator",
+            "model": "Chlorinator",
+        }
+        assert DeviceIdentifier.identify_device(device) is config
+        sensors = config.features["sensors"]
+        # c172 is water temperature — the generic profile wrongly read it as pH.
+        assert sensors["ph"] == 165
+        assert sensors["orp"] == 170
+        assert sensors["temperature"] == 172
+        assert sensors["salinity"] == 174
+        assert sensors["free_chlorine"] == 178
+        assert config.features["ph_setpoint"] == 16
+        assert config.features["orp_setpoint"] == 20
+        assert config.features["boost_mode"] == 103
+        # c154 drives the chlorinator_producing binary sensor (Issue #109).
+        assert config.features["cell_production_state"] == 154
+        assert 154 in config.features["specific_components"]
+        assert config.features["skip_mode_select"] is True
+
     def test_lc25024524_uses_teclc2_layout(self):
         """tecnoLC2 chlorinator LC25024524 maps on the tecnoLC2 layout, not the generic profile (Issue #73)."""
         config = DEVICE_CONFIGS["lc25024524_chlorinator"]


### PR DESCRIPTION
Fixes #125

## Summary
The Ducere 21 (`LC24008202`) fell back to the generic chlorinator profile, whose legacy layout reads c172 (water temperature) as pH. This adds a dedicated tecnoLC2 profile with the mapping supplied and validated by @onslope:

- Sensors: pH **c165**, ORP **c170**, water temperature **c172**, salinity **c174**, free chlorine **c178** (probe-dependent — may stay empty, as noted by the reporter)
- Setpoints: pH **c16**, ORP **c20**; boost **c103**
- Cell actual-production register **c154** → feeds the `chlorinator_producing` binary sensor (#109)
- `skip_mode_select` kept (the OFF/ON/AUTO select does not drive these units — consistent with "Mode is not reported")

The `_standard_tecnolc2()` factory gains an optional `cell_production_state` parameter (default `None`); the **53 existing profiles are proven unchanged** via a full registry snapshot diff.

## Testing
- New identification test (pattern → profile + full feature mapping)
- 1294 tests green, coverage gate met, mypy --strict clean
- Deployed on HA dev: zero `fluidra_pool` errors at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated support for the Ducere 21 chlorinator model so it now uses the correct TecnoLC2 layout.
  * Expanded chlorinator mapping coverage to include the cell production state, improving device sensor and feature detection.
* **Bug Fixes**
  * Fixed an issue where this model could fall back to a generic profile, ensuring the right readings and controls are shown.
* **Tests**
  * Added coverage to confirm the model is identified correctly and exposes the expected sensor and feature mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->