### PR TITLE
fix: surface silently-stuck component fetches as real failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A device whose component fetch keeps failing now surfaces a real error instead of freezing silently forever** (@fredfrazao) — `_fetch_components_parallel` catches each per-component request's exception via `asyncio.gather(return_exceptions=True)` and only debug-logs it, so one bad component can't sink an otherwise-healthy poll (by design). But if *every* requested component fails on *every* poll, that same swallowing meant the failure never reached the coordinator's own failure tracking: no `connection_error` repair issue, no reauth prompt, nothing — the device's sensors just kept reporting their last successfully-fetched state, indefinitely, with zero visible sign anything was wrong. Found via a real incident: a transient DNS failure tripped the API circuit breaker, and a chlorinator sat frozen on stale data for 6+ hours until a manual Home Assistant restart. Now tracks consecutive fully-empty component fetches per device and raises after 3 in a row, so it's treated exactly like a raw network failure and surfaces normally.
+
 ## [2.70.0] - 2026-07-29
 
 ### Added

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -70,6 +70,23 @@ HEAT_COOL_ACTION_DEADBAND: Final = 2.0
 # Recovery is immediate on the first online report.
 OFFLINE_GRACE_POLLS: Final = 2
 
+# A device's component fetch (_fetch_components) can come back completely
+# empty every poll — e.g. every per-component request failing individually —
+# without ever raising: _fetch_components_parallel catches each task's
+# exception via asyncio.gather(return_exceptions=True) and only debug-logs it
+# (a single bad component must not sink the whole poll). That's correct for an
+# occasional partial miss, but if it happens for every requested component on
+# every poll, the device's sensors silently freeze on stale data forever: no
+# exception ever reaches _async_update_data, so _note_update_failure() is never
+# called, no connection_error repair issue is raised, and the entities keep
+# reporting "successful" stale state indefinitely. This threshold bounds how
+# many consecutive fully-empty polls a device gets before that silence is
+# turned into a real failure that surfaces to the user (see coordinator.py
+# _refresh_pool). Observed in the wild: a transient DNS failure tripped the
+# circuit breaker, and a device sat frozen for 6+ hours with zero visible
+# error until a manual HA restart.
+EMPTY_COMPONENT_FETCH_THRESHOLD: Final = 3
+
 # Attributes
 ATTR_BRIGHTNESS: Final = "brightness"
 

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from ..api_resilience import FluidraError
+from ..api_resilience import FluidraConnectionError, FluidraError
 from ..const import (
     BULK_FETCH_FAILURE_LIMIT,
     CONNECTION_ISSUE_THRESHOLD,
@@ -26,6 +26,7 @@ from ..const import (
     DEVICE_TYPE_HEAT_PUMP,
     DEVICE_TYPE_LIGHT,
     DOMAIN,
+    EMPTY_COMPONENT_FETCH_THRESHOLD,
     OFFLINE_GRACE_POLLS,
     PUMP_SPEED_PERCENTAGES,
     STALE_DEVICE_THRESHOLD,
@@ -62,6 +63,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._missing_device_counts: dict[str, int] = {}
         # Consecutive offline connectivity reports per device (Issue #140 debounce).
         self._offline_poll_counts: dict[str, int] = {}
+        # Consecutive fully-empty component fetches per device — see
+        # EMPTY_COMPONENT_FETCH_THRESHOLD for why this must not stay silent.
+        self._empty_component_fetch_counts: dict[str, int] = {}
         # Skip heavy polling on first update for faster startup.
         self._first_update = True
         # Consecutive failed poll cycles; drives the connection_error repair issue.
@@ -850,6 +854,22 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 component_range = DeviceIdentifier.get_components_range(device)
                 components_to_scan = list(range(component_range))
             component_states = await self._fetch_components(device_id, components_to_scan)
+
+            if components_to_scan and not component_states:
+                strikes = self._empty_component_fetch_counts.get(device_id, 0) + 1
+                self._empty_component_fetch_counts[device_id] = strikes
+                if strikes >= EMPTY_COMPONENT_FETCH_THRESHOLD:
+                    # Every individual component request failed again: raise so this
+                    # propagates to _async_update_data's per-pool handler instead of
+                    # silently keeping stale data forever (Issue: sensors frozen 6h+
+                    # after a transient DNS failure, with no visible error anywhere).
+                    raise FluidraConnectionError(
+                        f"No component data received for device {device_id} after "
+                        f"{strikes} consecutive polls"
+                    )
+            else:
+                self._empty_component_fetch_counts.pop(device_id, None)
+
             for component_id, component_state in component_states.items():
                 self._process_component_state(device, pool_id, component_id, component_state)
 

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -873,12 +873,16 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # *every* device struck out this cycle, which is the actual
                     # "nothing is coming through" signal (e.g. the DNS outage
                     # this was built for) rather than one quirky device.
-                    _LOGGER.warning(
-                        "No component data received for device %s after %d consecutive "
-                        "polls — device may be unreachable or not support live polling",
-                        device_id,
-                        strikes,
-                    )
+                    if strikes == EMPTY_COMPONENT_FETCH_THRESHOLD:
+                        # Log once, right when it crosses the threshold — not on
+                        # every subsequent poll, or a permanently-stuck device
+                        # (like the test-strip one above) spams a warning forever.
+                        _LOGGER.warning(
+                            "No component data received for device %s after %d consecutive "
+                            "polls — device may be unreachable or not support live polling",
+                            device_id,
+                            strikes,
+                        )
                     chronically_stuck.append(device_id)
             else:
                 self._empty_component_fetch_counts.pop(device_id, None)

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -836,6 +836,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         # interpret; an empty list means no active alarms.
                         device["alarms"] = status.get("alarms", [])
 
+        chronically_stuck: list[str] = []
+        any_device_got_data = False
+
         for device in pool.get("devices", []):
             device_id = device.get("device_id")
             if not device_id:
@@ -859,15 +862,29 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 strikes = self._empty_component_fetch_counts.get(device_id, 0) + 1
                 self._empty_component_fetch_counts[device_id] = strikes
                 if strikes >= EMPTY_COMPONENT_FETCH_THRESHOLD:
-                    # Every individual component request failed again: raise so this
-                    # propagates to _async_update_data's per-pool handler instead of
-                    # silently keeping stale data forever (Issue: sensors frozen 6h+
-                    # after a transient DNS failure, with no visible error anywhere).
-                    raise FluidraConnectionError(
-                        f"No component data received for device {device_id} after {strikes} consecutive polls"
+                    # Every individual component request failed again for this
+                    # device. Don't raise here directly: some pools contain a
+                    # mix of real hardware and virtual/manual-input pseudo
+                    # devices (e.g. a photo-based test-strip entry) that never
+                    # answer component polls by design — raising per-device
+                    # would abort the whole pool's refresh and freeze healthy
+                    # devices right along with the permanently-stuck one.
+                    # Instead, collect it here and only fail the pool below if
+                    # *every* device struck out this cycle, which is the actual
+                    # "nothing is coming through" signal (e.g. the DNS outage
+                    # this was built for) rather than one quirky device.
+                    _LOGGER.warning(
+                        "No component data received for device %s after %d consecutive "
+                        "polls — device may be unreachable or not support live polling",
+                        device_id,
+                        strikes,
                     )
+                    chronically_stuck.append(device_id)
             else:
                 self._empty_component_fetch_counts.pop(device_id, None)
+
+            if component_states:
+                any_device_got_data = True
 
             for component_id, component_state in component_states.items():
                 self._process_component_state(device, pool_id, component_id, component_state)
@@ -896,3 +913,15 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # A code update added a verified profile for this device.
                 self._unverified_profile_flagged.discard(device_id)
                 async_delete_unverified_profile_issue(self.hass, device_id)
+
+        if chronically_stuck and not any_device_got_data:
+            # Every device in the pool struck out this cycle — that's the
+            # "nothing is coming through" signal (transient DNS/API outage,
+            # auth issue, etc.), as opposed to a single chronically-quirky
+            # device. Propagate so it reaches _async_update_data's per-pool
+            # handler and eventually the connection_error repair issue,
+            # instead of freezing silently forever.
+            raise FluidraConnectionError(
+                f"No component data received for any device in pool {pool_id} "
+                f"(stuck: {', '.join(chronically_stuck)})"
+            )

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -864,8 +864,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # silently keeping stale data forever (Issue: sensors frozen 6h+
                     # after a transient DNS failure, with no visible error anywhere).
                     raise FluidraConnectionError(
-                        f"No component data received for device {device_id} after "
-                        f"{strikes} consecutive polls"
+                        f"No component data received for device {device_id} after {strikes} consecutive polls"
                     )
             else:
                 self._empty_component_fetch_counts.pop(device_id, None)

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -922,6 +922,5 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # handler and eventually the connection_error repair issue,
             # instead of freezing silently forever.
             raise FluidraConnectionError(
-                f"No component data received for any device in pool {pool_id} "
-                f"(stuck: {', '.join(chronically_stuck)})"
+                f"No component data received for any device in pool {pool_id} (stuck: {', '.join(chronically_stuck)})"
             )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -595,9 +595,7 @@ class TestEmptyComponentFetchDetection:
         await coordinator._refresh_pool(pool, {})
         assert "D1" not in coordinator._empty_component_fetch_counts
 
-    async def test_end_to_end_surfaces_as_connection_repair_issue(
-        self, hass: HomeAssistant, mock_api: AsyncMock
-    ):
+    async def test_end_to_end_surfaces_as_connection_repair_issue(self, hass: HomeAssistant, mock_api: AsyncMock):
         """The whole path: coordinator._async_update_data must count this towards
         CONNECTION_ISSUE_THRESHOLD, exactly like a raw network failure would —
         this is the actual bug fix, not just the low-level counter."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -622,6 +622,42 @@ class TestEmptyComponentFetchDetection:
 
         assert coord._consecutive_update_failures > 0
 
+    async def test_one_chronically_stuck_device_does_not_block_healthy_ones(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """Reproduces the standardTestStrip incident (2026-07-30): a pool can contain
+        a virtual/manual-input pseudo device (e.g. a photo-based test-strip entry)
+        that never answers component polls by design, alongside real hardware that
+        polls fine. That one permanently-stuck device must not raise and revert the
+        whole pool's refresh — the healthy device's fresh data must survive, and no
+        exception should propagate as long as at least one device got real data.
+        """
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value=None)
+
+        async def fake_component_state(device_id: str, component_id: int):
+            return None if device_id == "STUCK" else {"reportedValue": 42}
+
+        mock_api.get_component_state = AsyncMock(side_effect=fake_component_state)
+
+        pool = {
+            "id": "pool_1",
+            "name": "Pool",
+            "devices": [
+                {"device_id": "STUCK", "name": "Test Strip", "online": True, "components": {}},
+                {"device_id": "HEALTHY", "name": "Chlorinator", "online": True, "components": {}},
+            ],
+        }
+
+        for _ in range(EMPTY_COMPONENT_FETCH_THRESHOLD + 2):
+            await coordinator._refresh_pool(pool, {})  # must not raise
+
+        assert coordinator._empty_component_fetch_counts["STUCK"] >= EMPTY_COMPONENT_FETCH_THRESHOLD
+        assert "HEALTHY" not in coordinator._empty_component_fetch_counts
+        healthy_device = next(d for d in pool["devices"] if d["device_id"] == "HEALTHY")
+        assert healthy_device["components"]
+
 
 class TestUnverifiedProfileIssue:
     """Devices resolved on a catch-all/legacy profile raise a repair issue once (Plan 004)."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,7 +10,11 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
 from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
-from custom_components.fluidra_pool.const import OFFLINE_GRACE_POLLS, STALE_DEVICE_THRESHOLD
+from custom_components.fluidra_pool.const import (
+    EMPTY_COMPONENT_FETCH_THRESHOLD,
+    OFFLINE_GRACE_POLLS,
+    STALE_DEVICE_THRESHOLD,
+)
 from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
 from custom_components.fluidra_pool.device_registry import DeviceIdentifier
 
@@ -523,6 +527,102 @@ class TestOnlineDebounce:
         mock_api.poll_pool_device_statuses = AsyncMock(return_value={"D1": {"connectivity": {"connected": True}}})
         await coordinator._refresh_pool(pool, {})
         assert device["online"] is True  # immediate recovery
+
+
+class TestEmptyComponentFetchDetection:
+    """A device whose component fetch keeps coming back empty must eventually
+    surface as a real failure instead of silently freezing forever.
+
+    Reproduces the incident where a transient DNS failure tripped the API
+    circuit breaker; every per-component request then failed individually
+    inside _fetch_components_parallel (which only debug-logs those, so one bad
+    component can't sink an otherwise-fine poll), component_states came back
+    empty every cycle, and the sensors sat frozen on stale data for 6+ hours
+    with no repair issue, no reauth prompt, and no visible error anywhere —
+    only a manual Home Assistant restart fixed it.
+    """
+
+    def _pool(self, device_id: str = "D1") -> dict:
+        device = {"device_id": device_id, "name": "Chlorinator", "online": True, "components": {}}
+        return {"id": "pool_1", "name": "Pool", "devices": [device]}
+
+    async def test_tolerates_fewer_than_threshold_empty_fetches(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """A blip under the threshold must not raise — matches existing partial-failure tolerance."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value=None)
+        mock_api.get_component_state = AsyncMock(return_value=None)
+        pool = self._pool()
+
+        for _ in range(EMPTY_COMPONENT_FETCH_THRESHOLD - 1):
+            await coordinator._refresh_pool(pool, {})
+
+        assert coordinator._empty_component_fetch_counts["D1"] == EMPTY_COMPONENT_FETCH_THRESHOLD - 1
+
+    async def test_raises_after_threshold_consecutive_empty_fetches(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """Hitting the threshold must raise FluidraConnectionError so it reaches _async_update_data."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value=None)
+        mock_api.get_component_state = AsyncMock(return_value=None)
+        pool = self._pool()
+
+        for _ in range(EMPTY_COMPONENT_FETCH_THRESHOLD - 1):
+            await coordinator._refresh_pool(pool, {})
+
+        with pytest.raises(FluidraConnectionError, match="No component data received"):
+            await coordinator._refresh_pool(pool, {})
+
+    async def test_successful_fetch_resets_the_strike_counter(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """A single good poll between blips must reset the streak, not accumulate towards it."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value=None)
+        mock_api.get_component_state = AsyncMock(return_value=None)
+        pool = self._pool()
+
+        for _ in range(EMPTY_COMPONENT_FETCH_THRESHOLD - 1):
+            await coordinator._refresh_pool(pool, {})
+        assert "D1" in coordinator._empty_component_fetch_counts
+
+        mock_api.get_component_state = AsyncMock(return_value={"reportedValue": 1})
+        await coordinator._refresh_pool(pool, {})
+        assert "D1" not in coordinator._empty_component_fetch_counts
+
+    async def test_end_to_end_surfaces_as_connection_repair_issue(
+        self, hass: HomeAssistant, mock_api: AsyncMock
+    ):
+        """The whole path: coordinator._async_update_data must count this towards
+        CONNECTION_ISSUE_THRESHOLD, exactly like a raw network failure would —
+        this is the actual bug fix, not just the low-level counter."""
+        mock_api.ensure_valid_token = AsyncMock(return_value=True)
+        mock_api.get_pools = AsyncMock(
+            return_value=[
+                {
+                    "id": "pool_1",
+                    "name": "Pool",
+                    "devices": [{"device_id": "D1", "name": "Chlorinator", "online": True, "components": {}}],
+                }
+            ]
+        )
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value=None)
+        mock_api.get_component_state = AsyncMock(return_value=None)
+        coord = FluidraDataUpdateCoordinator(hass, mock_api)
+
+        await coord._async_update_data()  # first update: minimal, no component fetch yet
+
+        for _ in range(EMPTY_COMPONENT_FETCH_THRESHOLD):
+            await coord._async_update_data()
+
+        assert coord._consecutive_update_failures > 0
 
 
 class TestUnverifiedProfileIssue:


### PR DESCRIPTION
# Description

A device whose per-component fetch fails for *every* component on *every* poll can currently freeze on stale data forever, with no error, no repair issue, and no reauth prompt anywhere — the only way out is a manual Home Assistant restart.

**Why this happens:** `_fetch_components_parallel` fires one request per component in parallel via `asyncio.gather(..., return_exceptions=True)`, and each task's exception is only debug-logged (`coordinator.py`). This is intentional and correct for the common case — an isolated failed component must not sink an otherwise-healthy poll of 20+ components. But when *every* component fails, every poll, that same swallowing means `component_states` comes back empty, the `for component_id, component_state in component_states.items()` loop does nothing, and the coordinator has no way to tell "0 components because nothing changed" apart from "0 components because everything is broken." No exception ever reaches `_async_update_data`, so `_note_update_failure()` is never called, `CONNECTION_ISSUE_THRESHOLD` is never reached, and the `connection_error` repair issue never fires.

**How I found it:** a transient DNS resolution failure for `api.fluidra-emea.com` tripped the built-in API circuit breaker (`api_resilience.py`) for a few minutes. DNS recovered shortly after (confirmed with a direct `socket.getaddrinfo` check from inside the HA container), but a chlorinator's ORP/pH/salinity/temperature sensors stayed frozen on the last-known values for **6+ hours**, with the pump running normally the whole time (ruled out as the cause) and Home Assistant/InfluxDB/Docker all confirmed healthy and writing other data continuously. The *only* visible trace in the logs was two `WARNING` lines around the original DNS blip:

```
2026-07-29 17:00:30.222 WARNING (MainThread) [custom_components.fluidra_pool.fluidra_api._session] Request failed after 4 attempts: Cannot connect to host api.fluidra-emea.com:443 ssl:default [DNS server returned answer with no data]
2026-07-29 17:00:30.223 WARNING (MainThread) [custom_components.fluidra_pool.api_resilience] Circuit breaker re-opened after failed recovery attempt
2026-07-29 17:06:07.230 WARNING (MainThread) [custom_components.fluidra_pool.fluidra_api._session] Request failed after 4 attempts: Cannot connect to host api.fluidra-emea.com:443 ssl:default [DNS server returned answer with no data]
2026-07-29 17:06:07.232 WARNING (MainThread) [custom_components.fluidra_pool.api_resilience] Circuit breaker re-opened after failed recovery attempt
```



...and then **nothing** — not even the `_LOGGER.info("Circuit breaker half-open, testing recovery")` that the breaker's own 5-minute recovery window (`CIRCUIT_BREAKER_TIMEOUT = 300`) should have logged every 5 minutes afterwards, debug logging enabled the whole time. The sensors simply stopped being written to InfluxDB from ~17:06 onward and never resumed until an HA restart the next morning re-initialized everything.

## The fix

Track consecutive fully-empty component fetches per device (`_empty_component_fetch_counts`, same pattern as the existing `_offline_poll_counts` debounce). After `EMPTY_COMPONENT_FETCH_THRESHOLD` (3) consecutive misses for a device, it's flagged as chronically stuck. This means:

- Same graceful degradation as today: entities keep their last-known values, nothing goes `unavailable` unnecessarily.
- But now it's **visible**: a `WARNING` is logged for the specific device instead of failing silently forever.
- A single successful fetch resets the streak — an isolated one-off miss stays silent, matching the tolerance the codebase already has for partial failures elsewhere (`OFFLINE_GRACE_POLLS`, `STALE_DEVICE_THRESHOLD`).

**Follow-up found while validating this fix live:** my first version raised an exception the moment *any one* device hit the threshold, which propagates to `_async_update_data`'s per-pool handler and reverts the *entire* pool to its previous cached state. That's correct when the whole connection is down (the DNS incident above), but a pool can also contain a mix of real hardware and virtual/manual-input pseudo-devices — in this case a photo-based "test strip" entry that never answers component polls by design. After deploying the first version, that harmless-but-permanently-empty device tripped the threshold on *every* poll cycle and kept reverting the whole pool, freezing the real chlorinator's sensors again — the exact symptom this PR set out to fix, just relocated to a new trigger.

The fix now only raises `FluidraConnectionError` (surfacing via the `connection_error` repair issue, same as before) if **every** device in the pool struck out in the same cycle — i.e. nothing came through at all, the real "is the connection down" signal — rather than any single device. A chronically-stuck device sitting alongside otherwise-healthy ones is logged and skipped; the healthy devices' fresh data is kept and the pool refresh is not reverted.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] New device support

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested on actual Fluidra hardware (if applicable) — this is the device that triggered the incident (AstralPool Energy Connect, see below)
- [x] All CI checks pass (1513 tests passing locally, mypy clean)
- [x] I have updated the documentation (CHANGELOG.md)

## Related Issues

Not filed as an issue first — found and root-caused directly while investigating an unexplained data gap in a personal Grafana dashboard built on top of this integration.

## Device Testing (if applicable)

- [x] Tested on: AstralPool Energy Connect chlorinator (the device that hit the real incident this fixes) — also validated live against a pool containing a permanently-unresponsive virtual test-strip device, confirming it no longer blocks the chlorinator's own updates
- [ ] Firmware version: not directly relevant — this is a coordinator-level fix independent of device profile/firmware

Also added 5 unit tests covering: tolerance below threshold, raising at threshold, streak reset on a successful fetch, the full end-to-end path into `_consecutive_update_failures`, and — for the follow-up — a chronically-stuck device alongside a healthy one in the same pool not raising and not losing the healthy device's data (`tests/test_coordinator.py`).

## Screenshots (if applicable)

N/A — this is a backend reliability fix with no UI surface of its own; its effect is that the existing `connection_error` repair issue now fires in a scenario where it previously never could, without collateral damage to unrelated healthy devices in the same pool.