### PR TITLE
feat(sensor): map real chlorination output percentage for CC24018506

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -633,6 +633,24 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # level, boost mode, pH setpoint, ORP setpoint) now write correctly and
         # the official app reflects each change within seconds, in both
         # directions (HA->app and app->HA).
+        # chlorination_actual (real cell output %, distinct from the c10 setpoint
+        # above) confirmed 2026-08-07. A same-value test first (consigna and real
+        # output both at 60%) couldn't tell a live sensor from a setpoint echo,
+        # since c10/c153/c154 all read 60 with no way to tell them apart. Forced
+        # a genuine split instead: lowered the ORP setpoint (c20) below the live
+        # ORP reading until the app confirmed real production had dropped to 0%,
+        # while the chlorination_level setpoint (c10) was left untouched at 60%.
+        # A component sweep at that moment showed c10 still at 60 with the exact
+        # same timestamp as before the test (never re-written -- it only reflects
+        # the configured target), while c153 and c154 had both dropped to 0 with
+        # their own fresh timestamps, seconds apart from the live ORP/salinity
+        # refresh -- a live reading, not an echo of c10. c154 is mapped here
+        # rather than c153 (which gave the identical result in this test) to
+        # match the register every other verified profile in this file already
+        # uses for chlorination_actual (cc24068402_chlorinator,
+        # cc_energy_connect_bridged_chlorinator, cc25005502_chlorinator,
+        # cc24042711_chlorinator) -- one fewer outlier in the catalog rather than
+        # a second convention for the same feature.
         identifier_patterns=["CC24018506*"],
         family_patterns=["chlorinator"],
         components_range=25,
@@ -649,11 +667,12 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "temperature": 172,  # 315 = 31.5 °C.
                 "ph": 165,  # Confirmed live pH probe reading — see profile comment.
                 "salinity": 174,  # Confirmed live salinity — see profile comment.
+                "chlorination_actual": 154,  # Real cell output % — confirmed 2026-08-07, see profile comment.
             },
             # 103 must be listed: specific_components is the exhaustive scan set
             # ([0,1,2,3] + this list), so an unlisted boost register is written but
             # never read back, leaving the switch snapping to off after each poll.
-            "specific_components": [4, 8, 10, 11, 16, 20, 103, 164, 165, 170, 172, 174, 245],
+            "specific_components": [4, 8, 10, 11, 16, 20, 103, 154, 164, 165, 170, 172, 174, 245],
         },
         priority=90,
     ),

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -295,6 +295,8 @@ class TestDeviceConfigRegistry:
         # Confirmed live pH probe (c165) and salinity (c174) — see profile comment.
         assert sensors["ph"] == 165
         assert sensors["salinity"] == 174
+        # Real cell output % (c154), confirmed 2026-08-07 — see profile comment.
+        assert sensors["chlorination_actual"] == 154
         # c20 is the ORP setpoint, not a mode register -> the broken mode select is skipped.
         assert config.features["skip_mode_select"] is True
         # Single-component fixes (2026-08-05): the declared write/read pairs and the
@@ -312,7 +314,7 @@ class TestDeviceConfigRegistry:
         for feature in ("chlorination_level", "ph_setpoint", "orp_setpoint", "boost_mode"):
             assert config.features[feature] in scanned, feature
         assert scanned >= set(config.features["sensors"].values())
-        assert set(config.features["specific_components"]) >= {10, 165, 174}
+        assert set(config.features["specific_components"]) >= {10, 154, 165, 174}
 
     def test_cc26010842_ei2_iq_20_ph_evo_ph_only_layout(self):
         """Ei2 iQ 20 pH Evo CC26010842 maps on the pH-only tecnoLC2 layout (Issue #104)."""


### PR DESCRIPTION
Adds `chlorination_actual` (component 154) to the cc24018506_chlorinator profile, giving Home Assistant a native sensor for the cell's real output percentage -- distinct from `number.clorador_48m3_nivel_de_cloracion` (component 10), which only reflects the configured setpoint and stays fixed even when the cell isn't actually producing (e.g. because the ORP setpoint is below the live ORP reading, so the cell has nothing to do).

A same-value test first (setpoint and real output both at 60%) couldn't distinguish a live sensor from a setpoint echo, since c10/c153/c154 all read 60 with no way to tell them apart. Forced a genuine split instead: lowered the ORP setpoint below the live ORP reading until the app confirmed real production had dropped to 0%, while chlorination_level was left untouched at 60%. A component sweep at that moment showed c10 frozen at 60 with its prior timestamp (never re-written), while c153 and c154 had both dropped to 0 with their own fresh timestamps -- a live reading, not an echo of c10.

c154 is mapped rather than c153 (identical result in this test) to match the register every other verified profile in this file already uses for `chlorination_actual`.

Verified: 1651 tests pass, `ruff check` and `ruff format --check` clean, mypy clean. Also verified against production hardware: forced the split described above and confirmed the new sensor tracked real output (0% while stalled, correctly climbing to 70-80% once production resumed) while the setpoint entity stayed at the configured value throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chlorinator status reporting so the live cell-output reading is detected and displayed correctly.
  - Updated device scanning to include the live chlorination output sensor, improving compatibility with affected pool systems.

- **Tests**
  - Added coverage to verify accurate live output readings and sensor discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->