### PR TITLE
Add chlorinator alarm binary sensor

### DIFF
--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -218,11 +218,19 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         Only the first active alarm is surfaced as top-level attributes
         (matching how the official app highlights one alarm at a time);
         ``active_alarm_count`` tells you if there is more than one.
+
+        ``last_known_*`` and ``device_offline`` are always present so a
+        dashboard can show something better than a bare "unknown" while the
+        device is offline — e.g. "last known: no alarm, confirmed 12 min ago"
+        — since ``is_on`` deliberately refuses to guess from stale data.
         """
         active = self._active_alarms()
         attributes: dict[str, Any] = {
             "device_id": self._device_id,
             "active_alarm_count": len(active),
+            "device_offline": self.device_data.get("online") is False,
+            "last_known_state": self._last_known_state,
+            "last_known_at": self._last_known_at.isoformat() if self._last_known_at else None,
         }
         if active:
             first = active[0]

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -106,6 +106,81 @@ class FluidraChlorinatorProducingBinarySensor(FluidraPoolEntity, BinarySensorEnt
         }
 
 
+class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity):
+    """Binary sensor for active chlorinator alarms (e.g. "PUMPSTOP PH").
+
+    Fluidra's cloud reports per-device alarms in the raw ``status.alarms``
+    array returned by ``GET .../generic/devices?format=tree`` — not in any of
+    the numbered ``specific_components`` the rest of the integration scans,
+    so they are otherwise invisible to Home Assistant. Each entry has an
+    ``errorCode``, a ``default.title``/``default.text`` pair, and a boolean
+    ``value`` marking whether that specific alarm is currently active. The
+    coordinator copies this list verbatim onto ``device["alarms"]``.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the chlorinator alarm binary sensor."""
+        super().__init__(coordinator, pool_id, device_id)
+
+        self._attr_unique_id = f"fluidra_{self._device_id}_alarm"
+        self._attr_translation_key = "chlorinator_alarm"
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available.
+
+        Mirrors the chlorinator measurement sensors, not the control
+        entities: bridged children can report ``online=False`` on a
+        transient MQTT_KEEP_ALIVE_TIMEOUT while polling keeps succeeding
+        (Issue #63) — the alarm state is diagnostic information like
+        pH/ORP/temperature, not a control surface, so it should keep
+        showing its last known value through those blips rather than
+        disappear exactly when an operator might want to check it.
+        """
+        return self.coordinator.last_update_success and bool(self.device_data)
+
+    def _active_alarms(self) -> list[dict[str, Any]]:
+        """Return the alarm entries whose ``value`` is currently truthy."""
+        alarms = self.device_data.get("alarms") or []
+        return [alarm for alarm in alarms if isinstance(alarm, dict) and alarm.get("value")]
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when at least one alarm is active."""
+        if not self.coordinator.last_update_success:
+            return None
+        return bool(self._active_alarms())
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes.
+
+        Only the first active alarm is surfaced as top-level attributes
+        (matching how the official app highlights one alarm at a time);
+        ``active_alarm_count`` tells you if there is more than one.
+        """
+        active = self._active_alarms()
+        attributes: dict[str, Any] = {
+            "device_id": self._device_id,
+            "active_alarm_count": len(active),
+        }
+        if active:
+            first = active[0]
+            default = first.get("default") or {}
+            attributes["error_code"] = first.get("errorCode")
+            attributes["title"] = default.get("title")
+            attributes["text"] = default.get("text")
+        return attributes
+
+
 class FluidraPumpSpeedInputBinarySensor(FluidraPoolEntity, BinarySensorEntity):
     """Speed-preset dry-contact digital input on a Victoria VS pump (Issue #144).
 
@@ -196,6 +271,17 @@ async def async_setup_entry(
                     pool_id,
                     device_id,
                     production_component,
+                )
+            )
+
+            # Alarms live in the raw status tree (device["alarms"]), not in
+            # any specific_components feature, so every chlorinator gets this
+            # sensor unconditionally alongside the producing sensor.
+            entities.append(
+                FluidraChlorinatorAlarmBinarySensor(
+                    coordinator,
+                    pool_id,
+                    device_id,
                 )
             )
 

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
@@ -9,7 +10,9 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.const import EntityCategory
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, FluidraPoolConfigEntry
 from .device_registry import DeviceIdentifier
@@ -133,6 +136,13 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         self._attr_unique_id = f"fluidra_{self._device_id}_alarm"
         self._attr_translation_key = "chlorinator_alarm"
 
+        # Last alarm state confirmed on a trustworthy (online) poll, frozen
+        # while the device stays offline. In-memory only — reset to None on
+        # every integration reload/HA restart until the next trustworthy
+        # poll (see _update_last_known).
+        self._last_known_state: bool | None = None
+        self._last_known_at: datetime | None = None
+
     @property
     def available(self) -> bool:
         """Return True if entity is available.
