### PR TITLE
Added support for heat pump model Zodiac Z650iQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   history across full on/off cycles): climate entity (HVAC modes, Smart+/Smart/
   Ecosilence/Boost presets, target/water/air temperature), on/off switch,
   instantaneous power sensor (Watts), running-hours and compressor-running-hours
-  sensors, and a WiFi signal sensor. Only registers whose meaning is confirmed
-  are polled — the rest stay visible through the unmapped-register debug log
-  added in 2.71.0, for whoever decodes them next.
+  sensors, a compressor-modulation sensor (percent) and a WiFi signal sensor.
+  Only registers whose meaning is confirmed are polled — the rest stay visible
+  through the unmapped-register debug log added in 2.71.0, for whoever decodes
+  them next.
 
 ### Fixed
 - **`start_pump`/`stop_pump` hardcoded component 13 as the on/off register for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Z650iQ heat pump support** — new device profile, added and reverse-engineered
+  from ~24h of live-unit captures (bulk-fetch snapshots plus Home Assistant
+  history across full on/off cycles): climate entity (HVAC modes, Smart+/Smart/
+  Ecosilence/Boost presets, target/water/air temperature), on/off switch,
+  instantaneous power sensor (Watts), running-hours and compressor-running-hours
+  sensors, and a WiFi signal sensor. Only registers whose meaning is confirmed
+  are polled — the rest stay visible through the unmapped-register debug log
+  added in 2.71.0, for whoever decodes them next.
+
+### Fixed
+- **`start_pump`/`stop_pump` hardcoded component 13 as the on/off register for
+  every heat pump family.** That's a live water-temperature register on the
+  Z650iQ, so writing 0/1 to it silently corrupted the reading instead of
+  turning the unit on/off. Both now resolve the on/off component per-family
+  via a new `on_off_component` device-config feature (still defaults to
+  component 13 for existing families, so no behavior changes for them).
+
 ## [2.71.1] - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ profile, so unknown equipment is usually still usable.
 - **Z550iQ+** — HVAC modes (heat / cool / auto), presets, HVAC action (heating/cooling/idle/no-flow), water/air temperatures
 - **Z650iQ** — HVAC modes (heat / cool / heat-cool), Smart+/Smart/Ecosilence/Boost presets,
   on/off switch, water/air temperatures, running hours, compressor running hours, WiFi
-  signal, instantaneous power (Watts). Reverse-engineered from live captures; some
-  registers remain undecoded and show up in the unmapped-register debug log.
+  signal, instantaneous power (Watts) and compressor modulation (percent). Reverse-
+  engineered from live captures; some registers remain undecoded and show up in
+  the unmapped-register
+  debug log.
 - **Gre HPGIC** — on/off, target temperature, water temperature
 - Generic heat-pump fallback
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ profile, so unknown equipment is usually still usable.
 - **Z250iQ / Z25iQ** — on/off, target temperature, current temperature
 - **Z260iQ** — HVAC modes (heat / cool / heat-cool), presets, no-flow alarm, water/air temperatures
 - **Z550iQ+** — HVAC modes (heat / cool / auto), presets, HVAC action (heating/cooling/idle/no-flow), water/air temperatures
