### PR TITLE
fix(chlorinator): map single-component write/read for CC24018506 setpoints and controls

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -650,7 +650,10 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "ph": 165,  # Confirmed live pH probe reading — see profile comment.
                 "salinity": 174,  # Confirmed live salinity — see profile comment.
             },
-            "specific_components": [4, 8, 10, 11, 16, 20, 164, 165, 170, 172, 174, 245],
+            # 103 must be listed: specific_components is the exhaustive scan set
+            # ([0,1,2,3] + this list), so an unlisted boost register is written but
+            # never read back, leaving the switch snapping to off after each poll.
+            "specific_components": [4, 8, 10, 11, 16, 20, 103, 164, 165, 170, 172, 174, 245],
         },
         priority=90,
     ),

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -612,16 +612,37 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # per-account read restriction; that earlier comparison was circular.
         # c20 is the ORP setpoint, not a 0/1/2 mode register, so the mode select is
         # skipped (it would map 710 → "off" and clobber the setpoint on write).
+        # Four additional write/read pairs in this profile were inherited from the
+        # generic catch-all and never verified against the real hardware -- same
+        # root cause as the pH/salinity sensor gap fixed above. Verified 2026-08-05
+        # against v2.75.1 by writing directly to each candidate component and
+        # confirming the change in the official app in real time:
+        #   - chlorination_level: {write: 4, read: 164} -> single component 10
+        #     (the declared pair was a dead write sink; the app never reflected it)
+        #   - boost_mode: 245 (component doesn't exist on this device) -> 103
+        #   - ph_setpoint: {write: 8, read: 16} -> single component 16
+        #     (c8 was a dead write sink -- writes landed there and stayed, but the
+        #     device and app never consumed it; c16 is both the live reading the
+        #     app already showed and the component that actually accepts writes)
+        #   - orp_setpoint: {write: 11, read: 20} -> single component 20 (same
+        #     dead-sink pattern as ph_setpoint, confirmed with the same method)
+        # All four match the pattern nearly every other tecnoLC2 profile already
+        # uses (single component, not a write/read pair) -- this profile was the
+        # outlier, not the norm. Tested locally against v2.75.1 with this exact
+        # patch applied on production hardware: all four controls (chlorination
+        # level, boost mode, pH setpoint, ORP setpoint) now write correctly and
+        # the official app reflects each change within seconds, in both
+        # directions (HA->app and app->HA).
         identifier_patterns=["CC24018506*"],
         family_patterns=["chlorinator"],
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
         features={
-            "chlorination_level": {"write": 4, "read": 164},
-            "ph_setpoint": {"write": 8, "read": 16},
-            "orp_setpoint": {"write": 11, "read": 20},
-            "boost_mode": 245,
+            "chlorination_level": 10,
+            "ph_setpoint": 16,
+            "orp_setpoint": 20,
+            "boost_mode": 103,
             "skip_mode_select": True,
             "sensors": {
                 "orp": 170,  # Calibrated ORP — matches the app (c177 is raw).
@@ -629,7 +650,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "ph": 165,  # Confirmed live pH probe reading — see profile comment.
                 "salinity": 174,  # Confirmed live salinity — see profile comment.
             },
-            "specific_components": [4, 8, 11, 16, 20, 164, 165, 170, 172, 174, 245],
+            "specific_components": [4, 8, 10, 11, 16, 20, 164, 165, 170, 172, 174, 245],
         },
         priority=90,
     ),

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -265,13 +265,18 @@ class TestDeviceConfigRegistry:
         }
         assert DeviceIdentifier.identify_device(device) is config
 
