### PR TITLE
feat: add air temperature sensor for the Z250iQ heat pump (Issue #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Air temperature sensor for the Z250iQ heat pump** (Issue #131, @Kal42) — the Z250iQ exposes the same air-temperature register (component 67, ×0.1) as the Z260iQ, confirmed against the official app. It now gets water and air temperature sensors like the Z260iQ, without otherwise changing its behaviour (it keeps its own on/off + preset handling — no Z260 mode/no-flow/running-hours).
+
 ## [2.45.4] - 2026-07-05
 
 ### Fixed

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -386,7 +386,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     pass
         elif component_id == 67:
             device["component_67_data"] = component_state
-            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
+            # Air temperature on the Z260iQ and Z250iQ (same register/scale).
+            air_temp_model = DeviceIdentifier.has_feature(device, "z260iq_mode") or DeviceIdentifier.has_feature(
+                device, "z250iq_mode"
+            )
+            if air_temp_model and reported_value is not None:
                 try:
                     air_temp = float(reported_value) / 10.0
                     if -30.0 <= air_temp <= 60.0:

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -32,15 +32,20 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         family_patterns=["heat pump"],
         components_range=5,
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info"],
+        entities=["climate", "switch", "sensor_info", "sensor_temperature"],
         features={
             "preset_modes": True,
             "temperature_control": True,
             "hvac_modes": ["off", "heat"],
             "skip_auto_mode": True,
             "skip_schedules": True,
-            # 7=signature (for differentiation), 13=ON/OFF, 14=preset, 15=target temp, 19=water temp.
-            "specific_components": [7, 13, 14, 15, 19],
+            # Air temperature only — kept distinct from z260iq_mode so the Z250iQ
+            # keeps its own on/off + preset handling (no Z260 mode/no-flow/running-hours).
+            "z250iq_mode": True,
+            # 7=signature (for differentiation), 13=ON/OFF, 14=preset, 15=target temp,
+            # 19=water temp (×0.1), 67=air temp (×0.1) — same air/water layout as the
+            # Z260iQ (Issue #131, confirmed by @Kal42: matches the official app).
+            "specific_components": [7, 13, 14, 15, 19, 67],
         },
         priority=95,
     ),

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -102,8 +102,10 @@ async def async_setup_entry(
                         entities.append(
                             FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "air")
                         )
-                    # Z260iQ heat pump specific temperature sensors
-                    if DeviceIdentifier.has_feature(device, "z260iq_mode"):
+                    # Z260iQ / Z250iQ heat pump specific temperature sensors
+                    if DeviceIdentifier.has_feature(device, "z260iq_mode") or DeviceIdentifier.has_feature(
+                        device, "z250iq_mode"
+                    ):
                         entities.append(
                             FluidraTemperatureSensor(coordinator, coordinator.api, pool_id, device_id, "water")
                         )

--- a/tests/test_coordinator_components.py
+++ b/tests/test_coordinator_components.py
@@ -150,6 +150,20 @@ async def test_component_67_out_of_range_temperature_ignored(coordinator: Fluidr
     assert "air_temperature" not in device
 
 
+async def test_component_67_air_temperature_for_z250iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """Component 67 is air temperature ×10 for the Z250iQ too (Issue #131)."""
+    device = _pinned_device(features={"z250iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 67, {"reportedValue": 213})
+    assert device["air_temperature"] == 21.3
+
+
+async def test_component_67_ignored_without_air_temp_model(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """A heat pump without z250iq_mode/z260iq_mode does not expose c67 as air temperature."""
+    device = _pinned_device(features={})
+    coordinator._process_component_state(device, "pool_001", 67, {"reportedValue": 245})
+    assert "air_temperature" not in device
+
+
 # --- Z550 specific paths (16, 17, 21, 37, 40, 61) -----------------------
 
 

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -188,6 +188,17 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         assert config.features["chlorination_level"] == 10
 
+    def test_z250iq_exposes_air_temperature_without_becoming_z260(self):
+        """Z250iQ gains the air-temperature sensor (c67) but keeps its own mode handling (Issue #131)."""
+        config = DEVICE_CONFIGS["z250iq_heat_pump"]
+        # Air temp is wired: component scanned, sensor_temperature entity, dedicated flag.
+        assert 67 in config.features["specific_components"]
+        assert "sensor_temperature" in config.entities
+        assert config.features.get("z250iq_mode") is True
+        # But it is NOT turned into a Z260iQ: no z260iq_mode, own hvac_modes kept.
+        assert "z260iq_mode" not in config.features
+        assert config.features["hvac_modes"] == ["off", "heat"]
+
     def test_cc24018506_energy_connect_calibrated_orp_no_fake_ph_salinity(self):
         """Energy Connect CC24018506 uses calibrated ORP (c170) and drops the fake pH/salinity (Issue #129)."""
         config = DEVICE_CONFIGS["cc24018506_chlorinator"]


### PR DESCRIPTION
Closes #131

## Summary
@Kal42 confirmed the **Z250iQ** exposes the same air-temperature register as the Z260iQ (**component 67, ×0.1**) and that its value matches the official app.

## Changes
- New `z250iq_mode` feature flag on the Z250iQ profile — **kept distinct from `z260iq_mode`** so the Z250iQ keeps its own on/off + preset handling (no Z260 mode / no-flow alarm / running-hours leakage).
- Poll component 67 (added to `specific_components`), and widen the coordinator's c67 air-temperature handling to both `z260iq_mode` and `z250iq_mode`.
- Enable `sensor_temperature` on the Z250iQ and create **water + air** temperature sensors, matching the Z260iQ (full temperature parity).

## Testing
- New tests: coordinator c67 → air temp for z250iq_mode (and not for a plain heat pump), profile asserts (c67 scanned, sensor_temperature entity, z250iq_mode set, no z260iq_mode, own hvac_modes kept).
- 1303 tests green, mypy --strict clean, ruff clean.
- Deployed on HA dev: zero errors at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Z250iQ heat pump now exposes water and air temperature sensors, matching the behavior already available on the Z260iQ.
  * Air-temperature readings are now available for supported Z250iQ devices.

* **Bug Fixes**
  * Improved temperature handling so air temperature is only shown for compatible heat pump models.
  * Preserved the Z250iQ’s existing on/off and heat-only behavior while adding the new sensor support.

* **Tests**
  * Added coverage for Z250iQ air-temperature detection and for devices that should not expose it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->