+- **Z650iQ** — HVAC modes (heat / cool / heat-cool), Smart+/Smart/Ecosilence/Boost presets,
+  on/off switch, water/air temperatures, running hours, compressor running hours, WiFi
+  signal, instantaneous power (Watts). Reverse-engineered from live captures; some
+  registers remain undecoded and show up in the unmapped-register debug log.
 - **Gre HPGIC** — on/off, target temperature, water temperature
 - Generic heat-pump fallback
 

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -351,7 +351,14 @@ async def async_setup_entry(
         # Z260iQ-family faults reported on their own registers (Issue #139).
         # E03 no-flow (c28) was only ever an attribute on the climate entity, so it
         # couldn't drive an automation — @Kal42 rightly flagged it as missing.
+        # Z650iQ uses c39 for compressor hours (not the air-temp alarm), so
+        # that alarm key is skipped for it — the coordinator never populates
+        # "air_temperature_alarm" for this family, which would otherwise leave
+        # a permanently-off, meaningless binary_sensor entity.
         if DeviceIdentifier.has_feature(device, "z260iq_mode"):
+            alarm_keys = ["no_flow_alarm"]
+            if not DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                alarm_keys.append("air_temperature_alarm")
             entities.extend(
                 FluidraHeatPumpAlarmBinarySensor(
                     coordinator,
@@ -360,7 +367,7 @@ async def async_setup_entry(
                     device_id,
                     alarm_key,
                 )
-                for alarm_key in ("air_temperature_alarm", "no_flow_alarm")
+                for alarm_key in alarm_keys
             )
 
         # Victoria VS speed-preset dry-contact inputs (Issue #144).

--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -29,6 +29,10 @@ from .const import (
     LG_PRESET_SMART_HEATING,
     LG_VALUE_TO_MODE,
     Z550_STATE_NO_FLOW,
+    Z650_MODE_TO_VALUE,
+    Z650_PRESET_MODES,
+    Z650_PRESET_SMART_PLUS,
+    Z650_VALUE_TO_MODE,
     FluidraPoolConfigEntry,
 )
 from .device_registry import DeviceIdentifier
@@ -177,6 +181,8 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         """Return available preset modes for heat pumps with this feature."""
         # Z550iQ+ has no controllable preset: component 17 is read-only and its
         # values don't match a silence/smart/boost scheme (Issue #88).
+        if DeviceIdentifier.has_feature(self.device_data, "z650iq_mode"):
+            return Z650_PRESET_MODES
         if DeviceIdentifier.has_feature(self.device_data, "preset_modes"):
             return LG_PRESET_MODES
         return []
@@ -195,8 +201,10 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             else:
                 return self._pending_preset_mode
 
-        # LG preset modes (Z550iQ+ has no controllable preset — see preset_modes).
-        if not DeviceIdentifier.has_feature(device_data, "preset_modes"):
+        # No controllable preset for devices without preset_modes (e.g. Z550iQ+).
+        if not DeviceIdentifier.has_feature(device_data, "preset_modes") and not DeviceIdentifier.has_feature(
+            device_data, "z650iq_mode"
+        ):
             return None
 
         # Get current mode from component 14 value
@@ -204,9 +212,13 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
         if isinstance(components, dict) and "14" in components:
             reported_value = components["14"].get("reportedValue")
             if reported_value is not None:
+                if DeviceIdentifier.has_feature(device_data, "z650iq_mode"):
+                    return Z650_VALUE_TO_MODE.get(reported_value, Z650_PRESET_SMART_PLUS)
                 return LG_VALUE_TO_MODE.get(reported_value, LG_PRESET_SMART_HEATING)
 
-        # Fallback to smart heating
+        # Fallback to family default
+        if DeviceIdentifier.has_feature(device_data, "z650iq_mode"):
+            return Z650_PRESET_SMART_PLUS
         return LG_PRESET_SMART_HEATING
 
     @property
@@ -401,7 +413,14 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
 
             success = False
 
-            if DeviceIdentifier.has_feature(self.device_data, "preset_modes"):
+            if DeviceIdentifier.has_feature(self.device_data, "z650iq_mode"):
+                if preset_mode not in Z650_MODE_TO_VALUE:
+                    self._pending_preset_mode = None
+                    self._last_preset_action_time = None
+                    return
+                mode_value = Z650_MODE_TO_VALUE[preset_mode]
+                success = await self._api.control_device_component(self._device_id, 14, mode_value)
+            elif DeviceIdentifier.has_feature(self.device_data, "preset_modes"):
                 # LG heat pumps use component 14 (Z550iQ+ has no controllable preset).
                 if preset_mode not in LG_MODE_TO_VALUE:
                     self._pending_preset_mode = None
@@ -530,8 +549,26 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             attrs["component_60_raw"] = device_data.get("components", {}).get("60", {}).get("reportedValue")
             attrs["component_61_raw"] = device_data.get("components", {}).get("61", {}).get("reportedValue")
 
-        # Z260iQ specific attributes
-        if isinstance(behavior, Z260iqBehavior):
+        # Z650iQ specific attributes
+        if DeviceIdentifier.has_feature(device_data, "z650iq_mode"):
+            components = device_data.get("components", {})
+
+            def _raw(comp_id: int) -> object:
+                return components.get(str(comp_id), {}).get("reportedValue") if isinstance(components, dict) else None
+
+            attrs["heat_pump_on"] = bool(device_data.get("heat_pump_reported"))
+            attrs["preset_mode_raw"] = _raw(14)
+            attrs["water_temperature"] = device_data.get("water_temperature")
+            attrs["air_temperature"] = device_data.get("air_temperature")
+            attrs["no_flow_alarm"] = device_data.get("no_flow_alarm")
+            attrs["running_hours"] = device_data.get("running_hours")
+            attrs["compressor_running_hours"] = device_data.get("compressor_running_hours")
+            attrs["power_w"] = device_data.get("pump_power")
+            attrs["rssi_dbm"] = device_data.get("signal_strength_component")
+            attrs["firmware"] = device_data.get("firmware_version_component")
+
+        # Z260iQ specific attributes (not Z650iQ — separate branch above)
+        elif isinstance(behavior, Z260iqBehavior):
             air_temp = device_data.get("air_temperature")
             if air_temp is not None:
                 attrs["air_temperature"] = air_temp

--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .api_resilience import FluidraError
-from .climate_behaviors import Z260iqBehavior, Z550Behavior, resolve_behavior
+from .climate_behaviors import Z260iqBehavior, Z550Behavior, Z650iqBehavior, resolve_behavior
 from .const import (
     CLIMATE_OPTIMISTIC_TIMEOUT,
     DOMAIN,
@@ -284,15 +284,19 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             self.async_write_ha_state()
 
             behavior = resolve_behavior(self.device_data)
-            # Only the Z260iQ family needs the current preset (to keep the
-            # specific Smart/Boost/Silence variant), and only on a non-OFF
-            # write — its OFF branch ignores current_preset, and the original
-            # never read self.preset_mode on OFF either. Reading it more widely
-            # would needlessly trigger the property's optimistic-preset expiry
-            # side effect (clearing an expired _pending_preset_mode) on paths
-            # where the original left it untouched.
+            # Only the Z260iQ and Z650iQ families need the current preset (to
+            # keep the specific Smart/Boost/Silence/Ecosilence variant instead
+            # of resetting to their default on every mode write), and only on
+            # a non-OFF write — their OFF branch ignores current_preset, and
+            # the original never read self.preset_mode on OFF either. Reading
+            # it more widely would needlessly trigger the property's
+            # optimistic-preset expiry side effect (clearing an expired
+            # _pending_preset_mode) on paths where the original left it
+            # untouched.
             current_preset = (
-                self.preset_mode if isinstance(behavior, Z260iqBehavior) and hvac_mode != HVACMode.OFF else None
+                self.preset_mode
+                if isinstance(behavior, (Z260iqBehavior, Z650iqBehavior)) and hvac_mode != HVACMode.OFF
+                else None
             )
             success = await behavior.async_set_hvac_mode(
                 self._api, self._pool_id, self._device_id, hvac_mode, current_preset

--- a/custom_components/fluidra_pool/climate_behaviors.py
+++ b/custom_components/fluidra_pool/climate_behaviors.py
@@ -34,6 +34,10 @@ from .const import (
     Z550_STATE_IDLE,
     Z550_STATE_NO_FLOW,
     Z550_TEMP_STEP,
+    Z650_MODE_TO_VALUE,
+    Z650_PRESET_BOOST,
+    Z650_PRESET_SMART,
+    Z650_PRESET_SMART_PLUS,
 )
 from .device_registry import DeviceIdentifier
 
@@ -325,9 +329,94 @@ class LgBehavior(HeatPumpBehavior):
         return HVACAction.HEATING
 
 
+class Z650iqBehavior(HeatPumpBehavior):
+    """Z650iQ command set: component 10 (on/off), 14 (mode/preset).
+
+    Shares the mode register with the Z260iQ but not its meaning: here c14 is
+    0 = Smart+ (Heat), 1 = Boost (Cool), 2 = Smart (Heat/Cool),
+    3 = Ecosilence (Heat), whereas the Z260iQ maps 1 → Heat and 3 → Cool. A
+    shared behavior would therefore invert this unit's modes and actions.
+    """
+
+    hvac_modes: list[HVACMode] = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL]
+    min_temp: float = 15.0
+    max_temp: float = 35.0
+    temp_step: float = 0.5
+
+    def hvac_mode(self, device_data: dict[str, Any]) -> HVACMode:
+        """ON/OFF from the coordinator-decoded state, direction from component 14."""
+        heat_pump_reported = device_data.get("heat_pump_reported")
+        if heat_pump_reported is not None and not bool(heat_pump_reported):
+            return HVACMode.OFF
+        mode_value = device_data.get("z260iq_mode_value")
+        if mode_value is not None:
+            # 0=Smart+ Heat, 3=Ecosilence Heat → HEAT
+            # 1=Boost Cool → COOL
+            # 2=Smart Heat/Cool → HEAT_COOL
+            if mode_value in (0, 3):
+                return HVACMode.HEAT
+            if mode_value == 1:
+                return HVACMode.COOL
+            if mode_value == 2:
+                return HVACMode.HEAT_COOL
+        return HVACMode.HEAT if bool(heat_pump_reported) else HVACMode.OFF
+
+    def hvac_action(self, device_data: dict[str, Any], infer_heat_cool: InferHeatCoolAction) -> HVACAction:
+        """Derive the action from ON/OFF + mode direction (component 14)."""
+        heat_pump_reported = device_data.get("heat_pump_reported")
+        if heat_pump_reported is not None and not bool(heat_pump_reported):
+            return HVACAction.OFF
+        if device_data.get("no_flow_alarm"):
+            return HVACAction.IDLE
+        mode_value = device_data.get("z260iq_mode_value")
+        if mode_value == 1:  # Boost Cool
+            return HVACAction.COOLING
+        if mode_value in (0, 3):  # Smart+ Heat / Ecosilence Heat
+            return HVACAction.HEATING
+        if mode_value == 2:  # Smart Heat+Cool: infer direction from temps
+            return infer_heat_cool()
+        return HVACAction.HEATING if bool(heat_pump_reported) else HVACAction.OFF
+
+    async def async_set_hvac_mode(
+        self,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        hvac_mode: HVACMode,
+        current_preset: str | None,
+    ) -> bool | None:
+        """Z650iQ: ON/OFF via start/stop_pump, mode via component 14.
+
+        start_pump/stop_pump resolve the on/off register from the profile's
+        "on_off_component" (c10 here), so this stays family-agnostic.
+        """
+        if hvac_mode == HVACMode.OFF:
+            return await api.stop_pump(device_id)
+
+        if hvac_mode == HVACMode.HEAT:
+            # Keep current preset if it's already a heat preset, else default to Smart+
+            mode_value = Z650_MODE_TO_VALUE.get(
+                current_preset or Z650_PRESET_SMART_PLUS, Z650_MODE_TO_VALUE[Z650_PRESET_SMART_PLUS]
+            )
+            if mode_value not in (0, 3):
+                mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_SMART_PLUS]
+        elif hvac_mode == HVACMode.COOL:
+            mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_BOOST]
+        elif hvac_mode == HVACMode.HEAT_COOL:
+            mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_SMART]
+        else:
+            return None
+
+        success = await api.control_device_component(device_id, 14, mode_value)
+        if success:
+            success = await api.start_pump(device_id)
+        return success
+
+
 # Behaviors are stateless: one singleton per family is enough.
 Z550_BEHAVIOR = Z550Behavior()
 Z260IQ_BEHAVIOR = Z260iqBehavior()
+Z650IQ_BEHAVIOR = Z650iqBehavior()
 LG_BEHAVIOR = LgBehavior()
 STANDARD_BEHAVIOR = StandardBehavior()
 
@@ -339,11 +428,14 @@ def resolve_behavior(device_data: dict[str, Any]) -> HeatPumpBehavior:
     comp-7 signature yet) and later ones; DeviceIdentifier.identify_device is
     cached, so re-resolving on every property/action access is cheap and
     mirrors the pre-refactor per-property has_feature() checks. Precedence