@@ -152,10 +162,52 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         alarms = self.device_data.get("alarms") or []
         return [alarm for alarm in alarms if isinstance(alarm, dict) and alarm.get("value")]
 
+    def _poll_is_trustworthy(self) -> bool:
+        """Return True when this poll's ``alarms[]`` content can be trusted.
+
+        False whenever the coordinator update itself failed, or the device
+        reports ``online=False`` — Fluidra's cloud can keep serving a cached
+        ``alarms[]`` snapshot for a disconnected device (confirmed
+        2026-07-20 — PUMPSTOP PH stayed reported ``True`` for 8+ hours after
+        the chlorinator was physically powered off, alongside a frozen ORP
+        reading).
+        """
+        return self.coordinator.last_update_success and self.device_data.get("online") is not False
+
+    def _update_last_known(self) -> None:
+        """Snapshot the confirmed alarm state, once per trustworthy poll.
+
+        Kept separate from ``_handle_coordinator_update`` so it can be
+        exercised in tests without a real ``hass``/entity_id (which
+        ``async_write_ha_state`` — called by the base
+        ``_handle_coordinator_update`` — requires).
+        """
+        if self._poll_is_trustworthy():
+            self._last_known_state = bool(self._active_alarms())
+            self._last_known_at = dt_util.utcnow()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator.
+
+        Runs once per coordinator refresh (unlike ``is_on``/
+        ``extra_state_attributes``, which HA may read multiple times per
+        update), so this is the right place for the last-known-good
+        bookkeeping rather than a side effect inside those properties.
+        """
+        self._update_last_known()
+        super()._handle_coordinator_update()
+
     @property
     def is_on(self) -> bool | None:
-        """Return True when at least one alarm is active."""
-        if not self.coordinator.last_update_success:
+        """Return True when at least one alarm is active.
+
+        Returns None (unknown) whenever the current poll can't be trusted
+        (see ``_poll_is_trustworthy``) — neither True nor False can be
+        trusted from stale data, not even False, since that could hide an
+        alarm that was genuinely active in the last real read.
+        """
+        if not self._poll_is_trustworthy():
             return None
         return bool(self._active_alarms())
 

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -825,6 +825,12 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         device["connectivity"] = connectivity
                         if "connected" in connectivity:
                             self._apply_online_flag(device, device_id, bool(connectivity["connected"]))
+                        # Device alarms (e.g. "PUMPSTOP PH") live only in this raw
+                        # status tree, not in any numbered component — the
+                        # specific_components scan never sees them (Piscina finding,
+                        # 2026-07-10/11). Surface the raw list as-is for entities to
+                        # interpret; an empty list means no active alarms.
+                        device["alarms"] = status.get("alarms", [])
 
         for device in pool.get("devices", []):
             device_id = device.get("device_id")

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -55,6 +55,9 @@
       "air_temperature_alarm": {
         "name": "Air temperature fault"
       },
+      "chlorinator_alarm": {
+        "name": "Alarm"
+      },
       "chlorinator_producing": {
         "name": "Producing"
       },

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -55,6 +55,9 @@
       "air_temperature_alarm": {
         "name": "Air temperature fault"
       },
+      "chlorinator_alarm": {
+        "name": "Alarm"
+      },
       "chlorinator_producing": {
         "name": "Producing"
       },

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -55,6 +55,9 @@
       "air_temperature_alarm": {
         "name": "Fallo de temperatura del aire"
       },
+      "chlorinator_alarm": {
+        "name": "Alarma"
+      },
       "chlorinator_producing": {
         "name": "Produciendo"
       },

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -55,6 +55,9 @@
       "air_temperature_alarm": {
         "name": "Défaut température d'air"
       },
+      "chlorinator_alarm": {
+        "name": "Alarme"
+      },
       "chlorinator_producing": {
         "name": "En production"
       },

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -55,6 +55,9 @@
       "air_temperature_alarm": {
         "name": "Falha de temperatura do ar"
       },
+      "chlorinator_alarm": {
+        "name": "Alarme"
+      },
       "chlorinator_producing": {
         "name": "A produzir"
       },

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -331,3 +331,53 @@ def test_heat_pump_alarm_unknown_before_reported() -> None:
 
 def test_heat_pump_alarm_unique_id() -> None:
     assert _alarm(_device()).unique_id == f"{DOMAIN}_{POOL_ID}_{DEVICE_ID}_air_temperature_alarm"
+
+
+# --- Chlorinator alarm offline guard (Issue #163) -------------------------
+
+from custom_components.fluidra_pool.binary_sensor import FluidraChlorinatorAlarmBinarySensor  # noqa: E402
+
+PH_ALARM = {
+    "errorCode": "PUMPSTOP_PH",
+    "default": {"title": "pH dosing stop", "text": "pH pump stopped dosing"},
+    "value": True,
+}
+
+
+def _chlorinator_alarm(device: dict) -> FluidraChlorinatorAlarmBinarySensor:
+    return FluidraChlorinatorAlarmBinarySensor(_coord([device]), POOL_ID, DEVICE_ID)
+
+
+def test_chlorinator_alarm_is_on_none_when_device_offline_with_cached_alarm() -> None:
+    """Fluidra's cloud can keep serving a cached alarms[] snapshot for a
+    disconnected device (confirmed 2026-07-20: PUMPSTOP PH stayed reported
+    True for 8+ hours after the chlorinator was physically powered off,
+    alongside a frozen ORP reading) -- online=False must make is_on
+    unknown rather than trust that stale True.
+    """
+    sensor = _chlorinator_alarm(_device(online=False, alarms=[PH_ALARM]))
+    assert sensor.is_on is None
+
+
+def test_chlorinator_alarm_last_known_state_freezes_when_offline() -> None:
+    """last_known_state should mirror the last *trustworthy* poll and stay
+    frozen once the device goes offline, rather than being cleared or
+    reflecting the (untrustworthy) cached alarms[] content.
+    """
+    online_device = _device(online=True, alarms=[PH_ALARM])
+    sensor = _chlorinator_alarm(online_device)
+
+    # A trustworthy poll while online confirms the alarm is active.
+    sensor._update_last_known()
+    assert sensor._last_known_state is True
+    frozen_at = sensor._last_known_at
+    assert frozen_at is not None
+
+    # Device goes offline; cloud keeps echoing the same cached alarms[].
+    # A further update must NOT treat this poll as trustworthy.
+    sensor.coordinator.data[POOL_ID]["devices"][0]["online"] = False
+    sensor._update_last_known()
+
+    assert sensor._last_known_state is True
+    assert sensor._last_known_at == frozen_at
+    assert sensor.is_on is None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -216,7 +216,8 @@ async def test_setup_adds_new_device_dynamically() -> None:
     listeners[0]()
 
     new_uids = {e.unique_id for e in added} - uids_after_setup
-    assert new_uids == {"fluidra_dev2_producing"}
+    # Each chlorinator gets both its producing sensor and its alarm sensor.
+    assert new_uids == {"fluidra_dev2_producing", "fluidra_dev2_alarm"}
 
 
 async def test_setup_falls_back_to_get_pools_when_no_cache() -> None:
@@ -239,7 +240,7 @@ async def test_setup_falls_back_to_get_pools_when_no_cache() -> None:
     await async_setup_entry(MagicMock(), entry, async_add)
 
     coordinator.api.get_pools.assert_awaited_once()
-    assert {e.unique_id for e in added} == {"fluidra_dev1_producing"}
+    assert {e.unique_id for e in added} == {"fluidra_dev1_producing", "fluidra_dev1_alarm"}
 
 
 @pytest.mark.parametrize("device_id", ["", None])
@@ -381,3 +382,79 @@ def test_chlorinator_alarm_last_known_state_freezes_when_offline() -> None:
     assert sensor._last_known_state is True
     assert sensor._last_known_at == frozen_at
     assert sensor.is_on is None
+
+
+def test_chlorinator_alarm_on_with_active_alarm() -> None:
+    """A trustworthy poll carrying an active alarm reads on."""
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[PH_ALARM]))
+    assert sensor.is_on is True
+    attrs = sensor.extra_state_attributes
+    assert attrs["error_code"] == "PUMPSTOP_PH"
+    assert attrs["title"] == "pH dosing stop"
+    assert attrs["active_alarm_count"] == 1
+    assert attrs["device_offline"] is False
+
+
+def test_chlorinator_alarm_off_without_active_alarms() -> None:
+    """Entries whose value is falsy don't count as active."""
+    cleared = {**PH_ALARM, "value": False}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[cleared]))
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes["active_alarm_count"] == 0
+    assert "error_code" not in sensor.extra_state_attributes
+
+
+def test_chlorinator_alarm_counts_multiple_and_surfaces_the_first() -> None:
+    """With several active alarms the count reflects all, details show the first."""
+    second = {"errorCode": "SALT_LOW", "default": {"title": "Low salt", "text": "Add salt"}, "value": True}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[PH_ALARM, second]))
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_alarm_count"] == 2
+    assert attrs["error_code"] == "PUMPSTOP_PH"
+
+
+def test_chlorinator_alarm_ignores_malformed_entries() -> None:
+    """Junk in alarms[] is skipped rather than crashing or counting."""
+    sensor = _chlorinator_alarm(_device(online=True, alarms=["junk", None, 42, {"no_value": 1}, PH_ALARM]))
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes["active_alarm_count"] == 1
+
+
+def test_chlorinator_alarm_handles_missing_alarms_key() -> None:
+    """A device the cloud never sent alarms for reads off, not unknown."""
+    sensor = _chlorinator_alarm(_device(online=True))
+    assert sensor.is_on is False
+
+
+def test_chlorinator_alarm_unknown_when_coordinator_failed() -> None:
+    """A failed poll can't be trusted either, even with the device online."""
+    device = _device(online=True, alarms=[PH_ALARM])
+    coord = _coord([device])
+    coord.last_update_success = False
+    sensor = FluidraChlorinatorAlarmBinarySensor(coord, POOL_ID, DEVICE_ID)
+    assert sensor.is_on is None
+
+
+def test_chlorinator_alarm_exposes_last_known_while_offline() -> None:
+    """Offline: is_on is unknown, but the last confirmed state stays visible.
+
+    Without this a dashboard can only show a bare "unknown"; with it, it can say
+    "last known: alarm active, confirmed at <time>".
+    """
+    device = _device(online=True, alarms=[PH_ALARM])
+    sensor = _chlorinator_alarm(device)
+    sensor._update_last_known()  # a trustworthy poll happened
+
+    device["online"] = False
+    assert sensor.is_on is None  # refuses to trust the cached snapshot
+    attrs = sensor.extra_state_attributes
+    assert attrs["device_offline"] is True
+    assert attrs["last_known_state"] is True
+    assert attrs["last_known_at"] is not None
+
+
+def test_chlorinator_alarm_last_known_absent_before_any_trustworthy_poll() -> None:
+    """Never confirmed yet → the attributes exist but stay empty, not fabricated."""
+    attrs = _chlorinator_alarm(_device(online=False, alarms=[PH_ALARM])).extra_state_attributes
+    assert attrs["last_known_state"] is None
+    assert attrs["last_known_at"] is None


