### PR TITLE
feat: expose full active_alarms list on chlorinator alarm sensor

### DIFF
--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -162,6 +162,16 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         alarms = self.device_data.get("alarms") or []
         return [alarm for alarm in alarms if isinstance(alarm, dict) and alarm.get("value")]
 
+    @staticmethod
+    def _flatten_alarm(alarm: dict[str, Any]) -> dict[str, Any]:
+        """Flatten a raw alarm entry to the {error_code, title, text} shape."""
+        default = alarm.get("default") or {}
+        return {
+            "error_code": alarm.get("errorCode"),
+            "title": default.get("title"),
+            "text": default.get("text"),
+        }
+
     def _poll_is_trustworthy(self) -> bool:
         """Return True when this poll's ``alarms[]`` content can be trusted.
 
@@ -215,9 +225,16 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes.
 
-        Only the first active alarm is surfaced as top-level attributes
-        (matching how the official app highlights one alarm at a time);
-        ``active_alarm_count`` tells you if there is more than one.
+        Only the first active alarm is surfaced as top-level ``error_code``/
+        ``title``/``text`` attributes (matching how the official app
+        highlights one alarm at a time, and kept for dashboard
+        compatibility); ``active_alarms`` carries the full flattened list so
+        multiple simultaneous alarms can be identified (follow-up to PR
+        #170), and ``active_alarm_count`` tells you its length.
+
+        ``active_alarms`` is always present, defaulting to ``[]`` — like
+        ``last_known_*``/``device_offline`` below — so the attribute's shape
+        never changes between updates.
 
         ``last_known_*`` and ``device_offline`` are always present so a
         dashboard can show something better than a bare "unknown" while the
@@ -228,16 +245,16 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         attributes: dict[str, Any] = {
             "device_id": self._device_id,
             "active_alarm_count": len(active),
+            "active_alarms": [self._flatten_alarm(alarm) for alarm in active],
             "device_offline": self.device_data.get("online") is False,
             "last_known_state": self._last_known_state,
             "last_known_at": self._last_known_at.isoformat() if self._last_known_at else None,
         }
         if active:
-            first = active[0]
-            default = first.get("default") or {}
-            attributes["error_code"] = first.get("errorCode")
-            attributes["title"] = default.get("title")
-            attributes["text"] = default.get("text")
+            first = self._flatten_alarm(active[0])
+            attributes["error_code"] = first["error_code"]
+            attributes["title"] = first["title"]
+            attributes["text"] = first["text"]
         return attributes
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -413,6 +413,7 @@ def test_chlorinator_alarm_off_without_active_alarms() -> None:
     sensor = _chlorinator_alarm(_device(online=True, alarms=[cleared]))
     assert sensor.is_on is False
     assert sensor.extra_state_attributes["active_alarm_count"] == 0
+    assert sensor.extra_state_attributes["active_alarms"] == []
     assert "error_code" not in sensor.extra_state_attributes
 
 
@@ -423,6 +424,36 @@ def test_chlorinator_alarm_counts_multiple_and_surfaces_the_first() -> None:
     attrs = sensor.extra_state_attributes
     assert attrs["active_alarm_count"] == 2
     assert attrs["error_code"] == "PUMPSTOP_PH"
+    assert attrs["title"] == "pH dosing stop"
+    assert attrs["text"] == "pH pump stopped dosing"
+    assert attrs["active_alarms"] == [
+        {"error_code": "PUMPSTOP_PH", "title": "pH dosing stop", "text": "pH pump stopped dosing"},
+        {"error_code": "SALT_LOW", "title": "Low salt", "text": "Add salt"},
+    ]
+
+
+def test_chlorinator_alarm_active_alarms_covers_unlisted_error_codes() -> None:
+    """active_alarms doesn't assume a closed set of alarm types."""
+    third = {"errorCode": "SALT_HIGH", "default": {"title": "High salt", "text": "Salt too high"}, "value": True}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[PH_ALARM, third]))
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_alarm_count"] == 2
+    assert attrs["active_alarms"] == [
+        {"error_code": "PUMPSTOP_PH", "title": "pH dosing stop", "text": "pH pump stopped dosing"},
+        {"error_code": "SALT_HIGH", "title": "High salt", "text": "Salt too high"},
+    ]
+
+
+def test_chlorinator_alarm_active_alarms_excludes_malformed_entries() -> None:
+    """Junk mixed in among valid alarms is excluded from active_alarms too."""
+    second = {"errorCode": "SALT_LOW", "default": {"title": "Low salt", "text": "Add salt"}, "value": True}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=["junk", None, 42, {"no_value": 1}, PH_ALARM, second]))
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_alarm_count"] == 2
+    assert attrs["active_alarms"] == [
+        {"error_code": "PUMPSTOP_PH", "title": "pH dosing stop", "text": "pH pump stopped dosing"},
+        {"error_code": "SALT_LOW", "title": "Low salt", "text": "Add salt"},
+    ]
 
 
 def test_chlorinator_alarm_ignores_malformed_entries() -> None:


### PR DESCRIPTION
Follow-up to #163/#170/#173. `extra_state_attributes` previously surfaced only the first active alarm as flat `error_code`/`title`/`text` attributes, even when `active_alarm_count` was greater than 1 -- documented as a planned follow-up in #170's review comment.

Adds `active_alarms`: the full list of active alarms, each flattened to the same `{error_code, title, text}` shape already used for the first alarm (via a new `_flatten_alarm()` helper, reused by both). The existing flat `error_code`/`title`/`text` attributes are unchanged for backward compatibility with existing dashboards.

`active_alarms` is always present (defaulting to `[]`), matching the existing pattern for `device_offline`/`last_known_state`/`last_known_at`, so the attribute's shape never changes between updates. Malformed entries in `alarms[]` are excluded the same way `_active_alarms()` already excludes them elsewhere.

Adds tests for: multiple simultaneous alarms, an unlisted error code (`SALT_HIGH`, confirming no closed set of alarm types is assumed), and malformed entries mixed in among valid alarms.

Verified: 40/40 tests pass on Linux (aarch64, Python 3.14.6 via an isolated venv), `ruff check` and `ruff format --check` clean.

## Known alarm categories (informational, not enforced in code)

Fluidra's chlorinator manuals document these alarm categories at the panel/app level (the exact set depends on the model and which probes/features it has -- e.g. salt-only units without pH/ORP probes won't raise pH or ORP alarms):

- **PumpStop** -- dosing pump halted (e.g. `PUMPSTOP PH`, the alarm that motivated the offline guard in [#170](https://github.com/foXaCe/Fluidra-pool/pull/170))
- **Flow alarm** -- cell not flooded / no water flow
- **CLE** -- stopped by an external controller
- **CLI** -- internal chlorine setpoint not reached
- **pH high/low** -- reading out of range (distinct from PumpStop)
- **ORP (mV) high/low**
- **Conductivity/production alarm**
- **Salinity high/low** -- salt too low or too high

This list is purely for context -- **the code does not assume a closed set of alarm types**. `errorCode` is whatever string Fluidra's cloud sends verbatim; `active_alarms`/`_flatten_alarm()` pass it through unchanged. If Fluidra adds, renames, or changes an alarm code, it surfaces automatically without needing a code change here (see the `SALT_HIGH` test case, which deliberately uses a code not seen elsewhere in this repo, to pin that behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a normalized list of all active chlorinator alarms.
  * Preserved the primary active alarm details while providing additional alarm information.
  * Invalid or malformed alarm entries are excluded, and valid alarms retain their original order.

* **Bug Fixes**
  * Improved alarm reporting for cleared, multiple, unlisted, and malformed alarm conditions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->