### PR TITLE
fix: add CC24018506 Energy Connect profile, calibrated ORP, drop fake pH/salinity (Issue #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **AstralPool / Fluidra Energy Connect chlorinator `CC24018506`** (tecnoLC2, fw 40 — Issue #129, @luistf76). The unit fell back to the generic profile, which read c172 (water temperature, 31.5 °C) as pH and c177 (raw, uncalibrated ORP) as ORP — ~72 mV higher than the app. Dedicated profile validated register-by-register against the Fluidra app: **calibrated ORP on c170**, temperature c172, pH/ORP setpoints c16/c20, legacy chlorination c4/c164. The unit exposes no live pH-measured component (c8 only echoes the pH setpoint) and no live salinity (c185 stays 0), so those misleading sensors are no longer created, and the mode select is skipped (c20 is the ORP setpoint, not a mode register).
+- **Impossible-zero guard extended to pH and salinity** (Issue #129) — a pH or salinity reading of exactly 0 (a setpoint-echo register clearing to 0, or a frozen salinity slot) now shows *unknown* instead of a physically-impossible 0.0, mirroring the existing ORP guard (Issue #111).
+
 ## [2.45.3] - 2026-07-04
 
 ### Changed

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -500,6 +500,43 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         priority=86,
         boost_mode=103,
     ),
+    "cc24018506_chlorinator": DeviceConfig(
+        device_type="chlorinator",
+        # AstralPool / Fluidra Energy Connect (tecnoLC2, firmware 40) — Issue #129
+        # (@luistf76). Fell back to the generic *.nn_* profile, which read c172
+        # (water temperature, 315 → 31.5 °C) as pH and c177 (raw, uncalibrated
+        # ORP, 676) as ORP. The reporter cross-checked every register against the
+        # Fluidra app on the live unit:
+        #   c170 = 597 → calibrated ORP (matches the app; c177 is ~79 mV high)
+        #   c172 = 315 → water temperature 31.5 °C
+        #   c16  = 740 → pH setpoint 7.40   c20 = 710 → ORP setpoint 710 mV
+        #   c4/c164     → chlorination level write/read (legacy slots; no c10)
+        # This bridge exposes no live pH-measured component (c165 absent; c8 is
+        # only the pH-setpoint write echo, dropping to 0 when the dosing pump is
+        # idle) and no live salinity (c185 stays 0; the app reads it from a
+        # different endpoint), so neither sensor is mapped rather than surfacing a
+        # misleading value. c20 is the ORP setpoint, not a 0/1/2 mode register, so
+        # the mode select is skipped (it would map 710 → "off" and clobber the
+        # setpoint on write).
+        identifier_patterns=["CC24018506*"],
+        family_patterns=["chlorinator"],
+        components_range=25,
+        required_components=[0, 1, 2, 3],
+        entities=["switch", "number", "sensor_info"],
+        features={
+            "chlorination_level": {"write": 4, "read": 164},
+            "ph_setpoint": {"write": 8, "read": 16},
+            "orp_setpoint": {"write": 11, "read": 20},
+            "boost_mode": 245,
+            "skip_mode_select": True,
+            "sensors": {
+                "orp": 170,  # Calibrated ORP — matches the app (c177 is raw).
+                "temperature": 172,  # 315 = 31.5 °C.
+            },
+            "specific_components": [4, 8, 11, 16, 20, 164, 170, 172, 245],
+        },
+        priority=90,
+    ),
     "cc24018202_chlorinator": _standard_tecnolc2(
         ["CC24018202*"],
         priority=87,

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -151,12 +151,14 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
             _LOGGER.debug("Failed to parse sensor value %s for component %s", raw_value, self._component_id)
             return None
 
-        # An ORP (redox) probe immersed in water always reads a non-zero mV
-        # potential, so a flat 0 means no probe is connected — e.g. the Zodiac
-        # eXO iQ LS, where the ORP probe is an optional Dual Link add-on (Issue
-        # #111). Report "unknown" instead of a misleading 0 mV; the entity
-        # surfaces a real value automatically if a probe is added later.
-        if self._sensor_type == "orp" and value == 0:
+        # A pH / ORP / salinity reading of exactly 0 is physically impossible for
+        # a probe in a running salt pool, so it means "no live reading" rather
+        # than a real value: a bare ORP register on a probe-less unit (Zodiac
+        # eXO iQ LS optional Dual Link probe, Issue #111), a pH register that
+        # only echoes the setpoint and clears to 0 when the dosing pump is idle,
+        # or a salinity slot frozen at 0 (Issue #129). Report "unknown" instead
+        # of a misleading 0; a real value surfaces automatically if it appears.
+        if value == 0 and self._sensor_type in ("orp", "ph", "salinity"):
             return None
 
         return value

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -188,6 +188,32 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         assert config.features["chlorination_level"] == 10
 
+    def test_cc24018506_energy_connect_calibrated_orp_no_fake_ph_salinity(self):
+        """Energy Connect CC24018506 uses calibrated ORP (c170) and drops the fake pH/salinity (Issue #129)."""
+        config = DEVICE_CONFIGS["cc24018506_chlorinator"]
+        device = {
+            "device_id": "CC24018506.nn_1",
+            "name": "Chlorinator",
+            "family": "Chlorinators",
+            "type": "chlorinator",
+            "model": "Chlorinator",
+        }
+        # Must win over the generic *.nn_* profile (priority 80).
+        assert DeviceIdentifier.identify_device(device) is config
+        assert config.priority > 80
+        sensors = config.features["sensors"]
+        # Calibrated ORP (c170), not the raw/uncalibrated c177 the generic profile used.
+        assert sensors["orp"] == 170
+        assert sensors["temperature"] == 172  # 315 = 31.5 °C, not read as pH.
+        # No live pH-measured / salinity component on this bridge -> no misleading sensor.
+        assert "ph" not in sensors
+        assert "salinity" not in sensors
+        # c20 is the ORP setpoint, not a mode register -> the broken mode select is skipped.
+        assert config.features["skip_mode_select"] is True
+        assert config.features["ph_setpoint"] == {"write": 8, "read": 16}
+        assert config.features["orp_setpoint"] == {"write": 11, "read": 20}
+        assert config.features["chlorination_level"] == {"write": 4, "read": 164}
+
     def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):
         """Ei2 iQ 20 pH Evo CC26010842 maps on the pH-only tecnoLC2 layout (Issue #104)."""
         config = DEVICE_CONFIGS["cc26010842_chlorinator"]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -279,3 +279,35 @@ def test_chlorinator_zero_non_orp_sensor_still_reads_zero() -> None:
     device = _pinned_device(DEVICE_ID, components={"178": {"reportedValue": 0}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "free_chlorine", 178)
     assert sensor.native_value == pytest.approx(0.0)
+
+
+def test_chlorinator_ph_zero_reads_unknown() -> None:
+    """A pH of exactly 0 is impossible for real pool water (Issue #129).
+
+    On some bridges the pH register only echoes the setpoint and clears to 0
+    when the dosing pump is idle, so 0 means "no live reading", not pH 0.0.
+    """
+    device = _pinned_device(DEVICE_ID, components={"8": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 8)
+    assert sensor.native_value is None
+
+
+def test_chlorinator_salinity_zero_reads_unknown() -> None:
+    """A running salt cell never reads exactly 0 g/L — a frozen 0 means no reading (Issue #129)."""
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    assert sensor.native_value is None
+
+
+def test_chlorinator_ph_nonzero_reads_value() -> None:
+    """A real pH reading is still reported unchanged (regression guard for #129)."""
+    device = _pinned_device(DEVICE_ID, components={"165": {"reportedValue": 742}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "ph", 165)
+    assert sensor.native_value == pytest.approx(7.42)
+
+
+def test_chlorinator_temperature_zero_still_reads_zero() -> None:
+    """Temperature is not guarded: 0 °C is a legitimate (if cold) reading."""
+    device = _pinned_device(DEVICE_ID, components={"172": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "temperature", 172)
+    assert sensor.native_value == pytest.approx(0.0)


### PR DESCRIPTION
Addresses #129 (@luistf76's exceptionally thorough report)

## Summary
The AstralPool / Fluidra Energy Connect (`CC24018506`, tecnoLC2, fw 40) fell back to the generic `*.nn_*` profile, which read **c172 (water temperature, 31.5 °C) as pH** and **c177 (raw, uncalibrated ORP, ~72 mV high) as ORP**. The reporter cross-checked every register against the live Fluidra app.

## Changes
- **Dedicated `CC24018506` profile** (priority 90, wins over the generic 80):
  - **Calibrated ORP on c170** (597 mV, matches the app; c177 = 676 is the raw value)
  - Temperature c172, pH setpoint c16, ORP setpoint c20, legacy chlorination c4/c164
  - **No pH sensor** — c165 is absent and c8 only echoes the pH-setpoint write (drops to 0 when the dosing pump is idle); showing that as a probe reading was the "0.0 pH" bug. The setpoint stays available as its own number entity.
  - **No salinity sensor** — c185 stays frozen at 0 (the app reads salinity from a different endpoint)
  - `skip_mode_select` — c20 is the ORP setpoint, not a 0/1/2 mode register, so the generic mode select would read "off" forever and clobber the setpoint on write
- **Generalized the impossible-zero guard** (Issue #111) from ORP to **pH and salinity**: a probe in a running salt pool never reads exactly 0, so 0 → *unknown* instead of a misleading 0.0. Temperature and free-chlorine keep legitimate zeros.

## Out of scope (server-side / needs traffic capture — explained in the issue reply)
- Live salinity value (#3): the app's telemetry endpoint is unknown; `poll_water_quality()` returns empty jobs for this account.
- c4 write 403 (#4): a Fluidra-side ACL on the account (viewer-level contracts), not an integration bug.
- boost c245 (#5): never populated by the hardware; the switch stays unavailable until it does.

## Testing
- 5 new tests: profile identification (calibrated ORP, no fake pH/salinity, skip_mode_select) + generalized zero-guard (pH 0 / salinity 0 → unknown, real pH kept, temperature 0 kept)
- 1300 tests green, mypy --strict clean, ruff clean
- 53 existing profiles proven unchanged (registry snapshot diff)
- Deployed on HA dev: zero errors at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for a specific chlorinator model so it now shows the correct available readings and controls instead of falling back to a generic setup.
  * Zero readings for pH and salinity are now treated as unavailable, matching other sensor behavior and avoiding misleading `0.0` values.
  * Calibrated ORP and temperature readings continue to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->