### PR TITLE
fix: reject malformed alarm entries with non-dict default before flattening

### DIFF
--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -158,9 +158,17 @@ class FluidraChlorinatorAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity)
         return self.coordinator.last_update_success and bool(self.device_data)
 
     def _active_alarms(self) -> list[dict[str, Any]]:
-        """Return the alarm entries whose ``value`` is currently truthy."""
+        """Return raw alarm entries currently active, filtering out malformed ones."""
         alarms = self.device_data.get("alarms") or []
-        return [alarm for alarm in alarms if isinstance(alarm, dict) and alarm.get("value")]
+        valid = []
+        for alarm in alarms:
+            if not isinstance(alarm, dict) or not alarm.get("value"):
+                continue
+            default = alarm.get("default")
+            if default is not None and not isinstance(default, dict):
+                continue
+            valid.append(alarm)
+        return valid
 
     @staticmethod
     def _flatten_alarm(alarm: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -456,6 +456,18 @@ def test_chlorinator_alarm_active_alarms_excludes_malformed_entries() -> None:
     ]
 
 
+def test_chlorinator_alarm_active_alarms_excludes_malformed_default() -> None:
+    """An active alarm with a non-dict `default` is excluded, not raised."""
+    valid = {"errorCode": "SALT_LOW", "default": {"title": "Low salt", "text": "Add salt"}, "value": True}
+    malformed = {"errorCode": "WEIRD", "default": "invalid", "value": True}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[valid, malformed]))
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_alarm_count"] == 1
+    assert attrs["active_alarms"] == [
+        {"error_code": "SALT_LOW", "title": "Low salt", "text": "Add salt"},
+    ]
+
+
 def test_chlorinator_alarm_ignores_malformed_entries() -> None:
     """Junk in alarms[] is skipped rather than crashing or counting."""
     sensor = _chlorinator_alarm(_device(online=True, alarms=["junk", None, 42, {"no_value": 1}, PH_ALARM]))

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -468,6 +468,22 @@ def test_chlorinator_alarm_active_alarms_excludes_malformed_default() -> None:
     ]
 
 
+def test_chlorinator_alarm_active_alarms_treats_none_default_as_missing() -> None:
+    """An explicit `default: None` is treated the same as a missing `default` key --
+    intentional: it doesn't crash, it just yields title/text as None, same as any
+    other alarm with partial data. Rejecting it would silently drop a real active
+    alarm just because detail fields are absent (see PR discussion)."""
+    valid = {"errorCode": "SALT_LOW", "default": {"title": "Low salt", "text": "Add salt"}, "value": True}
+    none_default = {"errorCode": "UNKNOWN_CODE", "default": None, "value": True}
+    sensor = _chlorinator_alarm(_device(online=True, alarms=[valid, none_default]))
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_alarm_count"] == 2
+    assert attrs["active_alarms"] == [
+        {"error_code": "SALT_LOW", "title": "Low salt", "text": "Add salt"},
+        {"error_code": "UNKNOWN_CODE", "title": None, "text": None},
+    ]
+
+
 def test_chlorinator_alarm_ignores_malformed_entries() -> None:
     """Junk in alarms[] is skipped rather than crashing or counting."""
     sensor = _chlorinator_alarm(_device(online=True, alarms=["junk", None, 42, {"no_value": 1}, PH_ALARM]))


### PR DESCRIPTION
Fixes a crash introduced by #179 (merged as 61b7ee4, present in v2.72.0 and v2.73.0).

`_active_alarms()` validated that each entry was a dict with a truthy `value`, but not that `default` was itself a dict. An active entry (`value` truthy) with a non-dict `default` reached `_flatten_alarm()` and raised `AttributeError` on `default.get(...)`.

Filters out entries where `default` is present but not a dict, before they're counted or flattened. Deliberately narrower than CodeRabbit's suggested diff on #179, which also required `errorCode`/`title`/`text` to all be `str` and `value` to be exactly `True` -- that would silently drop real active alarms with partial data (missing title/text) instead of just rejecting the malformed shape that crashes. Only the crash-causing case is rejected; the truthy-value criterion for "active" is unchanged.

Adds a regression test for the malformed-default case.

Verified: 41/41 tests pass on Linux (aarch64, Python 3.14.6), `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alarm handling by ignoring malformed active alarm entries instead of producing errors.
  * Valid active alarms continue to be counted and displayed correctly.

* **Tests**
  * Added regression coverage for malformed alarm data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->