### PR TITLE
fix(chlorinator): map live pH and salinity sensors for CC24018506

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -595,13 +595,23 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         #   c172 = 315 → water temperature 31.5 °C
         #   c16  = 740 → pH setpoint 7.40   c20 = 710 → ORP setpoint 710 mV
         #   c4/c164     → chlorination level write/read (legacy slots; no c10)
-        # This bridge exposes no live pH-measured component (c165 absent; c8 is
-        # only the pH-setpoint write echo, dropping to 0 when the dosing pump is
-        # idle) and no live salinity (c185 stays 0; the app reads it from a
-        # different endpoint), so neither sensor is mapped rather than surfacing a
-        # misleading value. c20 is the ORP setpoint, not a 0/1/2 mode register, so
-        # the mode select is skipped (it would map 710 → "off" and clobber the
-        # setpoint on write).
+        # Live pH (c165) and salinity (c174) confirmed 2026-08-04 by calling
+        # get_component_state() directly for these ids and comparing against the
+        # official app in real time: c165 tracked a deliberate setpoint change
+        # (747→746 while correcting toward a new 7.2 target, distinct from the
+        # setpoint registers c8/c16 themselves) and matched app readings within
+        # normal drift (7.46-7.47 vs the app's 7.5); c174 matched exactly on a
+        # second read (460 vs the app's 4.6) after an initial spurious spike (680)
+        # that doesn't reflect a real salinity change — a transient glitch, not a
+        # mapping error (same category as the c8==0 glitch the existing value==0
+        # guard already handles for ph/orp).
+        # The earlier "c165 absent / no live salinity" conclusion (2026-07-04) was
+        # reached by comparing c165 against c8 — itself only a write echo, not a
+        # real reading — and by c165/c174 sitting outside specific_components at
+        # the time, so they never reached coordinator.data/diagnostics. Not a
+        # per-account read restriction; that earlier comparison was circular.
+        # c20 is the ORP setpoint, not a 0/1/2 mode register, so the mode select is
+        # skipped (it would map 710 → "off" and clobber the setpoint on write).
         identifier_patterns=["CC24018506*"],
         family_patterns=["chlorinator"],
         components_range=25,
@@ -616,8 +626,10 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
             "sensors": {
                 "orp": 170,  # Calibrated ORP — matches the app (c177 is raw).
                 "temperature": 172,  # 315 = 31.5 °C.
+                "ph": 165,  # Confirmed live pH probe reading — see profile comment.
+                "salinity": 174,  # Confirmed live salinity — see profile comment.
             },
-            "specific_components": [4, 8, 11, 16, 20, 164, 170, 172, 245],
+            "specific_components": [4, 8, 11, 16, 20, 164, 165, 170, 172, 174, 245],
         },
         priority=90,
     ),

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -265,8 +265,13 @@ class TestDeviceConfigRegistry:
         }
         assert DeviceIdentifier.identify_device(device) is config
 
-    def test_cc24018506_energy_connect_calibrated_orp_no_fake_ph_salinity(self):
-        """Energy Connect CC24018506 uses calibrated ORP (c170) and drops the fake pH/salinity (Issue #129)."""
+    def test_cc24018506_energy_connect_calibrated_orp_ph_salinity(self):
+        """Energy Connect CC24018506 uses calibrated ORP (c170) plus confirmed live pH
+        (c165) and salinity (c174), corrected 2026-08-04 after comparing live reads
+        against the official app disproved the earlier 2026-07-04 "fake sensor"
+        conclusion — which had compared c165 against c8 (itself only a write echo,
+        not a real reading), a circular comparison, not evidence the components
+        were actually absent from the device."""
         config = DEVICE_CONFIGS["cc24018506_chlorinator"]
         device = {
             "device_id": "CC24018506.nn_1",
@@ -282,14 +287,15 @@ class TestDeviceConfigRegistry:
         # Calibrated ORP (c170), not the raw/uncalibrated c177 the generic profile used.
         assert sensors["orp"] == 170
         assert sensors["temperature"] == 172  # 315 = 31.5 °C, not read as pH.
-        # No live pH-measured / salinity component on this bridge -> no misleading sensor.
-        assert "ph" not in sensors
-        assert "salinity" not in sensors
+        # Confirmed live pH probe (c165) and salinity (c174) — see profile comment.
+        assert sensors["ph"] == 165
+        assert sensors["salinity"] == 174
         # c20 is the ORP setpoint, not a mode register -> the broken mode select is skipped.
         assert config.features["skip_mode_select"] is True
         assert config.features["ph_setpoint"] == {"write": 8, "read": 16}
         assert config.features["orp_setpoint"] == {"write": 11, "read": 20}
         assert config.features["chlorination_level"] == {"write": 4, "read": 164}
+        assert set(config.features["specific_components"]) >= {165, 174}
 
     def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):
         """Ei2 iQ 20 pH Evo CC26010842 maps on the pH-only tecnoLC2 layout (Issue #104)."""


### PR DESCRIPTION
Corrects the CC24018506 profile (Issue #129), which mapped calibrated ORP (c170) and temperature (c172) but left pH and salinity unmapped based on a 2026-07-04 conclusion that turned out to be wrong.

That earlier conclusion compared c165 against c8 (a setpoint write echo, not a real sensor reading) -- a circular comparison -- and c165/c174 were simply outside `specific_components` at the time, so they never reached `coordinator.data` or diagnostics to be checked properly.

Live verification today via `get_component_state()`, compared against the official app in real time:
- `c165` (pH): tracked a deliberate setpoint change (747→746 while correcting toward a new 7.2 target, distinct from the setpoint registers c8/c16 themselves) and matched the app within normal drift (7.46-7.47 vs app's 7.5)
- `c174` (salinity): matched exactly on a second read (460 vs app's 4.6), after an initial spurious spike (680) that doesn't reflect a real salinity change -- a transient glitch, not a mapping error

Adds `ph: 165` and `salinity: 174` to the profile's `sensors` dict and to `specific_components`. No changes to `sensor/chlorinator.py` -- the existing `value == 0` guard already covers both sensor types.

Updates the corresponding test with the corrected explanation and new assertions.

Verified: 1607/1607 tests pass, `ruff check` and `ruff format --check` clean (Python 3.14.4, WSL2).