### PR DESCRIPTION
## Description

Adds a `binary_sensor` that surfaces active chlorinator alarms (`device["alarms"]`, from the raw `status.alarms` array returned by the Fluidra API) as a `problem` entity — following the same pattern already used by `FluidraHeatPumpAlarmBinarySensor` (#139).

**Approach:**

- `coordinator.py`: copies `status.alarms` verbatim onto `device["alarms"]` in `_refresh_pool`, alongside where `status`/`connectivity` are already processed.
- `binary_sensor.py`: new `FluidraChlorinatorAlarmBinarySensor`, registered unconditionally alongside the producing sensor (alarms live in the raw status tree, not gated behind any `specific_components` feature).
  - `available` mirrors the chlorinator measurement entities' guard (Issue #63): stays available through transient `online=False` blips rather than disappearing exactly when an operator might want to check it.
  - `is_on` returns `None` before the coordinator has ever succeeded, rather than a false "no alarm."
  - `extra_state_attributes` surfaces `error_code`, `title`, `text`, and `active_alarm_count` from the first active alarm, matching how the official app presents it.
- Translations added for `chlorinator_alarm` in `strings.json` + en/es/fr/pt, in alphabetical order alongside the existing keys.

**Offline guard:**

Running this on real hardware surfaced a gap the initial version didn't handle: Fluidra's cloud can keep serving a *cached* `alarms[]` snapshot for a disconnected device instead of erroring — confirmed on 2026-07-20, where `PUMPSTOP PH` stayed reported `True` for 8+ hours after the chlorinator was physically powered off, alongside a frozen ORP reading. Without a guard, the sensor would silently report a stale alarm state (or a stale "no alarm") as if it were live.

To avoid that:

- `_poll_is_trustworthy()` — a poll's `alarms[]` content is only trusted when the coordinator update succeeded *and* the device reports `online is not False`.
- `is_on` returns `None` (unknown) on an untrustworthy poll, instead of trusting stale `True`/`False` — even a stale `False` could be hiding a real alarm from the last good read.
- `_last_known_state`/`_last_known_at` snapshot the confirmed state on every trustworthy poll (via `_handle_coordinator_update`) and freeze while offline, so `extra_state_attributes` can still show "last known: active since HH:MM" instead of just going blank.
- `device_offline`/`last_known_state`/`last_known_at` are always present in `extra_state_attributes` (not only while offline), since HA discourages an entity's attribute set changing shape between updates.

**Testing:**

Rebased onto current `main` (39d8fba0) to pick up the recent heat-pump alarm, bulk-fetch, and Victoria preset changes — verified no overlap or conflict with those.

Unit tests added for the offline guard (`tests/test_binary_sensor.py`): `is_on` returns `None` when `online=False` with a cached active alarm (the `PUMPSTOP PH` scenario above), and `last_known_state`/`last_known_at` stay frozen across the online→offline transition instead of picking up the untrustworthy poll. Both were verified by running the test functions directly in Python (not via `pytest`) and checking every assertion individually — `pytest-homeassistant-custom-component` cannot run at all on Windows in this environment: its event-loop setup collides with its own socket guard (`HASocketBlockedError` from `asyncio`'s Windows `ProactorEventLoop` needing a real `socket.socketpair()` for its self-pipe, which `pytest_socket` blocks). This reproduces identically on every test in the suite, including ones unrelated to this change, so it's a pre-existing platform limitation, not something introduced here. Deferring full suite verification (including these new tests running under the project's actual pytest setup) to CI, which runs on Linux.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] New device support

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested on actual Fluidra hardware (if applicable)
- [ ] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Fixes #163

## Device Testing (if applicable)

- [x] Tested on: DM Chlorinator (CC24018506), running in production for several days, including a real `PUMPSTOP PH` alarm cycle with an online→offline→online transition (visible in HA history) that validated the offline guard described above.
- [ ] Firmware version: <!-- if known -->

## Screenshots (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a chlorinator Alarm binary sensor.
  - Reports active alarms, alarm count, and details such as error code, title, and message.
  - Preserves the last trustworthy alarm state and timestamp for visibility.

- **Bug Fixes**
  - Prevents stale alarm information from being reported when the device is offline or data refresh fails.
  - Safely handles missing or malformed alarm data.

- **Translations**
  - Added Alarm labels in English, Spanish, French, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->