### PR TITLE
fix: add CC26027341 to Energy Connect tecnoLC2 profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **AstralPool Energy Connect chlorinator `CC26027341`** — the unit fell back to the generic profile, which read the water temperature (c172) as pH (2.59-2.60 instead of 25.9-26.0 °C) and did not surface a working ORP/salinity reading matching the app. Added to the Energy Connect tecnoLC2 profile: pH (c165), ORP (c170) and salinity (c174) now report live values matching the Fluidra app. This unit's c8 was non-blank (720), so the automatic tecnoLC2-signature detection never routed it here on its own.
+
 ## [2.69.0] - 2026-07-28
 
 ### Added

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -246,7 +246,16 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # CC26002143 (Issue #153, @Squallium) — Astra Pool Energy Connect, same layout;
         # app screenshot shows pH 7.3, ORP 706 mV (setpoint 700 on c20), water 28.8 °C
         # (c172 = 288, misread as pH 2.88 by the catch-all) and salinity 0.0 g/L.
-        ["CC24047102*", "CC25010924*", "CC25008731*", "CC25017029*", "CC25059122*", "CC26002143.nn_*"],
+        # CC26027341 — same family: app shows pH 7.3, ORP current 630 mV / setpoint 680
+        # mV (c20 = 680, exact match), water 25.9-26.0 °C (c172 = 259-260, misread as pH
+        # 2.59-2.60 by the catch-all). After switching to this profile, pH (c165), ORP
+        # (c170) and salinity (c174) all report live values matching the app (in
+        # diagnostics taken under the catch-all profile, c185 — its salinity slot —
+        # read 0, though it may just have been stale at that moment rather than always
+        # wrong). c8 was non-blank (720) on this unit, so the automatic
+        # tecnoLC2-signature detection (which requires a blank c8) never routed it
+        # to this profile on its own — pinning the serial directly instead.
+        ["CC24047102*", "CC25010924*", "CC25008731*", "CC25017029*", "CC25059122*", "CC26002143.nn_*", "CC26027341*"],
         priority=88,
         boost_mode=103,
     ),


### PR DESCRIPTION
## Description

Adds `CC26027341` to the Energy Connect tecnoLC2 chlorinator profile. The unit was falling back to the generic catch-all profile, which reads component 172 as pH (divisor 100) instead of water temperature (divisor 10): diagnostics showed c172 = 259-260 matching the app's 25.9-26.0 degC exactly, while the app's real pH stayed a steady 7.3 the whole time. c20 independently confirmed as the ORP setpoint (680, exact match), not the OFF/ON/AUTO mode register the catch-all assumes — toggling that mode was silently overwriting the real ORP setpoint. c8 is non-blank (720) on this unit, so the automatic tecnoLC2-signature detection never routed it to the right profile on its own.

Added to the same Energy Connect group as CC24047102/CC25008731/CC25017029/CC25059122/CC26002143 (Issues #85, #117, #121, #142, #153). pH (c165), ORP (c170) and salinity (c174) now report live values matching the Fluidra app.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] New device support

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested on actual Fluidra hardware (if applicable)
- [ ] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Same family as #85, #117, #121, #142, #153.

## Device Testing (if applicable)

- [x] Tested on: AstralPool Energy Connect Chlorinator (serial CC26027341)
- [x] Firmware version: 12

## Screenshots (if applicable)

_N/A_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected profile detection for AstralPool Energy Connect chlorinators.
  * pH, ORP, salinity, and water temperature now report live values accurately, matching the Fluidra app.
  * Fixed water temperature being incorrectly reported as pH for affected devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->