-    order matches the original dispatch: z550_mode, then z260iq_mode, then
+    order matches the original dispatch: z550_mode, then z650iq_mode (before
+    z260iq_mode since it also sets z260iq_mode=True), then z260iq_mode, then
     preset_modes, else standard.
     """
     if DeviceIdentifier.has_feature(device_data, "z550_mode"):
         return Z550_BEHAVIOR
+    if DeviceIdentifier.has_feature(device_data, "z650iq_mode"):
+        return Z650IQ_BEHAVIOR
     if DeviceIdentifier.has_feature(device_data, "z260iq_mode"):
         return Z260IQ_BEHAVIOR
     if DeviceIdentifier.has_feature(device_data, "preset_modes"):

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -199,6 +199,30 @@ LG_MODE_TO_VALUE: Final = {
 
 LG_VALUE_TO_MODE: Final = {v: k for k, v in LG_MODE_TO_VALUE.items()}
 
+# Z650iQ Heat Pump constants — the Fluidra App uses different names for the
+# same component-14 register values. Only 4 of the 7 LG presets are available.
+# Mapping: App "Smart+" -> c14=0, "Boost" -> c14=1, "Smart" -> c14=2, "Ecosilence" -> c14=3
+Z650_PRESET_SMART_PLUS: Final = "smart_plus"  # Fluidra App: "Smart+" (Heat)
+Z650_PRESET_SMART: Final = "smart"  # Fluidra App: "Smart" (Heat/Cool)
+Z650_PRESET_ECOSILENCE: Final = "ecosilence"  # Fluidra App: "Ecosilence" (Heat)
+Z650_PRESET_BOOST: Final = "boost"  # Fluidra App: "Boost" (Cool)
+
+Z650_PRESET_MODES: Final = [
+    Z650_PRESET_SMART_PLUS,
+    Z650_PRESET_SMART,
+    Z650_PRESET_ECOSILENCE,
+    Z650_PRESET_BOOST,
+]
+
+Z650_MODE_TO_VALUE: Final = {
+    Z650_PRESET_SMART_PLUS: 0,  # c14=0 -> Heat
+    Z650_PRESET_BOOST: 1,  # c14=1 -> Cool
+    Z650_PRESET_SMART: 2,  # c14=2 -> Heat/Cool
+    Z650_PRESET_ECOSILENCE: 3,  # c14=3 -> Heat
+}
+
+Z650_VALUE_TO_MODE: Final = {v: k for k, v in Z650_MODE_TO_VALUE.items()}
+
 # Z260iQ Heat Pump constants
 Z260_MIN_TEMP: Final = 7.0
 Z260_MAX_TEMP: Final = 40.0

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from ..api_resilience import FluidraConnectionError, FluidraError
 from ..const import (
     BULK_FETCH_FAILURE_LIMIT,
+    COMPONENT_HEAT_PUMP_SETPOINT,
     CONNECTION_ISSUE_THRESHOLD,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_TYPE_CHLORINATOR,
@@ -319,7 +320,8 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if bc_info_layout:
                 if not DeviceIdentifier.has_feature(device, "skip_signal"):
                     device["signal_strength_component"] = reported_value
-            else:
+            elif not DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                # Z650iQ uses c0 for running hours, not a device-id string.
                 device["device_id_component"] = reported_value
             if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
                 try:
@@ -329,29 +331,55 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         elif component_id == 1:
             if bc_info_layout:
                 device["device_id_component"] = reported_value
+            elif DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                # Z650iQ uses c1 for WiFi RSSI (standard layout uses c2).
+                if not DeviceIdentifier.has_feature(device, "skip_signal"):
+                    device["signal_strength_component"] = reported_value
             else:
                 device["part_numbers_component"] = reported_value
         elif component_id == 2:
             if bc_info_layout:
                 # Hardware UID on Blue Connect — not an RSSI value.
                 device["part_numbers_component"] = reported_value
+            elif DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                # Z650iQ c2 is empty — c1 already holds the RSSI, don't overwrite.
+                pass
             elif not DeviceIdentifier.has_feature(device, "skip_signal"):
                 device["signal_strength_component"] = reported_value
         elif component_id == 3:
-            if not DeviceIdentifier.has_feature(device, "skip_firmware"):
+            if DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                # Z650iQ: c3 is the device serial number, not firmware (c4 = firmware).
+                device["device_id_component"] = reported_value
+            elif not DeviceIdentifier.has_feature(device, "skip_firmware"):
                 device["firmware_version_component"] = reported_value
         elif component_id == 4:
-            device["hardware_errors_component"] = reported_value
+            if DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                # Z650iQ uses c4 for firmware version (standard layout uses c3).
+                if not DeviceIdentifier.has_feature(device, "skip_firmware"):
+                    device["firmware_version_component"] = reported_value
+            else:
+                device["hardware_errors_component"] = reported_value
         elif component_id == 5:
             device["comm_errors_component"] = reported_value
         elif component_id == 9:
             device["pump_reported"] = reported_value
             device["pump_desired"] = component_state.get("desiredValue")
             device["is_running"] = bool(reported_value)
+            # Not the heat-pump on/off flag on the Z650iQ — see that profile's
+            # register map in device_registry/configs/heat_pumps.py.
         elif component_id == 10:
             device["auto_reported"] = reported_value
             device["auto_desired"] = component_state.get("desiredValue")
             device["auto_mode_enabled"] = bool(reported_value)
+            # Z650iQ: c10 is the heat-pump on/off state (1=on, 0=off), not
+            # c9 or c13. Kept in sync with the write path through the
+            # profile's `on_off_component`.
+            if (
+                DeviceIdentifier.has_feature(device, "z650iq_mode")
+                and device.get("type", "").lower() == DEVICE_TYPE_HEAT_PUMP
+            ):
+                device["heat_pump_reported"] = reported_value
+                device["is_heating"] = bool(reported_value)
         elif component_id == 11:
             device["speed_level_reported"] = reported_value
             device["speed_level_desired"] = component_state.get("desiredValue")
@@ -365,13 +393,48 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     device["speed_percent"] = PUMP_SPEED_PERCENTAGES.get(reported_value, 0)
                 else:
                     device["speed_percent"] = 0
+        elif component_id == 12:
+            device["component_12_data"] = component_state
+            # Only use c12 as the setpoint when the device config designates it
+            # as such (e.g. Z650iQ with setpoint_component=12). Other heat pumps
+            # use c15 — reading c12 as a temperature for them would be wrong.
+            if (
+                device.get("type", "").lower() == DEVICE_TYPE_HEAT_PUMP
+                and DeviceIdentifier.get_feature(device, "setpoint_component", COMPONENT_HEAT_PUMP_SETPOINT) == 12
+                and reported_value is not None
+            ):
+                try:
+                    temp_val = float(reported_value) / 10.0
+                    if 10.0 <= temp_val <= 50.0:
+                        device["target_temperature"] = temp_val
+                except (ValueError, TypeError):
+                    pass
         elif component_id == 13:
             device["component_13_data"] = component_state
             if device.get("type", "").lower() == DEVICE_TYPE_HEAT_PUMP and not DeviceIdentifier.has_feature(
                 device, "z550_mode"
             ):
-                device["heat_pump_reported"] = reported_value
-                device["is_heating"] = bool(reported_value)
+                if DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                    # Z650iQ: c13 is the water temperature (decidegrees), not an
+                    # on/off flag — writing 0/1 here would corrupt the reading.
+                    if reported_value is not None:
+                        try:
+                            temp_val = float(reported_value) / 10.0
+                            if 5.0 <= temp_val <= 50.0:
+                                device["water_temperature"] = temp_val
+                        except (ValueError, TypeError):
+                            pass
+                else:
+                    # Z260iQ family: c13 is the on/off control (0=off, 1=on).
+                    device["heat_pump_reported"] = reported_value
+                    device["is_heating"] = bool(reported_value)
+                    if reported_value is not None:
+                        try:
+                            temp_val = float(reported_value) / 10.0
+                            if 5.0 <= temp_val <= 50.0:
+                                device["water_temperature"] = temp_val
+                        except (ValueError, TypeError):
+                            pass
         elif component_id == 14:
             device["component_14_data"] = component_state
             if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
@@ -386,7 +449,13 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raw_value = reported_value if reported_value is not None else desired_value
             device["component_15_speed"] = raw_value if raw_value is not None else 0
             temp_raw = raw_value
-            if device.get("type", "").lower() == DEVICE_TYPE_HEAT_PUMP and temp_raw is not None:
+            # Skip if this device uses a different setpoint component (e.g. Z650iQ uses c12).
+            if (
+                device.get("type", "").lower() == DEVICE_TYPE_HEAT_PUMP
+                and DeviceIdentifier.get_feature(device, "setpoint_component", COMPONENT_HEAT_PUMP_SETPOINT)
+                == COMPONENT_HEAT_PUMP_SETPOINT
+                and temp_raw is not None
+            ):
                 try:
                     temp_value = float(temp_raw) / 10.0
                     if 10.0 <= temp_value <= 50.0:
@@ -440,6 +509,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         elif component_id == 40:
             device[f"component_{component_id}_data"] = component_state
             if DeviceIdentifier.has_feature(device, "z550_mode") and reported_value:
+                # Z550iQ: c40 = outdoor air temperature.
                 try:
                     air_temp = float(reported_value) / 10.0
                     if -20.0 <= air_temp <= 60.0:
@@ -447,12 +517,30 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except (ValueError, TypeError):
                     pass
             else:
+                # Left undecoded for the Z650iQ: c40 is the evaporator
+                # temperature there, and c44 carries its outdoor air reading.
                 config = DeviceIdentifier.identify_device(device)
                 device_type = config.device_type if config else device.get("type", "")
                 if device_type == DEVICE_TYPE_LIGHT:
                     schedule_data = reported_value if isinstance(reported_value, list) else []
                     device["schedule_data"] = schedule_data
                     self._track_schedule_count(pool_id, device_id, schedule_data)
+        elif component_id == 48 and DeviceIdentifier.has_feature(device, "z650iq_mode"):
+            device["component_48_data"] = component_state
+            # Instantaneous power draw in Watts. Not meter-verified — see the
+            # profile's register map for the confidence note.
+            if isinstance(reported_value, (int, float)) and not isinstance(reported_value, bool):
+                device["pump_power"] = int(reported_value)
+        elif component_id == 44 and DeviceIdentifier.has_feature(device, "z650iq_mode"):
+            device["component_44_data"] = component_state
+            # Outdoor air on the Z650iQ — c40 is the evaporator temperature there.
+            if reported_value is not None:
+                try:
+                    air_temp = float(reported_value) / 10.0
+                    if -30.0 <= air_temp <= 60.0:
+                        device["air_temperature"] = air_temp
+                except (ValueError, TypeError):
+                    pass
         elif component_id == 60:
             device["component_60_data"] = component_state
             # Z550iQ+ total running hours (raw integer h, matches
@@ -492,14 +580,22 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     pass
         elif component_id == 39:
             device["component_39_data"] = component_state
-            # Z260iQ-family error E13: intake air above ~43 °C, which makes the unit
-            # refuse to run (0 = OK, 1 = error). Identified on a Z250iQ by @Kal42
-            # (Issue #139).
-            if DeviceIdentifier.has_feature(device, "z260iq_mode") and reported_value is not None:
-                try:
-                    device["air_temperature_alarm"] = int(reported_value) != 0
-                except (ValueError, TypeError):
-                    pass
+            if reported_value is not None:
+                if DeviceIdentifier.has_feature(device, "z650iq_mode"):
+                    # Compressor runtime while actively heating — not wall-clock
+                    # hours since power-on (that is c0 / running_hours).
+                    try:
+                        device["compressor_running_hours"] = int(reported_value)
+                    except (ValueError, TypeError):
+                        pass
+                elif DeviceIdentifier.has_feature(device, "z260iq_mode"):
+                    # Z260iQ-family error E13: intake air above ~43 °C, which
+                    # makes the unit refuse to run (0=OK, 1=error). Identified
+                    # on a Z250iQ by @Kal42 (Issue #139).
+                    try:
+                        device["air_temperature_alarm"] = int(reported_value) != 0
+                    except (ValueError, TypeError):
+                        pass
         elif component_id == 67:
             device["component_67_data"] = component_state
             # Air temperature on the Z260iQ family (incl. the Z250iQ, which

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -531,6 +531,12 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # profile's register map for the confidence note.
             if isinstance(reported_value, (int, float)) and not isinstance(reported_value, bool):
                 device["pump_power"] = int(reported_value)
+        elif component_id == 32 and DeviceIdentifier.has_feature(device, "z650iq_mode"):
+            device["component_32_data"] = component_state
+            # Compressor modulation level in percent — see the profile's
+            # register map for the confidence note.
+            if isinstance(reported_value, (int, float)) and not isinstance(reported_value, bool):
+                device["compressor_modulation"] = int(reported_value)
         elif component_id == 44 and DeviceIdentifier.has_feature(device, "z650iq_mode"):
             device["component_44_data"] = component_state
             # Outdoor air on the Z650iQ — c40 is the evaporator temperature there.

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -186,6 +186,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             "sensor_compressor_hours",
             "sensor_wifi_signal",
             "sensor_power",
+            "sensor_compressor_modulation",
         ],
         features={
             "z260iq_mode": True,
@@ -209,13 +210,19 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             #   0  running hours         4  firmware       6/7 SKU/signature
             #   9  generic running flag  10 ON/OFF          12 setpoint (write)
             #  13  water temperature     14 preset/mode     28 no-flow alarm
-            #  39  compressor hours      44 outdoor air     48 power (W)
+            #  32  compressor modulation 39 compressor hrs  44 outdoor air
+            #  48  power (W)
             # Confirmed against the official app: c12 by writing, c13 (275 ==
             # 27.5 degC), c44 (395 == 39.5 degC) and c39's compressor counter
             # by reading. c48 tracked the compressor across a full day (3 W
             # idle, ~640 W at start-up, ~455-525 W settled) but is not
             # meter-verified — treat the absolute value as approximate.
-            "specific_components": [0, 4, 6, 7, 9, 10, 12, 13, 14, 28, 39, 44, 48],
+            # c32 is the compressor's modulation level in percent: 0 when it
+            # is off, and otherwise linear in the power draw at a consistent
+            # ~13 W per unit, from idling in the 30s up to 92-93 under a
+            # Boost/max-load test — a 0-100 range, not an arbitrary Hz figure.
+            # c31/c111 carry a coarser version of the same signal.
+            "specific_components": [0, 4, 6, 7, 9, 10, 12, 13, 14, 28, 32, 39, 44, 48],
         },
         priority=98,
         verified=True,

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -163,4 +163,61 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=101,
     ),
+    "z650iq_heat_pump": DeviceConfig(
+        # Canonical register map for this family — the decoders in
+        # coordinator.py, climate.py and climate_behaviors.py refer back here
+        # instead of repeating it. Derived from live-unit captures (raw bulk
+        # snapshots across on/off/compressor cycles plus a day of Home
+        # Assistant history), not from vendor documentation. Its thingType
+        # signature on c5 reads "nhpp".
+        device_type="heat_pump",
+        identifier_patterns=["ZB*"],
+        name_patterns=["z650", "z65"],
+        model_patterns=["z650", "z65"],
+        family_patterns=["heat pump"],
+        components_range=5,
+        required_components=[0, 1, 2, 3],
+        entities=[
+            "climate",
+            "switch",
+            "sensor_info",
+            "sensor_temperature",
+            "sensor_running_hours",
+            "sensor_compressor_hours",
+            "sensor_wifi_signal",
+            "sensor_power",
+        ],
+        features={
+            "z260iq_mode": True,
+            "z650iq_mode": True,
+            "preset_modes": True,
+            "temperature_control": True,
+            "hvac_modes": ["off", "heat", "cool", "heat_cool"],
+            "skip_auto_mode": True,
+            "skip_schedules": True,
+            "min_temp": 15.0,
+            "max_temp": 35.0,
+            "temp_step": 0.5,
+            "setpoint_component": 12,
+            # c9 looks like the on/off flag by analogy with other families but
+            # stays constant through real on/off toggles; c10 tracks the state
+            # exactly. Read in coordinator.py, written by start_pump/stop_pump.
+            "on_off_component": 10,
+            # Only registers with a confirmed meaning are polled, so the
+            # unmapped-register debug log (Issues #174/#175) keeps surfacing
+            # the rest for whoever decodes them next.
+            #   0  running hours         4  firmware       6/7 SKU/signature
+            #   9  generic running flag  10 ON/OFF          12 setpoint (write)
+            #  13  water temperature     14 preset/mode     28 no-flow alarm
+            #  39  compressor hours      44 outdoor air     48 power (W)
+            # Confirmed against the official app: c12 by writing, c13 (275 ==
+            # 27.5 degC), c44 (395 == 39.5 degC) and c39's compressor counter
+            # by reading. c48 tracked the compressor across a full day (3 W
+            # idle, ~640 W at start-up, ~455-525 W settled) but is not
+            # meter-verified — treat the absolute value as approximate.
+            "specific_components": [0, 4, 6, 7, 9, 10, 12, 13, 14, 28, 39, 44, 48],
+        },
+        priority=98,
+        verified=True,
+    ),
 }

--- a/custom_components/fluidra_pool/fluidra_api/_commands.py
+++ b/custom_components/fluidra_pool/fluidra_api/_commands.py
@@ -26,11 +26,14 @@ class CommandsMixin(FluidraAPIBase):
     """Convenience commands wrapping ``control_device_component`` calls."""
 
     async def set_heat_pump_temperature(self, device_id: str, temperature: float) -> bool:
-        """Set heat pump target temperature on component 15 (setpoint × 10)."""
+        """Set heat pump target temperature on setpoint component (setpoint × 10)."""
         temperature_value = int(temperature * 10)
-        success = await self.control_device_component(device_id, COMPONENT_HEAT_PUMP_SETPOINT, temperature_value)
+        device = self.get_device_by_id(device_id)
+        setpoint_comp = COMPONENT_HEAT_PUMP_SETPOINT
+        if device:
+            setpoint_comp = DeviceIdentifier.get_feature(device, "setpoint_component", COMPONENT_HEAT_PUMP_SETPOINT)
+        success = await self.control_device_component(device_id, setpoint_comp, temperature_value)
         if success:
-            device = self.get_device_by_id(device_id)
             if device:
                 device["target_temperature"] = temperature
         return success
@@ -48,10 +51,23 @@ class CommandsMixin(FluidraAPIBase):
         device = self.get_device_by_id(device_id)
         return bool(device and DeviceIdentifier.get_feature(device, "victoria_vs_mode"))
 
+    def _heat_pump_on_off_component(self, device_id: str) -> int:
+        """Resolve the on/off component for a heat pump, honoring a per-family override.
+
+        This used to hardcode component 13 for every heat pump. That register
+        is the water temperature on the Z650iQ, so the write corrupted the
+        reading instead of switching the unit.
+        """
+        device = self.get_device_by_id(device_id)
+        if device:
+            component = DeviceIdentifier.get_feature(device, "on_off_component", COMPONENT_HEAT_PUMP_ONOFF)
+            return int(component)
+        return COMPONENT_HEAT_PUMP_ONOFF
+
     async def start_pump(self, device_id: str) -> bool:
         """Start pump using the correct component based on device type."""
         if self._is_heat_pump(device_id):
-            return await self.control_device_component(device_id, COMPONENT_HEAT_PUMP_ONOFF, 1)
+            return await self.control_device_component(device_id, self._heat_pump_on_off_component(device_id), 1)
 
         start_success = await self.control_device_component(device_id, COMPONENT_PUMP_ONOFF, 1)
 
@@ -65,7 +81,7 @@ class CommandsMixin(FluidraAPIBase):
     async def stop_pump(self, device_id: str) -> bool:
         """Stop pump using the correct component based on device type."""
         if self._is_heat_pump(device_id):
-            return await self.control_device_component(device_id, COMPONENT_HEAT_PUMP_ONOFF, 0)
+            return await self.control_device_component(device_id, self._heat_pump_on_off_component(device_id), 0)
         return await self.control_device_component(device_id, COMPONENT_PUMP_ONOFF, 0)
 
     async def pause_pump(self, device_id: str) -> bool:

--- a/custom_components/fluidra_pool/manifest.json
+++ b/custom_components/fluidra_pool/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.fluidra_pool"],
   "quality_scale": "platinum",
   "requirements": ["aiohttp>=3.11.0"],
-  "version": "2.71.1"
+  "version": "2.72.0"
 }

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -12,6 +12,7 @@ from ..platform_setup import async_setup_dynamic_platform
 from .base import FluidraPoolSensorBase, FluidraPoolSensorEntity
 from .chlorinator import FluidraChlorinatorSensor
 from .device import (
+    FluidraCompressorHoursSensor,
     FluidraDeviceInfoSensor,
     FluidraLightBrightnessSensor,
     FluidraPumpActivitySensor,
@@ -22,6 +23,7 @@ from .device import (
     FluidraPumpSpeedSensor,
     FluidraRunningHoursSensor,
     FluidraTemperatureSensor,
+    FluidraWifiSignalSensor,
 )
 from .pool import (
     FluidraPoolLocationSensor,
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "FluidraChlorinatorSensor",
+    "FluidraCompressorHoursSensor",
     "FluidraDeviceInfoSensor",
     "FluidraLightBrightnessSensor",
     "FluidraPoolLocationSensor",
@@ -52,6 +55,7 @@ __all__ = [
     "FluidraPumpSpeedSensor",
     "FluidraRunningHoursSensor",
     "FluidraTemperatureSensor",
+    "FluidraWifiSignalSensor",
     "async_setup_entry",
 ]
 
@@ -112,6 +116,12 @@ async def async_setup_entry(
 
         if DeviceIdentifier.should_create_entity(device, "sensor_running_hours"):
             entities.append(FluidraRunningHoursSensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_compressor_hours"):
+            entities.append(FluidraCompressorHoursSensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_wifi_signal"):
+            entities.append(FluidraWifiSignalSensor(coordinator, coordinator.api, pool_id, device_id))
 
         # Chlorinator sensors - create based on sensors_config from device registry
         config = DeviceIdentifier.identify_device(device)

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -13,6 +13,7 @@ from .base import FluidraPoolSensorBase, FluidraPoolSensorEntity
 from .chlorinator import FluidraChlorinatorSensor
 from .device import (
     FluidraCompressorHoursSensor,
+    FluidraCompressorModulationSensor,
     FluidraDeviceInfoSensor,
     FluidraLightBrightnessSensor,
     FluidraPumpActivitySensor,
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
 __all__ = [
     "FluidraChlorinatorSensor",
     "FluidraCompressorHoursSensor",
+    "FluidraCompressorModulationSensor",
     "FluidraDeviceInfoSensor",
     "FluidraLightBrightnessSensor",
     "FluidraPoolLocationSensor",
@@ -119,6 +121,9 @@ async def async_setup_entry(
 
         if DeviceIdentifier.should_create_entity(device, "sensor_compressor_hours"):
             entities.append(FluidraCompressorHoursSensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_compressor_modulation"):
+            entities.append(FluidraCompressorModulationSensor(coordinator, coordinator.api, pool_id, device_id))
 
         if DeviceIdentifier.should_create_entity(device, "sensor_wifi_signal"):
             entities.append(FluidraWifiSignalSensor(coordinator, coordinator.api, pool_id, device_id))

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -135,6 +135,62 @@ class FluidraRunningHoursSensor(FluidraPoolSensorEntity):
         return self.device_data.get("running_hours")
 
 
+class FluidraCompressorHoursSensor(FluidraPoolSensorEntity):
+    """Compressor running hours for Z650iQ (component 39)."""
+
+    _attr_translation_key = "compressor_running_hours"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_icon = "mdi:clock-outline"
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize compressor running hours sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "compressor_hours")
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the compressor running hours."""
+        return self.device_data.get("compressor_running_hours")
+
+
+class FluidraWifiSignalSensor(FluidraPoolSensorEntity):
+    """WiFi signal strength sensor (RSSI in dBm)."""
+
+    _attr_translation_key = "wifi_signal"
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "dBm"
+    _attr_entity_category = None  # visible by default, not diagnostic-only
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize WiFi signal sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "wifi_signal")
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the WiFi RSSI in dBm."""
+        raw = self.device_data.get("signal_strength_component")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return None
+
+
 class FluidraPumpSpeedSensor(FluidraPoolSensorEntity):
     """Speed sensor for pool pumps with mode detection."""
 

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -160,6 +160,37 @@ class FluidraCompressorHoursSensor(FluidraPoolSensorEntity):
         return self.device_data.get("compressor_running_hours")
 
 
+class FluidraCompressorModulationSensor(FluidraPoolSensorEntity):
+    """Compressor modulation level for the Z650iQ (component 32), in percent.
+
+    Reads 0 while the compressor is off and rises with the power draw
+    otherwise, at a consistent ~13 W per unit whether the compressor is
+    idling near 30 or driven to 92-93 under a Boost/max-load test — a range
+    that fits a 0-100 percent scale rather than an arbitrary Hz figure.
+    """
+
+    _attr_translation_key = "compressor_modulation"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_icon = "mdi:gauge"
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the compressor modulation sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "compressor_modulation")
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the raw modulation level."""
+        value: int | None = self.device_data.get("compressor_modulation")
+        return value
+
+
 class FluidraWifiSignalSensor(FluidraPoolSensorEntity):
     """WiFi signal strength sensor (RSSI in dBm)."""
 

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -207,6 +207,9 @@
       "chlorinator_water_temperature": {
         "name": "Water Temperature"
       },
