### PR TITLE
feat(sensor): show last known salinity reading during low chlorine production

### DIFF
--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -18,7 +19,9 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 from ..const import DOMAIN
 from ..device_registry import DeviceIdentifier
@@ -113,6 +116,14 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         self._api = api
         self._sensor_type = sensor_type
         self._component_id = component_id
+
+        # Last real (non-zero) salinity reading, held while the probe can't
+        # measure due to low production (see native_value). In-memory only —
+        # reset to None on every integration reload/HA restart until the next
+        # real reading, same lifetime as the alarm binary sensor's
+        # last-known-* pair. Unused by every other sensor_type.
+        self._last_known_value: float | None = None
+        self._last_known_at: datetime | None = None
 
         # Sensor configuration based on type
         self._sensor_config: dict[str, dict[str, Any]] = {
@@ -242,9 +253,8 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         mapped = sensors.get(self._sensor_type)
         return mapped if isinstance(mapped, int) else self._component_id
 
-    @property
-    def native_value(self) -> float | None:
-        """Return the sensor value."""
+    def _parsed_value(self) -> float | None:
+        """Return the current raw component value divided by ``_divisor``, or None."""
         components = self.device_data.get("components", {})
         component_data = components.get(str(self._resolved_component_id), {})
         raw_value = component_data.get("reportedValue")
@@ -254,8 +264,42 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
 
         try:
             value: float = float(raw_value) / self._divisor
+            return value
         except (ValueError, TypeError):
             _LOGGER.debug("Failed to parse sensor value %s for component %s", raw_value, self._component_id)
+            return None
+
+    def _update_last_known_salinity(self) -> None:
+        """Snapshot the last real (non-zero) salinity reading, once per poll.
+
+        Kept separate from ``_handle_coordinator_update`` so it can be
+        exercised in tests without a real ``hass``/entity_id. No-op for
+        every sensor_type other than salinity.
+        """
+        if self._sensor_type != "salinity":
+            return
+        value = self._parsed_value()
+        if value is not None and value != 0:
+            self._last_known_value = value
+            self._last_known_at = dt_util.utcnow()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator.
+
+        Runs once per coordinator refresh (unlike ``native_value``/
+        ``extra_state_attributes``, which HA may read multiple times per
+        update), so this is the right place for the last-known-good
+        bookkeeping rather than a side effect inside those properties.
+        """
+        self._update_last_known_salinity()
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the sensor value."""
+        value = self._parsed_value()
+        if value is None:
             return None
 
         # A pH / ORP / salinity reading of exactly 0 is physically impossible for
@@ -263,9 +307,18 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         # than a real value: a bare ORP register on a probe-less unit (Zodiac
         # eXO iQ LS optional Dual Link probe, Issue #111), a pH register that
         # only echoes the setpoint and clears to 0 when the dosing pump is idle,
-        # or a salinity slot frozen at 0 (Issue #129). Report "unknown" instead
-        # of a misleading 0; a real value surfaces automatically if it appears.
-        if value == 0 and self._sensor_type in ("orp", "ph", "salinity"):
+        # or a salinity slot that reads 0 whenever chlorination production drops
+        # below the ~40% threshold Fluidra documents for the conductivity probe
+        # (Issue #129). ORP/pH report "unknown" outright — a real value surfaces
+        # automatically if it appears. Salinity instead falls back to the last
+        # real reading (see _update_last_known_salinity), since a dashboard
+        # gauge tracking a continuously-produced measurement is more useful
+        # showing a slightly stale number than going blank every time
+        # production dips, and "unknown" is still correct if no real reading
+        # has ever been seen (e.g. right after an HA restart).
+        if value == 0 and self._sensor_type == "salinity":
+            return self._last_known_value
+        if value == 0 and self._sensor_type in ("orp", "ph"):
             return None
 
         return value
@@ -277,10 +330,17 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         components = self.device_data.get("components", {})
         component_data = components.get(str(component_id), {})
 
-        return {
+        attributes: dict[str, Any] = {
             "component_id": component_id,
             "sensor_type": self._sensor_type,
             "raw_value": component_data.get("reportedValue"),
             "divisor": self._divisor,
             "device_id": self._device_id,
         }
+
+        if self._sensor_type == "salinity":
+            attributes["last_known_value"] = self._last_known_value
+            attributes["last_known_at"] = self._last_known_at.isoformat() if self._last_known_at else None
+            attributes["low_production"] = self._parsed_value() == 0
+
+        return attributes

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -387,10 +387,61 @@ def test_chlorinator_ph_zero_reads_unknown() -> None:
 
 
 def test_chlorinator_salinity_zero_reads_unknown() -> None:
-    """A running salt cell never reads exactly 0 g/L — a frozen 0 means no reading (Issue #129)."""
+    """A running salt cell never reads exactly 0 g/L — a frozen 0 means no reading (Issue #129).
+
+    With no prior real reading captured (e.g. right after an HA restart),
+    there is nothing to fall back to, so this stays "unknown" — see
+    test_chlorinator_salinity_zero_falls_back_to_last_known_value for the
+    case where a real reading was seen earlier in the same session.
+    """
     device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 0}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
     assert sensor.native_value is None
+
+
+def test_chlorinator_salinity_zero_falls_back_to_last_known_value() -> None:
+    """Salinity holds the last real reading while production is too low to measure.
+
+    Unlike ORP/pH, a salinity probe reading 0 is a *temporary* condition
+    (Fluidra documents it as chlorination production dropping below ~40%,
+    not a hardware/echo issue), so a dashboard gauge is better served by the
+    last real value than by going blank every time production dips.
+    """
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    sensor._update_last_known_salinity()  # a trustworthy poll happened
+    assert sensor.native_value == pytest.approx(4.67)
+
+    # Production drops: the component now reports 0.
+    device["components"] = {"185": {"reportedValue": 0}}
+    sensor._update_last_known_salinity()  # no-op: 0 is not a real reading
+    assert sensor.native_value == pytest.approx(4.67)
+
+
+def test_chlorinator_salinity_extra_state_attributes_expose_last_known() -> None:
+    """The salinity sensor exposes last_known_value/at and low_production; others don't."""
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    sensor._update_last_known_salinity()
+
+    device["components"] = {"185": {"reportedValue": 0}}
+    attrs = sensor.extra_state_attributes
+    assert attrs["last_known_value"] == pytest.approx(4.67)
+    assert attrs["last_known_at"] is not None
+    assert attrs["low_production"] is True
+
+    orp_device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 738}})
+    orp_sensor = FluidraChlorinatorSensor(_coord([orp_device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
+    assert "last_known_value" not in orp_sensor.extra_state_attributes
+
+
+def test_chlorinator_salinity_last_known_update_is_a_no_op_for_other_sensor_types() -> None:
+    """`_update_last_known_salinity` only tracks salinity, mirroring the zero-value guard."""
+    device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
+    sensor._update_last_known_salinity()
+    assert sensor._last_known_value is None
+    assert sensor._last_known_at is None
 
 
 def test_chlorinator_ph_nonzero_reads_value() -> None:


### PR DESCRIPTION
The salinity probe on tecnoLC2-based chlorinators can't measure reliably when chlorine production drops below roughly 40% (documented by Fluidra), so the device reports a raw value of 0 during that window even though the device itself is online and functioning normally.

Worth framing correctly: this isn't a data-correctness bug. The existing zero-value guard (Issue #129) already did the right thing by not surfacing a misleading 0 -- that guard stays exactly as it was for ORP and pH. This is a presentation/UX improvement: holding the last known reading instead of going blank is more useful for a dashboard gauge tracking a continuously-produced measurement, but the underlying 0 reading was always accurate given the device's real state (low production), not a defect being corrected.

Extends the same last-known pattern already used by the alarm binary sensor's offline guard (#170/#173) to the salinity sensor. `extra_state_attributes` exposes `last_known_value`, `last_known_at`, and a `low_production` flag when the sensor type is salinity, so a dashboard can show 'last known: X, confirmed Y ago' instead of a blank gauge -- mirrors the alarm sensor's `device_offline`/`last_known_*` attributes.

Verified: 1623/1623 tests pass, `ruff check` and `ruff format --check` clean, mypy clean. Also verified against production hardware: lowered the ORP setpoint below the live reading to force the chlorinator to stop producing (confirmed via the official app showing 0% production and 0.0 g/L salinity), and confirmed Home Assistant's salinity sensor correctly held the last real reading (4.98 g/L) instead of dropping to zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Salinity readings now retain the most recent valid value when the device reports zero, improving measurement continuity.
  * A zero reading without any previous valid value remains unavailable.
  * pH and ORP zero readings continue to be treated as unavailable.

* **Diagnostics**
  * Added salinity details showing the cached value, when it was recorded, and whether production is currently low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->