-    def test_cc24018506_energy_connect_calibrated_orp_ph_salinity(self):
-        """Energy Connect CC24018506 uses calibrated ORP (c170) plus confirmed live pH
-        (c165) and salinity (c174), corrected 2026-08-04 after comparing live reads
-        against the official app disproved the earlier 2026-07-04 "fake sensor"
-        conclusion — which had compared c165 against c8 (itself only a write echo,
-        not a real reading), a circular comparison, not evidence the components
-        were actually absent from the device."""
+    def test_cc24018506_energy_connect_full_profile_fix(self):
+        """Energy Connect CC24018506 profile fix, covering four write/read pairs
+        inherited from the generic catch-all and never verified against real
+        hardware: chlorination_level, boost_mode, ph_setpoint, and orp_setpoint
+        all moved from broken/nonexistent components to the single component
+        that the official app actually uses (2026-08-05). Sensors (calibrated
+        ORP c170, live pH c165, live salinity c174) were fixed earlier
+        (2026-08-04, #184) after comparing live reads against the official app
+        disproved the earlier 2026-07-04 "fake sensor" conclusion — which had
+        compared c165 against c8 (itself only a write echo, not a real
+        reading), a circular comparison, not evidence the components were
+        actually absent from the device."""
         config = DEVICE_CONFIGS["cc24018506_chlorinator"]
         device = {
             "device_id": "CC24018506.nn_1",
@@ -292,10 +297,14 @@ class TestDeviceConfigRegistry:
         assert sensors["salinity"] == 174
         # c20 is the ORP setpoint, not a mode register -> the broken mode select is skipped.
         assert config.features["skip_mode_select"] is True
-        assert config.features["ph_setpoint"] == {"write": 8, "read": 16}
-        assert config.features["orp_setpoint"] == {"write": 11, "read": 20}
-        assert config.features["chlorination_level"] == {"write": 4, "read": 164}
-        assert set(config.features["specific_components"]) >= {165, 174}
+        # Single-component fixes (2026-08-05): the declared write/read pairs and the
+        # nonexistent boost component were all inherited from the generic catch-all
+        # and never verified against real hardware — see profile comment.
+        assert config.features["ph_setpoint"] == 16
+        assert config.features["orp_setpoint"] == 20
+        assert config.features["chlorination_level"] == 10
+        assert config.features["boost_mode"] == 103
+        assert set(config.features["specific_components"]) >= {10, 165, 174}
 
     def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):
         """Ei2 iQ 20 pH Evo CC26010842 maps on the pH-only tecnoLC2 layout (Issue #104)."""

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -304,6 +304,14 @@ class TestDeviceConfigRegistry:
         assert config.features["orp_setpoint"] == 20
         assert config.features["chlorination_level"] == 10
         assert config.features["boost_mode"] == 103
+        # specific_components is the exhaustive scan set ([0,1,2,3] + this list), so a
+        # mapped-but-unlisted register is written and never read back — the boost switch
+        # would snap to off after every poll. Assert every mapping is scanned, not just
+        # the ones this change happened to touch (CodeRabbit, PR #185).
+        scanned = set(config.features["specific_components"])
+        for feature in ("chlorination_level", "ph_setpoint", "orp_setpoint", "boost_mode"):
+            assert config.features[feature] in scanned, feature
+        assert scanned >= set(config.features["sensors"].values())
         assert set(config.features["specific_components"]) >= {10, 165, 174}
 
     def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):


### PR DESCRIPTION
Follow-up to #184. Corrects four write/read pairs in the cc24018506_chlorinator profile that were inherited from the generic catch-all and never verified against real hardware: `chlorination_level`, `boost_mode`, `ph_setpoint`, and `orp_setpoint`.

All four now use the single component the official app actually reads and writes, matching the pattern nearly every other tecnoLC2 profile already uses — this profile was the outlier, not the norm.

Verified 2026-08-05 against v2.75.1 by writing directly to each candidate component and confirming the app reflects the change in real time, in both directions (HA→app and app→HA). Also tested as a local patch on production hardware with normal user interaction — sliders, switches, both HA and the app — over an extended session, not just the diagnostic writes.

This appears to be a hardware/firmware quirk specific to this exact model rather than a systemic issue with the write/read-pair pattern itself, so no changes are proposed to other profiles.

Verified: 1611/1611 tests pass, ruff check and ruff format --check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Energy Connect chlorinator mappings for chlorination level, pH setpoint, and ORP setpoint.
  - Fixed boost mode detection and control.
  - Improved device discovery by including required components, ensuring the full chlorinator profile is recognized correctly and settings are available.
- **Tests**
  - Expanded coverage to verify all corrected settings, boost mode, and required device components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->