### PR TITLE
Recognise BXWAB heat pumps as lg_heat_pump

### DIFF
--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -96,7 +96,7 @@ def _identify_device_uncached(
         if config.device_type in device_type_hint:
             score += 10
 
-        if config_name == "lg_heat_pump" and _match(comp7_value, ("BXWAA",)):
+        if config_name == "lg_heat_pump" and _match(comp7_value, ("BXWAA", "BXWAB")):
             score += 100
             signal += 100
 


### PR DESCRIPTION
Fixes #164.

The Swim & Fun inverter heat pump (SKU 1441, firmware 2.5.0, serial `LG24…(redacted)`)
reports signature `BXWAB` on component 7, so it never wins the `+100` bonus that
selects `lg_heat_pump`. Its `LG*` identifier pattern matches, but the name,
family and model patterns do not — so it falls through to the generic
variable-speed pump profile and no climate entity is created.

I verified the existing LG component map against this unit's live values before
concluding it was only the signature that was wrong:

| Component | Reported | LG mapping | Interpretation |
|---|---|---|---|
| 0 | 835 | running hours | 835 h |
| 13 | 1 | ON/OFF | on |
| 14 | 2 | preset | Smart H+C |
| 15 | 200 | setpoint ×0.1 | **20.0 °C** |
| 19 | 185 | water temp ×0.1 | **18.5 °C** |

Those figures matched what the official Fluidra Pool app showed at the time, so
the unit belongs on the existing profile rather than needing a new one.

With this change the device is identified correctly and produces
`climate.inverter_heat_pumps_by_swim_fun_heat_pump` with water temperature,
setpoint, presets and a 10–40 °C range, plus the switch and sensors. It has been
running against 2.64.0 since, with no other modifications.

Happy to attach a full diagnostics download if that would help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification of supported LG heat pump configurations by recognizing an additional valid model variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
