### PR TITLE
fix: register chlorinator alarm sensor unconditionally and preserve alarms on failed poll

### DIFF
--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, FluidraPoolConfigEntry
+from .const import DEVICE_TYPE_CHLORINATOR, DOMAIN, FluidraPoolConfigEntry
 from .device_registry import DeviceIdentifier
 from .entity import FluidraPoolEntity
 from .platform_setup import async_setup_dynamic_platform
@@ -334,9 +334,12 @@ async def async_setup_entry(
                 )
             )
 
-            # Alarms live in the raw status tree (device["alarms"]), not in
-            # any specific_components feature, so every chlorinator gets this
-            # sensor unconditionally alongside the producing sensor.
+        # Alarms live in the raw status tree (device["alarms"]), not in any
+        # specific_components feature, so every chlorinator gets this sensor
+        # regardless of which feature registers its profile declares.
+        config = DeviceIdentifier.identify_device(device)
+        device_type = config.device_type if config else device.get("type", "")
+        if device_type == DEVICE_TYPE_CHLORINATOR:
             entities.append(
                 FluidraChlorinatorAlarmBinarySensor(
                     coordinator,

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -802,13 +802,20 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if isinstance(schedulers, list):
                 pool["schedulers"] = schedulers
 
-        # Preserve previous component data with deep copy to avoid aliasing.
+        # Preserve previous component and alarm data with deep copy to avoid
+        # aliasing. Alarms are seeded from the last known state so that a
+        # failed poll_pool_device_statuses call, or a status tree that omits
+        # this device for a cycle, doesn't overwrite an active alarm with an
+        # empty list -- it's overwritten below with fresh data whenever the
+        # status poll actually returns something for this device.
         for device in pool.get("devices", []):
             device_id = device.get("device_id")
             if device_id and device_id in prev_devices_by_id:
                 prev_device = prev_devices_by_id[device_id]
                 if "components" in prev_device:
                     device["components"] = copy.deepcopy(prev_device["components"])
+                if "alarms" in prev_device:
+                    device["alarms"] = copy.deepcopy(prev_device["alarms"])
 
         devices_with_ids = [(d, d.get("device_id")) for d in pool.get("devices", []) if d.get("device_id")]
         if devices_with_ids:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -203,8 +203,20 @@ async def test_setup_creates_producing_sensor_only_when_feature_present() -> Non
 
     uids = {e.unique_id for e in added}
     assert "fluidra_dev1_producing" in uids
-    assert not any("dev2" in u for u in uids)
+    assert "fluidra_dev2_producing" not in uids
     assert listeners, "a coordinator update listener must be registered for dynamic devices"
+
+
+async def test_setup_creates_alarm_sensor_regardless_of_production_feature() -> None:
+    """The alarm sensor lives in the raw status tree, not cell_production_state -- every
+    chlorinator gets it, even ones that never report cell production (Issue #163 follow-up
+    to CodeRabbit finding: the alarm sensor was previously nested inside the
+    production_component guard and silently skipped for these devices)."""
+    without_feature = _pinned_chlorinator("dev1", production_component=None)
+    added, _, _ = await _run_setup([without_feature])
+
+    uids = {e.unique_id for e in added}
+    assert uids == {"fluidra_dev1_alarm"}
 
 
 async def test_setup_adds_new_device_dynamically() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -774,3 +774,58 @@ class TestUnverifiedProfileIssue:
             delete.assert_called_once_with(coordinator.hass, "ZZ99999999.nn_1")
 
         assert coordinator._unverified_profile_flagged == set()
+
+
+class TestAlarmPreservation:
+    """A failed or partial device-status poll must not silently clear an active
+    alarm (CodeRabbit finding on PR #170, mirrors how `components` was already
+    preserved from `prev_devices_by_id` -- `alarms` had the same gap)."""
+
+    async def test_failed_status_poll_preserves_previous_alarms(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """poll_pool_device_statuses raising must not wipe an active alarm."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(side_effect=FluidraConnectionError("cloud down"))
+        device = {"device_id": "D1", "name": "Chlorinator", "online": True, "components": {}}
+        pool = {"id": "pool_1", "name": "Pool", "devices": [device]}
+        prev_device = {"device_id": "D1", "alarms": [{"error_code": 42, "title": "PUMPSTOP PH"}]}
+        previous_data = {"pool_1": {"devices": [prev_device]}}
+
+        await coordinator._refresh_pool(pool, previous_data)
+
+        assert device["alarms"] == [{"error_code": 42, "title": "PUMPSTOP PH"}]
+
+    async def test_status_missing_for_device_preserves_previous_alarms(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """A response that omits this device's entry must not read as 'no alarms'."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        # Statuses come back, but with no entry at all for D1 this cycle.
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value={})
+        device = {"device_id": "D1", "name": "Chlorinator", "online": True, "components": {}}
+        pool = {"id": "pool_1", "name": "Pool", "devices": [device]}
+        prev_device = {"device_id": "D1", "alarms": [{"error_code": 42, "title": "PUMPSTOP PH"}]}
+        previous_data = {"pool_1": {"devices": [prev_device]}}
+
+        await coordinator._refresh_pool(pool, previous_data)
+
+        assert device["alarms"] == [{"error_code": 42, "title": "PUMPSTOP PH"}]
+
+    async def test_successful_status_poll_still_overwrites_alarms(
+        self, coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock
+    ):
+        """A successful poll must still replace stale alarms with fresh data (including clearing them)."""
+        mock_api.get_pool_details = AsyncMock(return_value={})
+        mock_api.poll_water_quality = AsyncMock(return_value=None)
+        mock_api.poll_pool_device_statuses = AsyncMock(return_value={"D1": {"alarms": []}})
+        device = {"device_id": "D1", "name": "Chlorinator", "online": True, "components": {}}
+        pool = {"id": "pool_1", "name": "Pool", "devices": [device]}
+        prev_device = {"device_id": "D1", "alarms": [{"error_code": 42, "title": "PUMPSTOP PH"}]}
+        previous_data = {"pool_1": {"devices": [prev_device]}}
+
+        await coordinator._refresh_pool(pool, previous_data)
+
+        assert device["alarms"] == []


### PR DESCRIPTION
## Description

Follow-up to #170 (merged in v2.70.0). Two Major findings from CodeRabbit's review of that PR were left unresolved at merge time — see the review comments on #170. This PR applies both:

1. The alarm sensor was gated behind `cell_production_state`; now gated by device type (`DeviceIdentifier.identify_device(device).device_type`) so every chlorinator gets it, regardless of which feature its profile declares.
2. A failed or partial `poll_pool_device_statuses` response silently cleared active alarms instead of preserving the last known state — the same failure class the offline guard in #170 already handles for stale-cache reads. Alarms are now seeded from `prev_devices_by_id` alongside `components`, and still overwritten by fresh data whenever a status poll actually returns something for the device.

Adds regression tests for both, including a case CodeRabbit's own suggested diff didn't cover: a status response that comes back but omits this specific device's entry (not just a fully failed poll).

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] New device support

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have tested on actual Fluidra hardware (if applicable)
- [ ] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Follow-up to #163 / #170

## Device Testing (if applicable)

- [ ] Tested on:
- [ ] Firmware version:

## Screenshots (if applicable)

N/A

---

Tested locally on Python 3.14 (matching the CI pin in `requirements_test.txt`): full suite passes (1517 passed), `mypy` clean on both changed files, `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alarm sensors are now created only for chlorinator devices.
  * Chlorinator alarm sensors remain available even without cell production data.
  * Existing alarms are preserved when status updates fail or omit alarm information.
  * Successfully retrieved status updates now replace or clear outdated alarms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->