### PR TITLE
perf(boot): parallelize auth-time profile and pool discovery

### DIFF
--- a/custom_components/fluidra_pool/fluidra_api/_auth.py
+++ b/custom_components/fluidra_pool/fluidra_api/_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -42,24 +43,35 @@ class AuthMixin(FluidraAPIBase):
 
         Tries the stored refresh token first to avoid MFA on every HA restart.
         Falls back to full credentials auth only when needed.
+
+        The user-profile fetch and the pool/device discovery are independent of
+        each other once the access token is valid, so they run concurrently —
+        this trims one full RTT from the boot critical path (profile and pools
+        used to be two sequential requests).
         """
         try:
             if self.refresh_token:
                 if await self.refresh_access_token():
                     _LOGGER.info("Authenticated via stored refresh token (no MFA required)")
-                    await self._get_user_profile()
-                    await self.async_update_data()
+                    await self._post_auth_discovery()
                     return
                 _LOGGER.warning("Stored refresh token expired or invalid, falling back to full auth")
 
             await self._cognito_initial_auth()
-            await self._get_user_profile()
-            await self.async_update_data()
+            await self._post_auth_discovery()
 
         except FluidraError:
             raise
         except (aiohttp.ClientError, TimeoutError, json.JSONDecodeError, KeyError) as err:
             raise FluidraAuthError(f"Authentication failed: {type(err).__name__}") from err
+
+    async def _post_auth_discovery(self) -> None:
+        """Fetch the consumer profile and discover pools/devices concurrently.
+
+        Extracted from :meth:`authenticate` so both call sites (stored-token and
+        full-auth) share the same boot-time parallelism.
+        """
+        await asyncio.gather(self._get_user_profile(), self.async_update_data())
 
     async def _cognito_initial_auth(self) -> None:
         """Perform initial AWS Cognito authentication."""

--- a/custom_components/fluidra_pool/fluidra_api/_devices.py
+++ b/custom_components/fluidra_pool/fluidra_api/_devices.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 from urllib.parse import quote
@@ -19,7 +20,14 @@ class DevicesMixin(FluidraAPIBase):
     """Pool & device discovery, caching, and polling."""
 
     async def async_update_data(self) -> None:
-        """Discover pools and devices for the account; atomic replacement at end."""
+        """Discover pools and devices for the account; atomic replacement at end.
+
+        Device discovery per pool runs concurrently: pools are independent
+        once the account's pool list is known, so a multi-pool account's boot
+        discovery drops from N sequential RTTs to one (this is on the HA boot
+        critical path via ``authenticate``). ``asyncio.gather`` keeps the
+        result order aligned with the pool list.
+        """
         headers = self._build_auth_headers()
 
         user_pools: list[dict[str, Any]] = []
@@ -33,11 +41,14 @@ class DevicesMixin(FluidraAPIBase):
                 elif isinstance(data, dict):
                     user_pools = data.get("pools", [])
 
-                for pool in user_pools:
-                    pool_id = pool.get("id")
-                    if pool_id:
-                        pool_devices = await self._discover_devices_for_pool(pool_id, headers)
-                        devices.extend(pool_devices)
+                pool_ids: list[str] = [str(pool["id"]) for pool in user_pools if pool.get("id")]
+                discovery_results = await asyncio.gather(
+                    *(self._discover_devices_for_pool(pool_id, headers) for pool_id in pool_ids),
+                    return_exceptions=True,
+                )
+                for result in discovery_results:
+                    if isinstance(result, list):
+                        devices.extend(result)
         except FluidraError as err:
             _LOGGER.warning("Failed to update data: %s", err)
             return

--- a/tests/test_fluidra_api_auth.py
+++ b/tests/test_fluidra_api_auth.py
@@ -282,6 +282,39 @@ async def test_get_user_profile_returns_empty_on_connection_error() -> None:
 # --- authenticate (high-level orchestration) -----------------------------
 
 
+async def test_post_auth_discovery_runs_profile_and_pools_concurrently() -> None:
+    """Profile fetch and pool discovery overlap in time (boot critical path).
+
+    Both only depend on the freshly-obtained access token, so they must run
+    in parallel — sequential execution would add a whole RTT to every HA
+    restart. Each stub blocks on an event released by the other's *entry*,
+    so if they ran one after another the second would deadlock forever.
+    """
+    api = _FakeAPI(refresh_token="ref-1")
+    api._request.return_value = (200, {"AuthenticationResult": _ok_auth_result()}, "{}")
+
+    profile_started = asyncio.Event()
+    discovery_started = asyncio.Event()
+
+    async def _slow_profile() -> dict:
+        profile_started.set()
+        await discovery_started.wait()
+        return {}
+
+    async def _slow_update_data() -> None:
+        discovery_started.set()
+        await profile_started.wait()
+
+    api._get_user_profile = _slow_profile
+    api.async_update_data = _slow_update_data
+
+    # A 2s cap turns a regression to sequential execution into a failure
+    # instead of an infinite hang.
+    await asyncio.wait_for(api._post_auth_discovery(), timeout=2)
+    assert profile_started.is_set()
+    assert discovery_started.is_set()
+
+
 async def test_authenticate_uses_refresh_token_first_when_available() -> None:
     """When a refresh token exists, try it before falling back to MFA-able auth."""
     api = _FakeAPI(refresh_token="ref-1")

--- a/tests/test_fluidra_api_devices.py
+++ b/tests/test_fluidra_api_devices.py
@@ -12,6 +12,7 @@ from custom_components.fluidra_pool.api_resilience import (
     FluidraCircuitBreakerError,
     FluidraConnectionError,
 )
+from custom_components.fluidra_pool.fluidra_api._constants import USER_POOLS_ENDPOINT
 from custom_components.fluidra_pool.fluidra_api._devices import DevicesMixin
 
 
@@ -77,14 +78,48 @@ async def test_async_update_data_keeps_state_unchanged_on_request_error() -> Non
 async def test_async_update_data_skips_pool_devices_when_inner_call_fails() -> None:
     """A device discovery failure for one pool doesn't break the rest."""
     api = _FakeAPI()
