### PR TITLE
fix: add CC26010842 Ei2 iQ 20 pH Evo chlorinator profile (Issue #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Zodiac Ei2 iQ 20 pH Evo chlorinator `CC26010842`** (Issue #104, @terminator1992) — the unit fell back to the legacy generic profile, which read the water temperature (c172 = 289 → 28.9 °C) as pH *and* as the pH-setpoint read-back (pH stuck mirroring the setpoint), left salinity/temperature at 0 and exposed a non-working mode select. Dedicated pH-only tecnoLC2 profile: pH (c165), temperature (c172), salinity (c174), pH setpoint (c16), chlorination level (c10) — no ORP entities (no probe, c20 is null on this unit). The scan also polls the candidate CLE/COU production registers (c9/c13/c14/c103/c154) like the sibling Ei2 iQ Evo profile.
+
 ## [2.45.1] - 2026-07-02
 
 ### Fixed

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -319,6 +319,39 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=87,
     ),
+    "cc26010842_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # Zodiac Ei2 iQ 20 pH Evo (tecnoLC2, pH-only — no ORP probe) — Issue #104
+        # (@terminator1992). Fell back to the legacy generic profile which read
+        # c172 (water temperature, 289 → 28.9 °C, matches the app) as pH AND as
+        # the pH-setpoint read-back, so pH mirrored the setpoint (2.89). v2.45.1
+        # diagnostics confirmed: c20 = null (no ORP setpoint register on this
+        # pH-only unit), c177/c178/c183/c185 all 0 (legacy slots empty),
+        # disinfection saltLowLevel with pH-minus dosing only. Standard tecnoLC2
+        # layout minus everything ORP: pH c165, temperature c172, salinity c174,
+        # setpoint c16, chlorination c10.
+        identifier_patterns=["CC26010842*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "chlorination_level": 10,
+            "ph_setpoint": 16,
+            "skip_mode_select": True,
+            "sensors": {
+                "ph": 165,
+                "temperature": 172,  # 289 = 28.9 °C — confirmed against the app.
+                "salinity": 174,
+            },
+            # c9/c13/c14/c103/c154 widen the scan like the sibling Evo profile
+            # (cc25102423): same Ei2 iQ Evo mainboard family, so the CLE/COU
+            # production registers (Issue #104) should surface in the next
+            # diagnostics capture without creating any entity yet.
+            "specific_components": [9, 10, 13, 14, 16, 103, 154, 165, 172, 174],
+        },
+        priority=90,
+    ),
     "cc25102423_chlorinator": DeviceConfig(
         device_type="chlorinator",
         # tecnoLC2 "Evo" profile, with ORP + ORP setpoint — Issues #63, #73, #104.

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -188,6 +188,32 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         assert config.features["chlorination_level"] == 10
 
+    def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):
+        """Ei2 iQ 20 pH Evo CC26010842 maps on the pH-only tecnoLC2 layout (Issue #104)."""
+        config = DEVICE_CONFIGS["cc26010842_chlorinator"]
+        device = {
+            "device_id": "CC26010842.nn_1",
+            "name": "Chlorinator",
+            "family": "Chlorinators",
+            "type": "chlorinator",
+            "model": "Chlorinator",
+        }
+        assert DeviceIdentifier.identify_device(device) is config
+        sensors = config.features["sensors"]
+        # c172 is water temperature (289 = 28.9 °C) — the generic profile read it as pH.
+        assert sensors["ph"] == 165
+        assert sensors["temperature"] == 172
+        assert sensors["salinity"] == 174
+        # pH-only unit: no ORP probe, no ORP setpoint (c20 = null in diagnostics).
+        assert "orp" not in sensors
+        assert "free_chlorine" not in sensors
+        assert "orp_setpoint" not in config.features
+        assert config.features["ph_setpoint"] == 16
+        assert config.features["skip_mode_select"] is True
+        # Widened scan shared with the sibling Evo profile (CLE/COU hunt).
+        for component in (9, 13, 14, 103, 154):
+            assert component in config.features["specific_components"]
+
     def test_lc24008202_ducere21_uses_tecnolc2_layout(self):
         """Ducere 21 LC24008202 maps on the tecnoLC2 layout, not the generic profile (Issue #125)."""
         config = DEVICE_CONFIGS["lc24008202_chlorinator"]


### PR DESCRIPTION
Addresses #104 (@terminator1992's CC2601* report)

## Summary
The Zodiac Ei2 iQ 20 pH Evo (`CC26010842`) fell back to the legacy generic chlorinator profile, which reads c172 (water temperature) as pH **and** as the pH-setpoint read-back — so pH was stuck mirroring the setpoint (2.89), while salinity/temperature stayed at 0 and the mode select didn't work.

v2.45.1 diagnostics (device running, chlorination 100%) confirmed the mapping:
- c172 = 289 → **28.9 °C** water temperature (matches the Fluidra app)
- c20 = `null` → **no ORP setpoint register** (pH-only unit, `saltLowLevel` + pH-minus dosing)
- c177/c178/c183/c185 = 0 (legacy generic slots, empty)

## Profile
Standard tecnoLC2 layout minus everything ORP: pH **c165**, temperature **c172**, salinity **c174**, pH setpoint **c16**, chlorination level **c10**, `skip_mode_select`. No ORP/free-chlorine entities (no probe). The scan also polls the candidate CLE/COU production registers (**c9/c13/c14/c103/c154**) like the sibling Ei2 iQ Evo profile, so the next capture can map them (the open follow-up in #104).

## Testing
- New identification test (pattern → profile, pH-only mapping, no-ORP assertions)
- 1295 tests green, mypy --strict clean
- Deployed on HA dev: zero `fluidra_pool` errors at startup