+      "compressor_modulation": {
+        "name": "Compressor Modulation"
+      },
       "compressor_running_hours": {
         "name": "Compressor Running Hours"
       },

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -207,6 +207,9 @@
       "chlorinator_water_temperature": {
         "name": "Water Temperature"
       },
+      "compressor_running_hours": {
+        "name": "Compressor Running Hours"
+      },
       "current_temperature": {
         "name": "Current Temperature"
       },
@@ -290,6 +293,9 @@
       },
       "weather_temperature": {
         "name": "Weather Temperature"
+      },
+      "wifi_signal": {
+        "name": "WiFi Signal"
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/switch/heater.py
+++ b/custom_components/fluidra_pool/switch/heater.py
@@ -71,6 +71,8 @@ class FluidraHeatPumpSwitch(FluidraPoolSwitchEntity):
                 success = await self._api.control_device_component(self._device_id, 21, 1)
                 _LOGGER.debug("Z550iQ+ turn ON result: %s", success)
             else:
+                # start_pump() resolves the correct on/off component itself via
+                # the device's "on_off_component" feature (defaults to c13).
                 success = await self._api.start_pump(self._device_id)
 
             if success:
@@ -101,6 +103,8 @@ class FluidraHeatPumpSwitch(FluidraPoolSwitchEntity):
                 success = await self._api.control_device_component(self._device_id, 21, 0)
                 _LOGGER.debug("Z550iQ+ turn OFF result: %s", success)
             else:
+                # stop_pump() resolves the correct on/off component itself via
+                # the device's "on_off_component" feature (defaults to c13).
                 success = await self._api.stop_pump(self._device_id)
 
             if success:
@@ -122,7 +126,7 @@ class FluidraHeatPumpSwitch(FluidraPoolSwitchEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         attrs: dict[str, Any] = {
-            "component_id": 9,
+            "component_id": DeviceIdentifier.get_feature(self.device_data, "on_off_component", 13),
             "operation": "heat_pump_control",
             "device_type": "heat_pump",
             "heat_pump_reported": self.device_data.get("heat_pump_reported"),

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -207,6 +207,9 @@
       "chlorinator_water_temperature": {
         "name": "Water Temperature"
       },
+      "compressor_modulation": {
+        "name": "Compressor Modulation"
+      },
       "compressor_running_hours": {
         "name": "Compressor Running Hours"
       },

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -207,6 +207,9 @@
       "chlorinator_water_temperature": {
         "name": "Water Temperature"
       },
+      "compressor_running_hours": {
+        "name": "Compressor Running Hours"
+      },
       "current_temperature": {
         "name": "Current Temperature"
       },
@@ -290,6 +293,9 @@
       },
       "weather_temperature": {
         "name": "Weather Temperature"
+      },
+      "wifi_signal": {
+        "name": "WiFi Signal"
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -207,6 +207,12 @@
       "chlorinator_water_temperature": {
         "name": "Temperatura del Agua"
       },
+      "compressor_modulation": {
+        "name": "Modulación del compresor"
+      },
+      "compressor_running_hours": {
+        "name": "Horas de funcionamiento del compresor"
+      },
       "current_temperature": {
         "name": "Temperatura Actual"
       },
@@ -290,6 +296,9 @@
       },
       "weather_temperature": {
         "name": "Temperatura Meteorológica"
+      },
+      "wifi_signal": {
+        "name": "Señal wifi"
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -207,6 +207,12 @@
       "chlorinator_water_temperature": {
         "name": "Température de l'Eau"
       },
+      "compressor_modulation": {
+        "name": "Modulation du compresseur"
+      },
+      "compressor_running_hours": {
+        "name": "Heures de fonctionnement du compresseur"
+      },
       "current_temperature": {
         "name": "Température Actuelle"
       },
@@ -290,6 +296,9 @@
       },
       "weather_temperature": {
         "name": "Température Météo"
+      },
+      "wifi_signal": {
+        "name": "Signal Wi-Fi"
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -207,6 +207,12 @@
       "chlorinator_water_temperature": {
         "name": "Temperatura da Água"
       },
+      "compressor_modulation": {
+        "name": "Modulação do compressor"
+      },
+      "compressor_running_hours": {
+        "name": "Horas de funcionamento do compressor"
+      },
       "current_temperature": {
         "name": "Temperatura Atual"
       },
@@ -290,6 +296,9 @@
       },
       "weather_temperature": {
         "name": "Temperatura Clima"
+      },
+      "wifi_signal": {
+        "name": "Sinal Wi-Fi"
       }
     },
     "switch": {

--- a/tests/test_climate_full.py
+++ b/tests/test_climate_full.py
@@ -919,6 +919,23 @@ async def test_z650iq_set_preset_mode_ignores_unknown_preset() -> None:
     assert climate._pending_preset_mode is None
 
 
+async def test_z650iq_set_hvac_mode_heat_preserves_ecosilence_preset() -> None:
+    """Re-selecting HEAT while already on Ecosilence must not reset to Smart+.
+
+    async_set_hvac_mode passes the climate entity's *current* preset into the
+    behavior so it can keep it; the caller has to recognize Z650iqBehavior for
+    that plumbing to actually reach it (CodeRabbit finding).
+    """
+    api = _api()
+    climate = _make(_pin(features=_Z650, components={"14": {"reportedValue": 3}}), api)
+    assert climate.preset_mode == Z650_PRESET_ECOSILENCE  # sanity: currently on Ecosilence
+
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    api.control_device_component.assert_awaited_once_with(DEVICE_ID, 14, 3)  # Ecosilence, not Smart+
+    api.start_pump.assert_awaited_once_with(DEVICE_ID)
+
+
 def test_extra_state_attributes_z650iq_branch() -> None:
     """The Z650iQ branch reports coordinator-decoded values, not raw registers."""
     climate = _make(

--- a/tests/test_climate_full.py
+++ b/tests/test_climate_full.py
@@ -43,6 +43,11 @@ from custom_components.fluidra_pool.const import (
     Z550_STATE_HEATING,
     Z550_STATE_IDLE,
     Z550_STATE_NO_FLOW,
+    Z650_PRESET_BOOST,
+    Z650_PRESET_ECOSILENCE,
+    Z650_PRESET_MODES,
+    Z650_PRESET_SMART,
+    Z650_PRESET_SMART_PLUS,
 )
 
 POOL_ID = "pool-1"
@@ -860,6 +865,88 @@ async def test_set_preset_mode_api_exception_wrapped() -> None:
     with pytest.raises(HomeAssistantError):
         await climate.async_set_preset_mode(LG_PRESET_SMART_HEATING)
     assert climate._pending_preset_mode is None
+
+
+# --- Z650iQ family (Issue: new profile) --------------------------------
+
+_Z650 = {"z650iq_mode": True, "z260iq_mode": True, "preset_modes": True}
+
+
+def test_z650iq_preset_modes_are_the_app_four() -> None:
+    """Z650iQ exposes its own four presets, not the seven LG ones."""
+    assert _make(_pin(features=_Z650)).preset_modes == Z650_PRESET_MODES
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, Z650_PRESET_SMART_PLUS),
+        (1, Z650_PRESET_BOOST),
+        (2, Z650_PRESET_SMART),
+        (3, Z650_PRESET_ECOSILENCE),
+    ],
+)
+def test_z650iq_preset_mode_from_component_14(raw: int, expected: str) -> None:
+    """c14 uses a different mapping than the Z260iQ (1=Cool/3=Heat there)."""
+    climate = _make(_pin(features=_Z650, components={"14": {"reportedValue": raw}}))
+    assert climate.preset_mode == expected
+
+
+def test_z650iq_preset_mode_defaults_without_component_14() -> None:
+    """No c14 reading yet -> fall back to the family default, not the LG one."""
+    assert _make(_pin(features=_Z650)).preset_mode == Z650_PRESET_SMART_PLUS
+
+
+def test_z650iq_preset_mode_unknown_raw_falls_back() -> None:
+    """An unmapped c14 value must not raise."""
+    climate = _make(_pin(features=_Z650, components={"14": {"reportedValue": 99}}))
+    assert climate.preset_mode == Z650_PRESET_SMART_PLUS
+
+
+async def test_z650iq_set_preset_mode_writes_component_14() -> None:
+    api = _api()
+    climate = _make(_pin(features=_Z650), api)
+    await climate.async_set_preset_mode(Z650_PRESET_BOOST)
+    api.control_device_component.assert_awaited_once_with(DEVICE_ID, 14, 1)
+
+
+async def test_z650iq_set_preset_mode_ignores_unknown_preset() -> None:
+    """An LG-only preset name is not writable on this family."""
+    api = _api()
+    climate = _make(_pin(features=_Z650), api)
+    await climate.async_set_preset_mode(LG_PRESET_SMART_HEATING)
+    api.control_device_component.assert_not_awaited()
+    assert climate._pending_preset_mode is None
+
+
+def test_extra_state_attributes_z650iq_branch() -> None:
+    """The Z650iQ branch reports coordinator-decoded values, not raw registers."""
+    climate = _make(
+        _pin(
+            features=_Z650,
+            heat_pump_reported=1,
+            water_temperature=27.5,
+            air_temperature=23.0,
+            running_hours=72,
+            compressor_running_hours=15,
+            pump_power=642,
+            signal_strength_component=-52,
+            firmware_version_component="1.5.0",
+            no_flow_alarm=False,
+            components={"14": {"reportedValue": 3}},
+        )
+    )
+    attrs = climate.extra_state_attributes
+    assert attrs["heat_pump_on"] is True
+    assert attrs["preset_mode_raw"] == 3
+    assert attrs["water_temperature"] == 27.5
+    assert attrs["air_temperature"] == 23.0
+    assert attrs["running_hours"] == 72
+    assert attrs["compressor_running_hours"] == 15
+    assert attrs["power_w"] == 642
+    assert attrs["rssi_dbm"] == -52
+    assert attrs["firmware"] == "1.5.0"
+    assert attrs["no_flow_alarm"] is False
 
 
 # --- extra_state_attributes --------------------------------------------

