### PR TITLE
feat: detect pool access level, warn on viewer (read-only) accounts (Issue #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Pool access-level awareness** (Issue #129 follow-up) — the integration now records whether the account **owns** a pool or only has **viewer** (read-only) access, exposed as the `access_level` / `read_only` attributes on the pool status sensor. A viewer account is a known trap: the Fluidra cloud accepts control writes (setpoints, switches) with an HTTP 200 that echoes the requested value but never persists it, so commands silently have no effect. When a pool is viewer-only, a clear warning is logged once at setup. (Control entities are intentionally left enabled — the permission model isn't fully known and owner accounts must keep working.)
 - **Air temperature sensor for the Z250iQ heat pump** (Issue #131, @Kal42) — the Z250iQ exposes the same air-temperature register (component 67, ×0.1) as the Z260iQ, confirmed against the official app. It now gets water and air temperature sensors like the Z260iQ, without otherwise changing its behaviour (it keeps its own on/off + preset handling — no Z260 mode/no-flow/running-hours).
 
 ## [2.45.4] - 2026-07-05

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ entities:
 | `No pools found` | Account has no equipment, or it's offline in the Fluidra app |
 | Device shows *unavailable* | The device reports itself offline to the Fluidra cloud |
 | Commands seem ignored | Check debug logs; transient cloud rejections now surface as errors |
+| Setpoints/switches never change (no error) | Account has **viewer** (read-only) access to the pool — the cloud accepts writes but doesn't apply them. Check the `access_level` attribute on the pool status sensor; owner access is required to control equipment |
 
 ---
 

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -31,6 +31,7 @@ from ..const import (
 )
 from ..device_registry import DeviceIdentifier
 from ..fluidra_api import FluidraPoolAPI
+from ..helpers import determine_pool_access
 from ..repairs import async_create_connection_issue, async_delete_connection_issue
 from ._parsers import calculate_auto_speed_from_schedules, parse_dm24049704_schedule_format
 
@@ -54,6 +55,8 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._first_update = True
         # Consecutive failed poll cycles; drives the connection_error repair issue.
         self._consecutive_update_failures = 0
+        # Pools already warned about read-only (viewer) access — warn once, not every poll.
+        self._read_only_pools_warned: set[str] = set()
 
         # Honour the user-configured polling interval.
         scan_interval = DEFAULT_SCAN_INTERVAL
@@ -546,6 +549,21 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             api_devices = pool.get("devices", [])
             pool.update(pool_details_result)
             pool["devices"] = api_devices
+
+        # Determine whether the account can actually control this pool. A viewer
+        # (read-only) contract makes the backend accept control writes with a
+        # fake HTTP 200 that echoes the requested value but never persists it, so
+        # commands silently have no effect (Issue #129). Surface it and warn once.
+        access_level = determine_pool_access(pool, self.api.user_id)
+        pool["access_level"] = access_level
+        if access_level == "viewer" and pool_id not in self._read_only_pools_warned:
+            self._read_only_pools_warned.add(pool_id)
+            _LOGGER.warning(
+                "Account has viewer (read-only) access to pool %s: control commands "
+                "(setpoints, switches) are accepted by the Fluidra cloud but not applied. "
+                "Owner-level access is required to change settings",
+                pool.get("name", pool_id),
+            )
 
         if isinstance(water_quality_result, dict):
             pool["water_quality"] = water_quality_result

--- a/custom_components/fluidra_pool/fluidra_api/_auth.py
+++ b/custom_components/fluidra_pool/fluidra_api/_auth.py
@@ -173,16 +173,20 @@ class AuthMixin(FluidraAPIBase):
     async def _get_user_profile(self) -> dict[str, Any]:
         """Fetch user profile.
 
-        The result is intentionally unused: this call mirrors the official
-        mobile app's login sequence (Cognito auth → consumers/me → discovery)
-        so our traffic stays indistinguishable from the app's. Failures are
-        ignored on purpose — the profile is not needed for operation.
+        Mirrors the official mobile app's login sequence (Cognito auth →
+        consumers/me → discovery) so our traffic stays indistinguishable from
+        the app's. We also keep the consumer id, which lets the coordinator tell
+        whether the account owns a pool or only has shared/viewer access.
+        Failures are ignored on purpose — the profile is not required to operate.
         """
         headers = self._build_auth_headers()
 
         try:
             status, data, _ = await self._request("GET", CONSUMER_PROFILE_ENDPOINT, headers=headers)
             if status == 200 and isinstance(data, dict):
+                consumer_id = data.get("id")
+                if isinstance(consumer_id, str):
+                    self.user_id = consumer_id
                 return data
         except FluidraError:
             _LOGGER.debug("Failed to get user profile, continuing anyway")

--- a/custom_components/fluidra_pool/fluidra_api/_base.py
+++ b/custom_components/fluidra_pool/fluidra_api/_base.py
@@ -36,6 +36,7 @@ class FluidraAPIBase:
         refresh_token: str | None
         token_expires_at: int | None
         _last_token_store: float
+        user_id: str | None
         _on_token_persist: Callable[[str], None] | None
         user_pools: list[dict[str, Any]]
         devices: list[dict[str, Any]]

--- a/custom_components/fluidra_pool/fluidra_api/client.py
+++ b/custom_components/fluidra_pool/fluidra_api/client.py
@@ -47,6 +47,9 @@ class FluidraPoolAPI(SessionMixin, AuthMixin, DevicesMixin, ComponentsMixin, Com
         self.access_token: str | None = None
         self.refresh_token: str | None = refresh_token
         self.token_expires_at: int | None = None
+        # Consumer id of the authenticated account (from mobile/consumers/me);
+        # lets us tell whether the account owns a pool or only has shared access.
+        self.user_id: str | None = None
         # Monotonic stamp of the last successful token store — lets waiters on
         # the token lock detect that another task already refreshed (see
         # AuthMixin.force_refresh_token).

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -65,3 +65,39 @@ def parse_cron_time(cron_time: str) -> time | None:
     except (ValueError, TypeError, IndexError, AttributeError):
         pass
     return None
+
+
+def determine_pool_access(pool: dict[str, Any], user_id: str | None) -> str:
+    """Classify the account's access to a pool.
+
+    Returns one of ``"owner"``, ``"viewer"``, ``"shared"`` or ``"unknown"``.
+    The account owns the pool when its consumer id matches ``pool["owner"]``.
+    Otherwise the access level is read from the ``contracts`` list: the account's
+    own contract when it can be matched by id, else ``"viewer"`` when every
+    contract is viewer-only, else ``"shared"``. ``"unknown"`` when there is not
+    enough information.
+
+    A ``"viewer"`` result matters because the Fluidra backend accepts control
+    writes from a viewer with an HTTP 200 that echoes the requested value but
+    never persists it, so commands silently have no effect (Issue #129).
+    """
+    owner_id = pool.get("owner")
+    if user_id and owner_id and owner_id == user_id:
+        return "owner"
+
+    contracts = pool.get("contracts")
+    if not isinstance(contracts, list) or not contracts:
+        return "unknown"
+
+    levels = [c.get("accessLevel") for c in contracts if isinstance(c, dict)]
+
+    if user_id:
+        for contract in contracts:
+            if isinstance(contract, dict) and contract.get("id") == user_id:
+                level = contract.get("accessLevel")
+                if isinstance(level, str):
+                    return level
+
+    if levels and all(level == "viewer" for level in levels):
+        return "viewer"
+    return "shared"

--- a/custom_components/fluidra_pool/sensor/pool.py
+++ b/custom_components/fluidra_pool/sensor/pool.py
@@ -117,6 +117,12 @@ class FluidraPoolStatusSensor(FluidraPoolSensorBase):
         attrs["pool_state"] = pool_data.get("state", "unknown")
         if "owner" in pool_data:
             attrs["owner_id"] = pool_data["owner"]
+        access_level = pool_data.get("access_level")
+        if access_level:
+            attrs["access_level"] = access_level
+            # Read-only account: control writes are accepted by the cloud but
+            # silently discarded (Issue #129).
+            attrs["read_only"] = access_level == "viewer"
 
         characteristics = pool_data.get("characteristics", {})
         if characteristics:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def mock_api() -> AsyncMock:
     api.access_token = "test-access-token"
     api.refresh_token = "test-refresh-token"
     api.token_expires_at = None
+    api.user_id = "test-user-id"
     api.authenticate = AsyncMock(return_value=True)
     api.ensure_valid_token = AsyncMock(return_value=True)
     api.get_pools = AsyncMock(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -418,3 +418,35 @@ class TestUpdateDataOutagePath:
         note_success.assert_called_once()
         sync_fw.assert_called_once()
         assert "p1" in data
+
+
+class TestPoolAccessLevel:
+    """The coordinator classifies pool access and warns once on viewer (read-only)."""
+
+    async def _refresh(self, hass: HomeAssistant, mock_api: AsyncMock, pool_details: dict, user_id):
+        coord = FluidraDataUpdateCoordinator(hass, mock_api)
+        mock_api.user_id = user_id
+        mock_api.get_pool_details = AsyncMock(return_value=pool_details)
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_device_status = AsyncMock(return_value=None)
+        pool = {"id": "pool_1", "name": "casa", "devices": []}
+        await coord._refresh_pool(pool, {})
+        return coord, pool
+
+    async def test_viewer_access_flagged_and_warns_once(self, hass: HomeAssistant, mock_api: AsyncMock, caplog):
+        details = {"owner": "someone-else", "contracts": [{"id": "me", "accessLevel": "viewer"}]}
+        coord, pool = await self._refresh(hass, mock_api, details, "me")
+        assert pool["access_level"] == "viewer"
+        assert "pool_1" in coord._read_only_pools_warned
+        assert any("viewer (read-only) access" in r.message for r in caplog.records)
+
+        # A second refresh of the same pool must not warn again.
+        caplog.clear()
+        pool2 = {"id": "pool_1", "name": "casa", "devices": []}
+        await coord._refresh_pool(pool2, {})
+        assert not any("viewer (read-only) access" in r.message for r in caplog.records)
+
+    async def test_owner_access_not_flagged(self, hass: HomeAssistant, mock_api: AsyncMock):
+        details = {"owner": "me", "contracts": [{"id": "me", "accessLevel": "viewer"}]}
+        _, pool = await self._refresh(hass, mock_api, details, "me")
+        assert pool["access_level"] == "owner"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,3 +64,50 @@ def test_parse_cron_time_valid(cron, expected) -> None:
 def test_parse_cron_time_invalid_returns_none(invalid) -> None:
     """Short, non-numeric, out-of-range or non-string input → None."""
     assert parse_cron_time(invalid) is None  # type: ignore[arg-type]
+
+
+# --- determine_pool_access --------------------------------------------------
+
+
+def test_pool_access_owner_by_user_id_match() -> None:
+    """The account owns the pool when its consumer id matches pool['owner']."""
+    from custom_components.fluidra_pool.helpers import determine_pool_access
+
+    pool = {"owner": "user-1", "contracts": [{"id": "user-1", "accessLevel": "viewer"}]}
+    # Owner match wins even if a contract says viewer.
+    assert determine_pool_access(pool, "user-1") == "owner"
+
+
+def test_pool_access_viewer_when_all_contracts_viewer_and_not_owner() -> None:
+    from custom_components.fluidra_pool.helpers import determine_pool_access
+
+    pool = {
+        "owner": "someone-else",
+        "contracts": [{"id": "a", "accessLevel": "viewer"}, {"id": "b", "accessLevel": "viewer"}],
+    }
+    assert determine_pool_access(pool, "user-1") == "viewer"
+
+
+def test_pool_access_reads_own_contract_level() -> None:
+    """When our contract is identifiable, its exact level is returned."""
+    from custom_components.fluidra_pool.helpers import determine_pool_access
+
+    pool = {
+        "owner": "owner-x",
+        "contracts": [{"id": "user-1", "accessLevel": "editor"}, {"id": "b", "accessLevel": "viewer"}],
+    }
+    assert determine_pool_access(pool, "user-1") == "editor"
+
+
+def test_pool_access_shared_when_mixed_and_unmatched() -> None:
+    from custom_components.fluidra_pool.helpers import determine_pool_access
+
+    pool = {"owner": "owner-x", "contracts": [{"accessLevel": "viewer"}, {"accessLevel": "owner"}]}
+    assert determine_pool_access(pool, "user-1") == "shared"
+
+
+def test_pool_access_unknown_without_contracts() -> None:
+    from custom_components.fluidra_pool.helpers import determine_pool_access
+
+    assert determine_pool_access({"owner": "x"}, None) == "unknown"
+    assert determine_pool_access({}, "user-1") == "unknown"


### PR DESCRIPTION
Closes #133 · follow-up to #129

## Background
@luistf76 proved with debug logging that a **viewer** (read-only) Fluidra account gets a **fake HTTP 200** for control writes: the cloud echoes the requested value in `reportedValue` but never persists it, so setpoints and switches silently have no effect. A legitimate write returns the same 200 + echo, so it can't be distinguished at write time.

## Changes
- **Capture the account's consumer id** from `mobile/consumers/me` (it was fetched and discarded) — lets us tell *owner* from *shared* access.
- **New pure helper** `determine_pool_access(pool, user_id)` → `owner` / `viewer` / `shared` / `unknown`, from `pool.owner` vs the consumer id and `contracts[].accessLevel`.
- **Coordinator** records `pool["access_level"]` on every refresh and logs a **clear one-time warning** when a pool is viewer-only.
- **Pool status sensor** exposes `access_level` and `read_only` attributes; README troubleshooting row added.

## Deliberately NOT done
Control entities are **left enabled**: only `viewer` is confirmed read-only, the write-capable level name is unconfirmed, and owner accounts must keep working. Making entities read-only for confirmed-viewer pools is tracked in #133 pending an owner-account capture.

## Testing
- New helper tests + coordinator tests (viewer flagged + warn-once, owner not flagged).
- 1310 tests green, mypy --strict clean, ruff clean.
- Deployed on HA dev (owner account): zero errors, no false viewer warning.