-    api._request.side_effect = [
-        (200, [{"id": "pool_1"}, {"id": "pool_2"}], "[]"),
-        FluidraConnectionError("fail for pool_1"),  # _discover_devices_for_pool raises.
-        (200, [{"id": "DEV-2", "info": {"name": "Pump", "family": "pump"}, "type": "connected"}], "[]"),
-    ]
+
+    async def _request(method, url, **kwargs):
+        if url == USER_POOLS_ENDPOINT:
+            return (200, [{"id": "pool_1"}, {"id": "pool_2"}], "[]")
+        if kwargs.get("params", {}).get("poolId") == "pool_1":
+            raise FluidraConnectionError("fail for pool_1")
+        return (200, [{"id": "DEV-2", "info": {"name": "Pump", "family": "pump"}, "type": "connected"}], "[]")
+
+    api._request = _request
     await api.async_update_data()
     # pool_2's devices were still discovered.
     assert any(d["device_id"] == "DEV-2" for d in api.devices)
+
+
+async def test_async_update_data_discovers_pools_concurrently() -> None:
+    """Per-pool device discovery runs in parallel (boot critical path).
+
+    Each pool's device fetch blocks on an event released by the other pool's
+    *entry*. If the pools were discovered one after another, the second fetch
+    would never start and the call would deadlock (the 2s cap turns that into
+    a failure).
+    """
+    import asyncio
+
+    api = _FakeAPI()
+    pool_1_entered = asyncio.Event()
+    pool_2_entered = asyncio.Event()
+
+    async def _request(method, url, **kwargs):
+        if url == USER_POOLS_ENDPOINT:
+            return (200, [{"id": "pool_1"}, {"id": "pool_2"}], "[]")
+        # Device-tree fetch for a pool: block until the sibling pool entered too.
+        pool_id = kwargs.get("params", {}).get("poolId")
+        event = pool_1_entered if pool_id == "pool_1" else pool_2_entered
+        event.set()
+        other = pool_2_entered if pool_id == "pool_1" else pool_1_entered
+        await other.wait()
+        return (200, [{"id": f"DEV-{pool_id}", "info": {"name": "Pump", "family": "pump"}, "type": "connected"}], "[]")
+
+    api._request = _request
+    await asyncio.wait_for(api.async_update_data(), timeout=2)
+    assert {d["device_id"] for d in api.devices} == {"DEV-pool_1", "DEV-pool_2"}
 
 
 # --- _discover_devices_for_pool ------------------------------------------


### PR DESCRIPTION
## Summary

Speed up the config-entry setup (HA boot critical path) by removing two sequential network round-trips.

**Before** — 4 sequential RTTs on every restart:
`refresh token → profile → pools → devices`

**After** — the profile fetch and the pool/device discovery only depend on the freshly-obtained access token, so they now run concurrently:

- `authenticate()` fetches the consumer profile and discovers pools in parallel (extracted into `_post_auth_discovery()`, shared by the stored-token and full-auth paths)
- `async_update_data()` discovers devices for each pool in parallel, so a multi-pool account no longer pays N sequential device-tree round-trips

## Measured

On the HA dev instance, same account:
- config_entry_setup: **~2.18s → ~1.19s (-45%)**

## Tests

- Full suite: **1659 passed**, coverage 96.6%
- Two new concurrency tests use cross-blocking `asyncio.Event` stubs — if a regression re-introduces sequential execution, the test deadlocks (2s cap → failure) instead of passing silently
- Existing per-pool failure isolation test rewritten to dispatch on `poolId` (order is non-deterministic under parallelism)

## Safety

- `asyncio.gather(return_exceptions=True)` on per-pool discovery keeps the existing behaviour: one failing pool doesn't break the others
- ruff, mypy strict, pre-commit all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Faster sign-in and account setup through concurrent profile and pool discovery.
  * Faster device updates by discovering devices across pools simultaneously.
  * Device discovery continues for other pools when one pool encounters an error.

* **Reliability**
  * Improved handling of partial discovery failures without interrupting the overall update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->