--- a/tests/test_coordinator_components.py
+++ b/tests/test_coordinator_components.py
@@ -360,6 +360,25 @@ async def test_component_44_air_temperature_for_z650iq(coordinator: FluidraDataU
     assert device["air_temperature"] == 39.5
 
 
+async def test_component_32_compressor_modulation_for_z650iq(
+    coordinator: FluidraDataUpdateCoordinator,
+) -> None:
+    """c32 is the compressor modulation level (0 = compressor off)."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 32, {"reportedValue": 52})
+    assert device["compressor_modulation"] == 52
+
+    coordinator._process_component_state(device, "pool_001", 32, {"reportedValue": 0})
+    assert device["compressor_modulation"] == 0
+
+
+async def test_component_32_ignored_without_z650iq_mode(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c32 means something else on other families — don't decode it there."""
+    device = _pinned_device(device_type="heat_pump")
+    coordinator._process_component_state(device, "pool_001", 32, {"reportedValue": 52})
+    assert "compressor_modulation" not in device
+
+
 async def test_component_48_power_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
     """c48 is the instantaneous power draw in Watts."""
     device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True})

--- a/tests/test_coordinator_components.py
+++ b/tests/test_coordinator_components.py
@@ -284,6 +284,89 @@ async def test_component_19_out_of_range_ignored(coordinator: FluidraDataUpdateC
     assert "water_temperature" not in device
 
 
+# --- Z650iQ-specific paths (components 9, 10, 12, 13, 39, 44, 48, 31/111, 130) ---
+
+
+async def test_component_9_does_not_set_heat_pump_reported_for_z650iq(
+    coordinator: FluidraDataUpdateCoordinator,
+) -> None:
+    """c9 stayed constant across real on/off toggles — it must NOT drive on/off."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True, "z260iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 9, {"reportedValue": 1})
+    assert "heat_pump_reported" not in device
+    assert device["pump_reported"] == 1  # still recorded generically
+
+
+async def test_component_10_heat_pump_on_off_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c10 is the confirmed on/off register for this family."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True, "z260iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 10, {"reportedValue": 1})
+    assert device["heat_pump_reported"] == 1
+    assert device["is_heating"] is True
+
+    coordinator._process_component_state(device, "pool_001", 10, {"reportedValue": 0})
+    assert device["heat_pump_reported"] == 0
+    assert device["is_heating"] is False
+
+
+async def test_component_10_auto_mode_unaffected_for_non_z650iq_devices(
+    coordinator: FluidraDataUpdateCoordinator,
+) -> None:
+    """c10 keeps its generic auto-mode meaning for pumps and other families."""
+    device = _pinned_device(device_type="pump")
+    coordinator._process_component_state(device, "pool_001", 10, {"reportedValue": 1})
+    assert device["auto_mode_enabled"] is True
+    assert "heat_pump_reported" not in device
+
+
+async def test_component_12_setpoint_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c12 raw 280 → 28.0°C target when setpoint_component=12 (Z650iQ)."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True, "setpoint_component": 12})
+    coordinator._process_component_state(device, "pool_001", 12, {"reportedValue": 280})
+    assert device["target_temperature"] == 28.0
+
+
+async def test_component_15_ignored_when_setpoint_component_is_12(
+    coordinator: FluidraDataUpdateCoordinator,
+) -> None:
+    """The generic c15 setpoint path must defer to a family's setpoint_component override."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True, "setpoint_component": 12})
+    coordinator._process_component_state(device, "pool_001", 15, {"reportedValue": 500})
+    assert "target_temperature" not in device
+
+
+async def test_component_13_water_temperature_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c13 is the current water temperature on this family, NOT on/off (unlike Z260iQ)."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 13, {"reportedValue": 275})
+    assert device["water_temperature"] == 27.5
+    assert "heat_pump_reported" not in device
+
+
+async def test_component_39_compressor_running_hours_for_z650iq(
+    coordinator: FluidraDataUpdateCoordinator,
+) -> None:
+    """c39 is compressor running hours here, not the Z260iQ air-temperature alarm."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True, "z260iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 39, {"reportedValue": 12})
+    assert device["compressor_running_hours"] == 12
+    assert "air_temperature_alarm" not in device
+
+
+async def test_component_44_air_temperature_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c44 raw 395 → 39.5°C outdoor air (Z650iQ only — c40 is refrigerant temp)."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 44, {"reportedValue": 395})
+    assert device["air_temperature"] == 39.5
+
+
+async def test_component_48_power_for_z650iq(coordinator: FluidraDataUpdateCoordinator) -> None:
+    """c48 is the instantaneous power draw in Watts."""
+    device = _pinned_device(device_type="heat_pump", features={"z650iq_mode": True})
+    coordinator._process_component_state(device, "pool_001", 48, {"reportedValue": 642})
+    assert device["pump_power"] == 642
+
+
 async def test_component_62_heat_pump_water_temp(coordinator: FluidraDataUpdateCoordinator) -> None:
     """Components 62 and 65 are alternate water-temp paths used by some heat pumps."""
     device = _pinned_device(device_type="heat_pump")

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -787,10 +787,11 @@ class TestIdentifyDevice:
         specific = config.features["specific_components"]
         # ON/OFF (10), setpoint (12), water temp (13), compressor hours (39),
         # outdoor air (44) and power (48) all have a decoder + entity.
-        for component in (10, 12, 13, 39, 44, 48):
+        for component in (10, 12, 13, 32, 39, 44, 48):
             assert component in specific
         assert "sensor_power" in config.entities
         assert "sensor_compressor_hours" in config.entities
+        assert "sensor_compressor_modulation" in config.entities
         # Undecoded candidates must NOT be scanned.
         for undecoded in (31, 111, 130, 115, 116, 118):
             assert undecoded not in specific

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -755,6 +755,46 @@ class TestIdentifyDevice:
         # Presets stay disabled for this unit (component 17 is read-only).
         assert config.features.get("preset_modes") is not True
 
+    def test_identify_z650iq_heat_pump(self):
+        device = {
+            "device_id": "ZB25230029",
+            "name": "Z650iQ",
+            "family": "heat pump",
+            "model": "",
+            "type": "heat_pump",
+        }
+        config = DeviceIdentifier.identify_device(device)
+        assert config is not None
+        assert config.device_type == "heat_pump"
+        assert config.features.get("z650iq_mode") is True
+        # Reuses the Z260iQ info-block layout (c0 running hours, c1 RSSI, ...).
+        assert config.features.get("z260iq_mode") is True
+
+    def test_z650iq_heat_pump_on_off_and_setpoint_components(self):
+        """On/off lives on c10 (not c9, despite other families) and setpoint on c12."""
+        config = DEVICE_CONFIGS["z650iq_heat_pump"]
+        assert config.features.get("on_off_component") == 10
+        assert config.features.get("setpoint_component") == 12
+
+    def test_z650iq_heat_pump_scans_only_decoded_components(self):
+        """Scan the confirmed registers, and deliberately nothing else.
+
+        Anything still undecoded is left out on purpose so the unmapped-register
+        debug log (Issues #174/#175) keeps surfacing it for future decoding,
+        rather than being polled for no benefit.
+        """
+        config = DEVICE_CONFIGS["z650iq_heat_pump"]
+        specific = config.features["specific_components"]
+        # ON/OFF (10), setpoint (12), water temp (13), compressor hours (39),
+        # outdoor air (44) and power (48) all have a decoder + entity.
+        for component in (10, 12, 13, 39, 44, 48):
+            assert component in specific
+        assert "sensor_power" in config.entities
+        assert "sensor_compressor_hours" in config.entities
+        # Undecoded candidates must NOT be scanned.
+        for undecoded in (31, 111, 130, 115, 116, 118):
+            assert undecoded not in specific
+
     def test_skip_bridge_devices(self):
         device = {
             "device_id": "BR123",

--- a/tests/test_fluidra_api_commands.py
+++ b/tests/test_fluidra_api_commands.py
@@ -86,16 +86,40 @@ async def test_start_pump_for_regular_pump_calls_pump_onoff_then_speed() -> None
 
 
 async def test_start_pump_for_heat_pump_calls_heat_pump_onoff_only() -> None:
-    """Heat pump: a single write to COMPONENT_HEAT_PUMP_ONOFF."""
+    """Heat pump: a single write to COMPONENT_HEAT_PUMP_ONOFF (the default on_off_component)."""
     api = _FakeAPI(is_heat_pump_device={"device_id": "HP-1"})
     with patch(
         "custom_components.fluidra_pool.fluidra_api._commands.DeviceIdentifier.identify_device",
-        return_value=SimpleNamespace(device_type="heat_pump"),
+        return_value=SimpleNamespace(device_type="heat_pump", features={}),
     ):
         success = await api.start_pump("HP-1")
 
     assert success is True
     api.control_device_component.assert_awaited_once_with("HP-1", COMPONENT_HEAT_PUMP_ONOFF, 1)
+
+
+async def test_heat_pump_on_off_component_falls_back_when_device_unknown() -> None:
+    """No device in cache -> the historic default (component 13) is still used."""
+    api = _FakeAPI()
+    assert api._heat_pump_on_off_component("MISSING") == COMPONENT_HEAT_PUMP_ONOFF
+
+
+async def test_start_pump_respects_on_off_component_override() -> None:
+    """A family with a non-default on/off register (e.g. Z650iQ's c10) must use it.
+
+    start_pump/stop_pump used to hardcode COMPONENT_HEAT_PUMP_ONOFF (13) for
+    every heat pump — a live water-temperature register on the Z650iQ, so the
+    write silently corrupted the reading instead of turning the unit on/off.
+    """
+    api = _FakeAPI(is_heat_pump_device={"device_id": "HP-1"})
+    with patch(
+        "custom_components.fluidra_pool.fluidra_api._commands.DeviceIdentifier.identify_device",
+        return_value=SimpleNamespace(device_type="heat_pump", features={"on_off_component": 10}),
+    ):
+        success = await api.start_pump("HP-1")
+
+    assert success is True
+    api.control_device_component.assert_awaited_once_with("HP-1", 10, 1)
 
 
 async def test_start_pump_returns_false_when_initial_write_fails() -> None:
@@ -117,10 +141,21 @@ async def test_stop_pump_routes_by_device_type() -> None:
     api = _FakeAPI(is_heat_pump_device={"device_id": "HP-1"})
     with patch(
         "custom_components.fluidra_pool.fluidra_api._commands.DeviceIdentifier.identify_device",
-        return_value=SimpleNamespace(device_type="heat_pump"),
+        return_value=SimpleNamespace(device_type="heat_pump", features={}),
     ):
         await api.stop_pump("HP-1")
     api.control_device_component.assert_awaited_once_with("HP-1", COMPONENT_HEAT_PUMP_ONOFF, 0)
+
+
+async def test_stop_pump_respects_on_off_component_override() -> None:
+    """Same on_off_component override, on the stop path."""
+    api = _FakeAPI(is_heat_pump_device={"device_id": "HP-1"})
+    with patch(
+        "custom_components.fluidra_pool.fluidra_api._commands.DeviceIdentifier.identify_device",
+        return_value=SimpleNamespace(device_type="heat_pump", features={"on_off_component": 10}),
+    ):
+        await api.stop_pump("HP-1")
+    api.control_device_component.assert_awaited_once_with("HP-1", 10, 0)
 
 
 async def test_stop_pump_regular_pump_uses_pump_onoff() -> None:

--- a/tests/test_sensor_full.py
+++ b/tests/test_sensor_full.py
@@ -16,12 +16,14 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.const import PERCENTAGE
 import pytest
 
 from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.sensor import (
     FluidraChlorinatorSensor,
     FluidraCompressorHoursSensor,
+    FluidraCompressorModulationSensor,
     FluidraDeviceInfoSensor,
     FluidraLightBrightnessSensor,
     FluidraPoolLocationSensor,
@@ -265,6 +267,32 @@ def test_compressor_hours_none_when_absent() -> None:
     """Absent compressor_running_hours -> None (not confused with running_hours)."""
     device = _pinned_device(DEVICE_ID, running_hours=999)
     sensor = FluidraCompressorHoursSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value is None
+
+
+# --------------------------------------------------------------------------- #
+# FluidraCompressorModulationSensor (Z650iQ, component 32)                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_compressor_modulation_reads_field() -> None:
+    """Modulation surfaces the raw level as a percentage."""
+    device = _pinned_device(DEVICE_ID, compressor_modulation=52)
+    sensor = FluidraCompressorModulationSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value == 52
+    assert sensor.native_unit_of_measurement == PERCENTAGE
+
+
+def test_compressor_modulation_zero_is_preserved() -> None:
+    """0 means 'compressor off' and must not be swallowed as missing data."""
+    device = _pinned_device(DEVICE_ID, compressor_modulation=0)
+    sensor = FluidraCompressorModulationSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value == 0
+
+
+def test_compressor_modulation_none_when_absent() -> None:
+    device = _pinned_device(DEVICE_ID)
+    sensor = FluidraCompressorModulationSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
     assert sensor.native_value is None
 
 
@@ -1148,6 +1176,7 @@ async def test_setup_creates_device_level_sensors_per_entities_flags() -> None:
             "sensor_brightness",
             "sensor_running_hours",
             "sensor_compressor_hours",
+            "sensor_compressor_modulation",
             "sensor_wifi_signal",
         ],
     )
@@ -1160,6 +1189,7 @@ async def test_setup_creates_device_level_sensors_per_entities_flags() -> None:
     assert FluidraLightBrightnessSensor in classes
     assert FluidraRunningHoursSensor in classes
     assert FluidraCompressorHoursSensor in classes
+    assert FluidraCompressorModulationSensor in classes
     assert FluidraWifiSignalSensor in classes
 
 

--- a/tests/test_sensor_full.py
+++ b/tests/test_sensor_full.py
@@ -21,6 +21,7 @@ import pytest
 from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.sensor import (
     FluidraChlorinatorSensor,
+    FluidraCompressorHoursSensor,
     FluidraDeviceInfoSensor,
     FluidraLightBrightnessSensor,
     FluidraPoolLocationSensor,
@@ -35,6 +36,7 @@ from custom_components.fluidra_pool.sensor import (
     FluidraPumpSpeedSensor,
     FluidraRunningHoursSensor,
     FluidraTemperatureSensor,
+    FluidraWifiSignalSensor,
     async_setup_entry,
 )
 
@@ -243,6 +245,53 @@ def test_running_hours_none_when_absent() -> None:
     """Absent running_hours -> None."""
     device = _pinned_device(DEVICE_ID)
     sensor = FluidraRunningHoursSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value is None
+
+
+# --------------------------------------------------------------------------- #
+# FluidraCompressorHoursSensor (Z650iQ, component 39)                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_compressor_hours_reads_field() -> None:
+    """Compressor hours sensor surfaces the ``compressor_running_hours`` field."""
+    device = _pinned_device(DEVICE_ID, compressor_running_hours=15)
+    sensor = FluidraCompressorHoursSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value == 15
+    assert sensor._attr_translation_key == "compressor_running_hours"
+
+
+def test_compressor_hours_none_when_absent() -> None:
+    """Absent compressor_running_hours -> None (not confused with running_hours)."""
+    device = _pinned_device(DEVICE_ID, running_hours=999)
+    sensor = FluidraCompressorHoursSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value is None
+
+
+# --------------------------------------------------------------------------- #
+# FluidraWifiSignalSensor                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_wifi_signal_reads_rssi() -> None:
+    """RSSI is surfaced as a float in dBm."""
+    device = _pinned_device(DEVICE_ID, signal_strength_component=-52)
+    sensor = FluidraWifiSignalSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value == -52.0
+    assert sensor._attr_native_unit_of_measurement == "dBm"
+
+
+def test_wifi_signal_none_when_absent() -> None:
+    """No RSSI reported -> None."""
+    device = _pinned_device(DEVICE_ID)
+    sensor = FluidraWifiSignalSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
+    assert sensor.native_value is None
+
+
+def test_wifi_signal_none_for_non_numeric() -> None:
+    """A non-numeric reading must not raise, just report unavailable."""
+    device = _pinned_device(DEVICE_ID, signal_strength_component="n/a")
+    sensor = FluidraWifiSignalSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID)
     assert sensor.native_value is None
 
 
@@ -1098,6 +1147,8 @@ async def test_setup_creates_device_level_sensors_per_entities_flags() -> None:
             "sensor_speed",
             "sensor_brightness",
             "sensor_running_hours",
+            "sensor_compressor_hours",
+            "sensor_wifi_signal",
         ],
     )
     coordinator = _setup_coordinator([device])
@@ -1108,6 +1159,8 @@ async def test_setup_creates_device_level_sensors_per_entities_flags() -> None:
     assert FluidraPumpSpeedSensor in classes
     assert FluidraLightBrightnessSensor in classes
     assert FluidraRunningHoursSensor in classes
+    assert FluidraCompressorHoursSensor in classes
+    assert FluidraWifiSignalSensor in classes
 
 
 async def test_setup_temperature_target_only() -> None:


### PR DESCRIPTION
## Description

My heat pump model (Zodiac Z650iQ) was not working correctly with the existing compatibility mode. I reverse-engineered the protocol by analyzing the communication and added support for the Z650iQ model.

As I'm not familiar with Python, I used AI as an implementation aid. The implementation has been tested on my own heat pump running firmware 1.5.0. I tested all functionality that I could reasonably verify, although I wasn't able to trigger hardware error conditions. The changes are intended to be limited to the new model and should not affect support for existing models.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [X] New device support

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have tested on actual Fluidra hardware (if applicable)
- [ ] All CI checks pass
- [X] I have updated the documentation (if needed)

## Related Issues

Fixes #

## Device Testing (if applicable)

- [X] Tested on: Zodiac Z650iQ heat pump
- [X] Firmware version: 1.5.0

## Screenshots (if applicable)
<img width="1192" height="828" alt="Bildschirmfoto 2026-08-03 um 14 19 32" src="https://github.com/user-attachments/assets/a1fbec4b-4936-47f2-b9b4-5fe40c0add93" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Z650iQ heat pumps, including heating/cooling modes, presets, temperature control, alarms, power, runtime, compressor modulation, and Wi‑Fi monitoring.
  - Added compressor hours, modulation, and Wi‑Fi signal sensors.
- **Bug Fixes**
  - Heat-pump controls now use the correct device-specific components for temperature and power changes.
  - Improved alarm handling for supported heat-pump models.
- **Documentation**
  - Updated hardware documentation and changelog with Z650iQ support details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->