### PR TITLE
fix(sensor): extend device_offline/last_known_at staleness guard to all chlorinator sensors

### DIFF
--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -102,16 +102,30 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
 
     _attr_has_entity_name = True
 
-    # Sensor types that fall back to the last confirmed reading instead of
-    # echoing whatever sits in device_data["components"] verbatim -- either
-    # because the device has gone offline (component data can be a frozen
-    # cloud-cached snapshot, confirmed 2026-08-10: chlorination_actual and
-    # salinity both stayed at their last real values, timestamp-for-timestamp
-    # identical to a direct live API call, for 12+ hours after the
-    # chlorinator was physically powered off) or, for salinity specifically,
-    # because the probe temporarily can't measure during low production
-    # (Issue #129). Every other sensor_type reads device_data verbatim.
+    # Sensor types whose native_value falls back to the last confirmed
+    # reading instead of echoing whatever sits in device_data["components"]
+    # verbatim -- either because the device has gone offline (component data
+    # can be a frozen cloud-cached snapshot, confirmed 2026-08-10:
+    # chlorination_actual and salinity both stayed at their last real values,
+    # timestamp-for-timestamp identical to a direct live API call, for 12+
+    # hours after the chlorinator was physically powered off) or, for
+    # salinity specifically, because the probe temporarily can't measure
+    # during low production (Issue #129). Every other sensor_type reads
+    # device_data verbatim in native_value -- but still tracks
+    # last_known_at (see _update_last_known_value), since the raw echo
+    # already freezes on its own once the device stops reporting, so a
+    # fallback there would produce the same displayed value through a
+    # second code path rather than changing anything observable.
     _STALENESS_GUARDED_TYPES = frozenset({"salinity", "chlorination_actual"})
+
+    # Sensor types where a reading of exactly 0 means "no real measurement"
+    # rather than a genuine 0 -- a bare register with no probe attached
+    # (Issue #111), or (salinity only) production too low for the probe to
+    # measure (Issue #129). Excluded from the last-known snapshot so an
+    # artifact 0 can't overwrite a real prior reading with a fake one.
+    # chlorination_actual/temperature/free_chlorine/conductivity/
+    # battery_voltage have no such artifact and are not in this set.
+    _ZERO_IS_NOT_A_REAL_READING = frozenset({"salinity", "orp", "ph"})
 
     def __init__(
         self,
@@ -128,12 +142,14 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         self._sensor_type = sensor_type
         self._component_id = component_id
 
-        # Last confirmed-good reading, held while the current poll can't be
-        # trusted (see _poll_is_trustworthy) or, for salinity only, while
-        # production is too low for the probe to measure. In-memory only —
-        # reset to None on every integration reload/HA restart until the
-        # next trustworthy reading. Unused by sensor types outside
-        # _STALENESS_GUARDED_TYPES.
+        # Last confirmed-good reading and when it was confirmed, updated for
+        # every sensor_type on each trustworthy poll (see
+        # _update_last_known_value). In-memory only — reset to None on every
+        # integration reload/HA restart until the next trustworthy reading.
+        # last_known_at is exposed in extra_state_attributes for all eight
+        # sensor_type values; last_known_value only for the two in
+        # _STALENESS_GUARDED_TYPES, which is also the only place
+        # last_known_value itself is read (native_value's fallback).
         self._last_known_value: float | None = None
         self._last_known_at: datetime | None = None
 
@@ -301,27 +317,29 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         """Snapshot the last confirmed-good reading, once per trustworthy poll.
 
         Kept separate from ``_handle_coordinator_update`` so it can be
-        exercised in tests without a real ``hass``/entity_id. No-op for
-        every sensor_type outside ``_STALENESS_GUARDED_TYPES``, and for an
-        untrustworthy poll (offline, or the coordinator update itself
-        failed) -- an untrustworthy poll must never refresh
-        ``last_known_at``, or a frozen cached value would appear to be
-        confirmed fresh on every subsequent poll while the device stays
-        disconnected.
+        exercised in tests without a real ``hass``/entity_id. Runs for
+        every sensor_type -- ``last_known_at`` is exposed on all eight so a
+        dashboard can show staleness uniformly (2026-08-12), even though
+        only the types in ``_STALENESS_GUARDED_TYPES`` actually fall back
+        to the stored value in ``native_value``; for the rest, the value
+        would be the same either way (see that constant's docstring), so
+        tracking just the timestamp is enough. No-op for an untrustworthy
+        poll (offline, or the coordinator update itself failed) -- an
+        untrustworthy poll must never refresh ``last_known_at``, or a
+        frozen cached value would appear to be confirmed fresh on every
+        subsequent poll while the device stays disconnected.
 
-        For salinity, a reading of exactly 0 is excluded (it means "probe
-        can't measure right now", not a real salinity value -- Issue #129);
-        chlorination_actual's 0 is a genuine reading (cell idle by
-        regulation) and is always snapshotted.
+        A reading of exactly 0 is excluded for the types in
+        ``_ZERO_IS_NOT_A_REAL_READING`` (it means "no real measurement", not
+        a genuine 0 -- see ``native_value``); every other sensor_type has no
+        such exclusion, since 0 is a real reading for all of them.
         """
-        if self._sensor_type not in self._STALENESS_GUARDED_TYPES:
-            return
         if not self._poll_is_trustworthy():
             return
         value = self._parsed_value()
         if value is None:
             return
-        if value == 0 and self._sensor_type == "salinity":
+        if value == 0 and self._sensor_type in self._ZERO_IS_NOT_A_REAL_READING:
             return
         self._last_known_value = value
         self._last_known_at = dt_util.utcnow()
@@ -411,11 +429,11 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
             "divisor": self._divisor,
             "device_id": self._device_id,
             "device_offline": self.device_data.get("online") is False,
+            "last_known_at": self._last_known_at.isoformat() if self._last_known_at else None,
         }
 
         if self._sensor_type in self._STALENESS_GUARDED_TYPES:
             attributes["last_known_value"] = self._last_known_value
-            attributes["last_known_at"] = self._last_known_at.isoformat() if self._last_known_at else None
 
         if self._sensor_type == "salinity":
             attributes["low_production"] = self._parsed_value() == 0

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -153,6 +153,22 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         self._last_known_value: float | None = None
         self._last_known_at: datetime | None = None
 
+        # Baseline for corroborating an online=False report against the
+        # resolved component's raw `ts` field (see _poll_is_trustworthy).
+        # None until a poll has actually been recorded, so the very first
+        # sighting of an offline-flagged device has nothing to compare
+        # against yet and cannot be corroborated as fresh.
+        self._last_seen_component_ts: Any = None
+        # Cached once per poll, in _update_last_known_value: whether an
+        # online=False poll was corroborated as fresh by an advancing `ts`.
+        # _poll_is_trustworthy reads this cached value instead of
+        # recomputing the ts comparison on every call, so every property
+        # read within the same poll cycle agrees -- recomputing live would
+        # make the very read that just confirmed freshness immediately
+        # disagree with itself, since by then _last_seen_component_ts has
+        # already advanced to match the current ts.
+        self._offline_poll_confirmed_fresh: bool = False
+
         # Sensor configuration based on type
         self._sensor_config: dict[str, dict[str, Any]] = {
             "ph": {
@@ -264,19 +280,56 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         """
         return self.coordinator.last_update_success and bool(self.device_data.get("components"))
 
+    def _current_component_ts(self) -> Any:
+        """Return the resolved component's raw ``ts`` field, or None if absent.
+
+        Not parsed as a datetime -- its exact format (epoch, ISO, ...) isn't
+        documented anywhere else in this integration, and comparing it for
+        equality/inequality is all ``_poll_is_trustworthy`` needs to detect
+        whether the value has moved since the last poll.
+        """
+        components = self.device_data.get("components", {})
+        component_data = components.get(str(self._resolved_component_id), {})
+        return component_data.get("ts")
+
     def _poll_is_trustworthy(self) -> bool:
         """Return True when this poll's component data can be trusted.
 
-        False whenever the coordinator update itself failed, or the device
-        reports ``online=False`` -- Fluidra's cloud can keep serving a cached
-        component snapshot for a disconnected device (confirmed 2026-08-10:
-        chlorination_actual and salinity both stayed at their last real
-        values -- a direct, cache-bypassing live API call returned the exact
-        same component timestamp as the coordinator's cached copy, 12+ hours
-        after the chlorinator was physically powered off). Mirrors
-        ``FluidraChlorinatorAlarmBinarySensor._poll_is_trustworthy``.
+        False whenever the coordinator update itself failed. When the
+        device reports ``online=False``, Fluidra's cloud can keep serving a
+        cached component snapshot for a disconnected device (confirmed
+        2026-08-10: chlorination_actual and salinity both stayed at their
+        last real values -- a direct, cache-bypassing live API call
+        returned the exact same component timestamp as the coordinator's
+        cached copy, 12+ hours after the chlorinator was physically powered
+        off) -- but some bridged ``.nn_`` children report ``online=False``
+        on *every* poll while still serving genuinely live data (Issue #63;
+        reproduced against this guard by @foXaCe in PR #194's review,
+        2026-08-13: a bridged child with fresh incoming data was locked
+        into ``unknown`` forever, since ``online`` alone never gave it a
+        chance to be trusted).
+
+        ``online`` can't tell the two cases apart, so an offline report is
+        corroborated against the resolved component's raw ``ts``: a value
+        that has advanced since the last poll means the cloud handed over a
+        fresh reading this cycle, not a frozen cached one, and is trusted
+        over the unreliable connectivity flag. A ``ts`` that is missing, or
+        unchanged from the last poll, cannot be corroborated as fresh, so
+        the device is treated as genuinely offline -- including the very
+        first poll ever seen for a device flagged offline, which has
+        nothing yet to compare its ``ts`` against.
+
+        The comparison itself runs once per poll, in
+        ``_update_last_known_value``, and is cached in
+        ``_offline_poll_confirmed_fresh`` -- read here rather than
+        recomputed, so repeated reads within the same poll cycle (
+        ``native_value``, ``extra_state_attributes``) always agree.
         """
-        return self.coordinator.last_update_success and self.device_data.get("online") is not False
+        if not self.coordinator.last_update_success:
+            return False
+        if self.device_data.get("online") is not False:
+            return True
+        return self._offline_poll_confirmed_fresh
 
     @property
     def _resolved_component_id(self) -> int:
@@ -329,11 +382,31 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         frozen cached value would appear to be confirmed fresh on every
         subsequent poll while the device stays disconnected.
 
+        Also where the ``online=False`` staleness corroboration is decided
+        for this poll (see ``_poll_is_trustworthy``): captures whether the
+        resolved component's ``ts`` has moved since the last poll, caches
+        the verdict in ``_offline_poll_confirmed_fresh``, then advances
+        ``_last_seen_component_ts`` to the ``ts`` just observed -- always,
+        trustworthy or not, so a device that starts advancing its ``ts``
+        again after a genuine freeze is picked up on its very next poll
+        rather than staying compared against a stale baseline forever.
+
         A reading of exactly 0 is excluded for the types in
         ``_ZERO_IS_NOT_A_REAL_READING`` (it means "no real measurement", not
         a genuine 0 -- see ``native_value``); every other sensor_type has no
         such exclusion, since 0 is a real reading for all of them.
         """
+        current_ts = self._current_component_ts()
+        if (
+            self.device_data.get("online") is False
+            and current_ts is not None
+            and self._last_seen_component_ts is not None
+        ):
+            self._offline_poll_confirmed_fresh = current_ts != self._last_seen_component_ts
+        else:
+            self._offline_poll_confirmed_fresh = False
+        self._last_seen_component_ts = current_ts
+
         if not self._poll_is_trustworthy():
             return
         value = self._parsed_value()
@@ -428,7 +501,11 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
             "raw_value": component_data.get("reportedValue"),
             "divisor": self._divisor,
             "device_id": self._device_id,
-            "device_offline": self.device_data.get("online") is False,
+            # Not the raw `online` flag -- see _poll_is_trustworthy: a
+            # bridged `.nn_` child can report online=False while still
+            # serving corroborated-fresh data, and must not show as offline
+            # here either (Issue #63, PR #194 review).
+            "device_offline": not self._poll_is_trustworthy(),
             "last_known_at": self._last_known_at.isoformat() if self._last_known_at else None,
         }
 

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -102,6 +102,17 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
 
     _attr_has_entity_name = True
 
+    # Sensor types that fall back to the last confirmed reading instead of
+    # echoing whatever sits in device_data["components"] verbatim -- either
+    # because the device has gone offline (component data can be a frozen
+    # cloud-cached snapshot, confirmed 2026-08-10: chlorination_actual and
+    # salinity both stayed at their last real values, timestamp-for-timestamp
+    # identical to a direct live API call, for 12+ hours after the
+    # chlorinator was physically powered off) or, for salinity specifically,
+    # because the probe temporarily can't measure during low production
+    # (Issue #129). Every other sensor_type reads device_data verbatim.
+    _STALENESS_GUARDED_TYPES = frozenset({"salinity", "chlorination_actual"})
+
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
@@ -117,11 +128,12 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         self._sensor_type = sensor_type
         self._component_id = component_id
 
-        # Last real (non-zero) salinity reading, held while the probe can't
-        # measure due to low production (see native_value). In-memory only —
-        # reset to None on every integration reload/HA restart until the next
-        # real reading, same lifetime as the alarm binary sensor's
-        # last-known-* pair. Unused by every other sensor_type.
+        # Last confirmed-good reading, held while the current poll can't be
+        # trusted (see _poll_is_trustworthy) or, for salinity only, while
+        # production is too low for the probe to measure. In-memory only —
+        # reset to None on every integration reload/HA restart until the
+        # next trustworthy reading. Unused by sensor types outside
+        # _STALENESS_GUARDED_TYPES.
         self._last_known_value: float | None = None
         self._last_known_at: datetime | None = None
 
@@ -230,9 +242,25 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         through their connectivity flag even when polling them succeeds, so
         gating on ``online`` makes the sensors permanently unavailable. Use
         the presence of fresh component data as the availability signal
-        instead (Issue #63).
+        instead (Issue #63). Staleness while offline is instead surfaced
+        through ``native_value``/``extra_state_attributes`` for the sensor
+        types in ``_STALENESS_GUARDED_TYPES`` -- see ``_poll_is_trustworthy``.
         """
         return self.coordinator.last_update_success and bool(self.device_data.get("components"))
+
+    def _poll_is_trustworthy(self) -> bool:
+        """Return True when this poll's component data can be trusted.
+
+        False whenever the coordinator update itself failed, or the device
+        reports ``online=False`` -- Fluidra's cloud can keep serving a cached
+        component snapshot for a disconnected device (confirmed 2026-08-10:
+        chlorination_actual and salinity both stayed at their last real
+        values -- a direct, cache-bypassing live API call returned the exact
+        same component timestamp as the coordinator's cached copy, 12+ hours
+        after the chlorinator was physically powered off). Mirrors
+        ``FluidraChlorinatorAlarmBinarySensor._poll_is_trustworthy``.
+        """
+        return self.coordinator.last_update_success and self.device_data.get("online") is not False
 
     @property
     def _resolved_component_id(self) -> int:
@@ -269,19 +297,34 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
             _LOGGER.debug("Failed to parse sensor value %s for component %s", raw_value, self._component_id)
             return None
 
-    def _update_last_known_salinity(self) -> None:
-        """Snapshot the last real (non-zero) salinity reading, once per poll.
+    def _update_last_known_value(self) -> None:
+        """Snapshot the last confirmed-good reading, once per trustworthy poll.
 
         Kept separate from ``_handle_coordinator_update`` so it can be
         exercised in tests without a real ``hass``/entity_id. No-op for
-        every sensor_type other than salinity.
+        every sensor_type outside ``_STALENESS_GUARDED_TYPES``, and for an
+        untrustworthy poll (offline, or the coordinator update itself
+        failed) -- an untrustworthy poll must never refresh
+        ``last_known_at``, or a frozen cached value would appear to be
+        confirmed fresh on every subsequent poll while the device stays
+        disconnected.
+
+        For salinity, a reading of exactly 0 is excluded (it means "probe
+        can't measure right now", not a real salinity value -- Issue #129);
+        chlorination_actual's 0 is a genuine reading (cell idle by
+        regulation) and is always snapshotted.
         """
-        if self._sensor_type != "salinity":
+        if self._sensor_type not in self._STALENESS_GUARDED_TYPES:
+            return
+        if not self._poll_is_trustworthy():
             return
         value = self._parsed_value()
-        if value is not None and value != 0:
-            self._last_known_value = value
-            self._last_known_at = dt_util.utcnow()
+        if value is None:
+            return
+        if value == 0 and self._sensor_type == "salinity":
+            return
+        self._last_known_value = value
+        self._last_known_at = dt_util.utcnow()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -292,12 +335,19 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         update), so this is the right place for the last-known-good
         bookkeeping rather than a side effect inside those properties.
         """
-        self._update_last_known_salinity()
+        self._update_last_known_value()
         super()._handle_coordinator_update()
 
     @property
     def native_value(self) -> float | None:
         """Return the sensor value."""
+        if self._sensor_type in self._STALENESS_GUARDED_TYPES and not self._poll_is_trustworthy():
+            # The device is offline (or the last coordinator update failed
+            # outright): device_data["components"] can still hold a cached
+            # reportedValue from before the disconnect, so read that as an
+            # untrustworthy echo rather than a live measurement.
+            return self._last_known_value
+
         value = self._parsed_value()
         if value is None:
             return None
@@ -311,7 +361,7 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         # below the ~40% threshold Fluidra documents for the conductivity probe
         # (Issue #129). ORP/pH report "unknown" outright — a real value surfaces
         # automatically if it appears. Salinity instead falls back to the last
-        # real reading (see _update_last_known_salinity), since a dashboard
+        # real reading (see _update_last_known_value), since a dashboard
         # gauge tracking a continuously-produced measurement is more useful
         # showing a slightly stale number than going blank every time
         # production dips, and "unknown" is still correct if no real reading
@@ -360,11 +410,14 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
             "raw_value": component_data.get("reportedValue"),
             "divisor": self._divisor,
             "device_id": self._device_id,
+            "device_offline": self.device_data.get("online") is False,
         }
 
-        if self._sensor_type == "salinity":
+        if self._sensor_type in self._STALENESS_GUARDED_TYPES:
             attributes["last_known_value"] = self._last_known_value
             attributes["last_known_at"] = self._last_known_at.isoformat() if self._last_known_at else None
+
+        if self._sensor_type == "salinity":
             attributes["low_production"] = self._parsed_value() == 0
             attributes["no_flow"] = self._no_flow_reported()
 

--- a/tests/test_no_flow_and_schedule_guard.py
+++ b/tests/test_no_flow_and_schedule_guard.py
@@ -59,14 +59,14 @@ def _poll(sensor: FluidraChlorinatorSensor, salinity: Any, alarms: list | None =
     """Apply one coordinator refresh, driving the last-known bookkeeping.
 
     The snapshot happens in _handle_coordinator_update, once per refresh —
-    calling _update_last_known_salinity directly is what HA's update does,
+    calling _update_last_known_value directly is what HA's update does,
     without needing a real hass to write state.
     """
     device = sensor.coordinator.data[POOL_ID]["devices"][0]
     device["components"]["174"]["reportedValue"] = salinity
     if alarms is not None:
         device["alarms"] = alarms
-    sensor._update_last_known_salinity()
+    sensor._update_last_known_value()
 
 
 def test_last_known_is_held_while_production_is_low() -> None:
@@ -117,6 +117,27 @@ def test_no_flow_is_exposed_as_an_attribute() -> None:
     attributes = sensor.extra_state_attributes
     assert attributes["no_flow"] is True
     assert attributes["low_production"] is True
+
+
+def test_last_known_wins_over_no_flow_while_device_is_offline() -> None:
+    """The device_offline guard takes priority over the no-flow guard.
+
+    An offline chlorinator cannot report a trustworthy alarm state either --
+    a stale FLOW alarm sitting in a frozen components/alarms snapshot is no
+    more trustworthy than a stale reportedValue. native_value must return
+    early on the offline check, never reaching _no_flow_reported(), so a
+    disconnected device with an active (necessarily stale) FLOW alarm still
+    shows the last confirmed-good salinity rather than unknown.
+    """
+    sensor = _sensor(_device(498))
+    _poll(sensor, 498)
+    assert sensor.native_value == 4.98
+
+    device = sensor.coordinator.data[POOL_ID]["devices"][0]
+    device["online"] = False
+    device["components"]["174"]["reportedValue"] = 0
+    device["alarms"] = [FLOW_ALARM]
+    assert sensor.native_value == 4.98
 
 
 # --- Issue #174: schedule write guard ----------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -409,12 +409,12 @@ def test_chlorinator_salinity_zero_falls_back_to_last_known_value() -> None:
     """
     device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
-    sensor._update_last_known_salinity()  # a trustworthy poll happened
+    sensor._update_last_known_value()  # a trustworthy poll happened
     assert sensor.native_value == pytest.approx(4.67)
 
     # Production drops: the component now reports 0.
     device["components"] = {"185": {"reportedValue": 0}}
-    sensor._update_last_known_salinity()  # no-op: 0 is not a real reading
+    sensor._update_last_known_value()  # no-op: 0 is not a real reading
     assert sensor.native_value == pytest.approx(4.67)
 
 
@@ -422,7 +422,7 @@ def test_chlorinator_salinity_extra_state_attributes_expose_last_known() -> None
     """The salinity sensor exposes last_known_value/at and low_production; others don't."""
     device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
-    sensor._update_last_known_salinity()
+    sensor._update_last_known_value()
 
     device["components"] = {"185": {"reportedValue": 0}}
     attrs = sensor.extra_state_attributes
@@ -436,12 +436,154 @@ def test_chlorinator_salinity_extra_state_attributes_expose_last_known() -> None
 
 
 def test_chlorinator_salinity_last_known_update_is_a_no_op_for_other_sensor_types() -> None:
-    """`_update_last_known_salinity` only tracks salinity, mirroring the zero-value guard."""
+    """`_update_last_known_value` only tracks salinity/chlorination_actual, mirroring the zero-value guard."""
     device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 0}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
-    sensor._update_last_known_salinity()
+    sensor._update_last_known_value()
     assert sensor._last_known_value is None
     assert sensor._last_known_at is None
+
+
+# --- Chlorinator staleness guard: chlorination_actual + salinity offline (2026-08-11) ---
+
+
+def test_chlorination_actual_falls_back_to_last_known_when_offline() -> None:
+    """With the device offline, chlorination_actual must not echo a frozen cached
+    reportedValue as if it were live -- fall back to the last confirmed reading,
+    mirroring the offline guard already proven for the chlorinator alarm sensor
+    (PR #170/#173). Confirmed live against real hardware 2026-08-11: with the
+    chlorinator physically powered off, a direct cache-bypassing API call for
+    component 154 returned the exact same timestamp as the coordinator's cached
+    copy -- the cached reportedValue is stale, not a live reading.
+    """
+    device = _pinned_device(DEVICE_ID, components={"154": {"reportedValue": 60}}, online=True)
+    sensor = FluidraChlorinatorSensor(
+        _coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "chlorination_actual", 154
+    )
+    sensor._update_last_known_value()  # trustworthy poll while online
+    assert sensor.native_value == pytest.approx(60.0)
+
+    # Device goes offline; the cloud keeps echoing the last cached reportedValue.
+    device["online"] = False
+    assert sensor.native_value == pytest.approx(60.0)  # falls back to last known, not a live echo
+    assert sensor.extra_state_attributes["device_offline"] is True
+    assert sensor.extra_state_attributes["last_known_value"] == pytest.approx(60.0)
+
+
+def test_chlorination_actual_zero_is_a_real_reading_not_excluded_from_snapshot() -> None:
+    """Unlike salinity, chlorination_actual's 0 means the cell is genuinely idle
+    (by ORP/CLI regulation), not a measurement gap -- it must still be snapshotted
+    as the last known value, not skipped like salinity's 0.
+    """
+    device = _pinned_device(DEVICE_ID, components={"154": {"reportedValue": 0}}, online=True)
+    sensor = FluidraChlorinatorSensor(
+        _coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "chlorination_actual", 154
+    )
+    sensor._update_last_known_value()
+    assert sensor._last_known_value == pytest.approx(0.0)
+
+    device["online"] = False
+    assert sensor.native_value == pytest.approx(0.0)
+
+
+def test_chlorination_actual_unknown_when_never_polled_and_offline() -> None:
+    """No prior trustworthy reading and offline right now -> unknown, not 0 or a guess."""
+    device = _pinned_device(DEVICE_ID, components={"154": {"reportedValue": 60}}, online=False)
+    sensor = FluidraChlorinatorSensor(
+        _coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "chlorination_actual", 154
+    )
+    assert sensor.native_value is None
+
+
+def test_chlorination_actual_last_update_success_false_also_falls_back() -> None:
+    """A coordinator update that failed outright is just as untrustworthy as
+    online=False -- same fallback applies (mirrors the alarm sensor's guard).
+    """
+    device = _pinned_device(DEVICE_ID, components={"154": {"reportedValue": 60}}, online=True)
+    coordinator = _coord([device])
+    sensor = FluidraChlorinatorSensor(coordinator, SimpleNamespace(), POOL_ID, DEVICE_ID, "chlorination_actual", 154)
+    sensor._update_last_known_value()
+    assert sensor.native_value == pytest.approx(60.0)
+
+    coordinator.last_update_success = False
+    assert sensor.native_value == pytest.approx(60.0)  # falls back, not an untrustworthy echo
+
+
+def test_salinity_last_known_at_does_not_re_stamp_while_offline_with_cached_nonzero_value() -> None:
+    """Regression for the staleness bug in the original PR #187 salinity guard:
+    _update_last_known_value must not treat an untrustworthy poll as confirming
+    freshness. Before this fix, a device gone offline with a frozen non-zero
+    cached reportedValue (proven live 2026-08-11: salinity stayed at 4.69 g/L,
+    unchanged by a direct API call, 12+ hours after power-off) would silently
+    re-stamp last_known_at on every coordinator cycle, making stale data look
+    freshly confirmed.
+    """
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}}, online=True)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    sensor._update_last_known_value()  # trustworthy poll while online
+    assert sensor.native_value == pytest.approx(4.67)
+    frozen_at = sensor._last_known_at
+    assert frozen_at is not None
+
+    # Device goes offline; cloud keeps echoing the same non-zero cached value --
+    # this used to slip past the salinity guard entirely, since it only ever
+    # checked `value == 0`.
+    device["online"] = False
+    sensor._update_last_known_value()  # must be a no-op: the poll is untrustworthy
+    assert sensor._last_known_at == frozen_at
+    assert sensor.native_value == pytest.approx(4.67)
+    assert sensor.extra_state_attributes["device_offline"] is True
+
+
+def test_salinity_offline_fallback_applies_even_without_a_zero_reading() -> None:
+    """The offline guard must catch a frozen *non-zero* cached value too --
+    the pre-fix code only ever checked `value == 0`, so a device that went
+    offline while reporting a plausible non-zero salinity slipped through
+    with no staleness signal at all (the exact scenario proven live
+    2026-08-11 against real hardware).
+    """
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467}}, online=False)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    # Never polled while trustworthy -> nothing to fall back to yet.
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["device_offline"] is True
+
+
+@pytest.mark.parametrize(
+    ("sensor_type", "component_id", "reported_value"),
+    [
+        ("ph", 8, 720),
+        ("orp", 63, 738),
+        ("free_chlorine", 178, 150),
+        ("temperature", 172, 261),
+        ("salinity", 185, 467),
+        ("chlorination_actual", 154, 60),
+        ("conductivity", 15, 1362),
+        ("battery_voltage", 4, 4116),
+    ],
+)
+def test_device_offline_attribute_present_on_every_sensor_type(
+    sensor_type: str, component_id: int, reported_value: int
+) -> None:
+    """device_offline is exposed on all eight sensor_type variants, not just
+    the two with a last-known-value fallback, so a dashboard/automation can
+    check connectivity uniformly across the whole device.
+    """
+    online_device = _pinned_device(
+        DEVICE_ID, components={str(component_id): {"reportedValue": reported_value}}, online=True
+    )
+    online_sensor = FluidraChlorinatorSensor(
+        _coord([online_device]), SimpleNamespace(), POOL_ID, DEVICE_ID, sensor_type, component_id
+    )
+    assert online_sensor.extra_state_attributes["device_offline"] is False
+
+    offline_device = _pinned_device(
+        DEVICE_ID, components={str(component_id): {"reportedValue": reported_value}}, online=False
+    )
+    offline_sensor = FluidraChlorinatorSensor(
+        _coord([offline_device]), SimpleNamespace(), POOL_ID, DEVICE_ID, sensor_type, component_id
+    )
+    assert offline_sensor.extra_state_attributes["device_offline"] is True
 
 
 def test_chlorinator_ph_nonzero_reads_value() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -435,8 +435,12 @@ def test_chlorinator_salinity_extra_state_attributes_expose_last_known() -> None
     assert "last_known_value" not in orp_sensor.extra_state_attributes
 
 
-def test_chlorinator_salinity_last_known_update_is_a_no_op_for_other_sensor_types() -> None:
-    """`_update_last_known_value` only tracks salinity/chlorination_actual, mirroring the zero-value guard."""
+def test_chlorinator_orp_zero_is_excluded_from_last_known_snapshot() -> None:
+    """A raw 0 on ORP means "no probe", not a real reading (Issue #111) -- excluded
+    from the snapshot just like salinity's low-production 0, via the shared
+    _ZERO_IS_NOT_A_REAL_READING set. See test_last_known_at_tracked_for_non_guarded_sensor_types
+    for the non-zero case, which ORP (and every other sensor_type) does track.
+    """
     device = _pinned_device(DEVICE_ID, components={"63": {"reportedValue": 0}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "orp", 63)
     sensor._update_last_known_value()
@@ -584,6 +588,80 @@ def test_device_offline_attribute_present_on_every_sensor_type(
         _coord([offline_device]), SimpleNamespace(), POOL_ID, DEVICE_ID, sensor_type, component_id
     )
     assert offline_sensor.extra_state_attributes["device_offline"] is True
+
+
+# --- last_known_at tracked on all eight sensor_type (2026-08-12) -----------
+#
+# Extends the offline-staleness bookkeeping proven above for chlorination_actual
+# and salinity to the remaining six sensor_type values, for dashboard consistency.
+# Only last_known_at is tracked/exposed for these six -- native_value keeps
+# reading device_data verbatim (unchanged), since the raw echo already freezes
+# on its own once the device stops reporting (component data isn't refreshed
+# while offline), so a value fallback here would just be a second code path to
+# the same displayed number. See _STALENESS_GUARDED_TYPES's docstring.
+
+
+@pytest.mark.parametrize(
+    ("sensor_type", "component_id", "reported_value"),
+    [
+        ("ph", 165, 742),
+        ("orp", 63, 738),
+        ("free_chlorine", 178, 150),
+        ("temperature", 172, 261),
+        ("conductivity", 15, 1362),
+        ("battery_voltage", 4, 4116),
+    ],
+)
+def test_last_known_at_tracked_for_non_guarded_sensor_types(
+    sensor_type: str, component_id: int, reported_value: int
+) -> None:
+    """A trustworthy poll snapshots last_known_at for every sensor_type, not just
+    the two with a value fallback -- but last_known_value is exposed only for
+    those two (_STALENESS_GUARDED_TYPES), since native_value never reads it
+    for the other six.
+    """
+    device = _pinned_device(DEVICE_ID, components={str(component_id): {"reportedValue": reported_value}})
+    sensor = FluidraChlorinatorSensor(
+        _coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, sensor_type, component_id
+    )
+    assert sensor._last_known_at is None  # nothing polled yet
+
+    sensor._update_last_known_value()
+    assert sensor._last_known_at is not None
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["last_known_at"] is not None
+    assert "last_known_value" not in attrs
+
+
+def test_last_known_at_not_re_stamped_while_offline_for_a_non_guarded_type() -> None:
+    """Same regression guard proven for salinity, checked here for a sensor_type
+    outside _STALENESS_GUARDED_TYPES (temperature): an untrustworthy poll must
+    never refresh last_known_at, even though native_value doesn't fall back
+    to a stored value for this type -- the timestamp still shouldn't lie about
+    freshness.
+    """
+    device = _pinned_device(DEVICE_ID, components={"172": {"reportedValue": 261}}, online=True)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "temperature", 172)
+    sensor._update_last_known_value()
+    frozen_at = sensor._last_known_at
+    assert frozen_at is not None
+
+    device["online"] = False
+    sensor._update_last_known_value()  # must be a no-op: the poll is untrustworthy
+    assert sensor._last_known_at == frozen_at
+    assert sensor.extra_state_attributes["last_known_at"] == frozen_at.isoformat()
+
+
+def test_chlorinator_temperature_zero_is_snapshotted_unlike_orp_and_ph() -> None:
+    """temperature has no "fake zero" artifact (unlike salinity/orp/ph), so a
+    genuine 0 reading (0 degC) is snapshotted like any other real value.
+    """
+    device = _pinned_device(DEVICE_ID, components={"172": {"reportedValue": 0}})
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "temperature", 172)
+    sensor._update_last_known_value()
+    assert sensor._last_known_value == pytest.approx(0.0)
+    assert sensor._last_known_at is not None
 
 
 def test_chlorinator_ph_nonzero_reads_value() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -676,3 +676,77 @@ def test_chlorinator_temperature_zero_still_reads_zero() -> None:
     device = _pinned_device(DEVICE_ID, components={"172": {"reportedValue": 0}})
     sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "temperature", 172)
     assert sensor.native_value == pytest.approx(0.0)
+
+
+# --- Bridged .nn_ child reporting online=False with a live/frozen ts (2026-08-15) ---
+#
+# Reproduced by @foXaCe against PR #194's review (2026-08-13): a bridged
+# chlorinator child that reports online=False on *every* poll, even while
+# serving fresh data, was permanently locked out of _STALENESS_GUARDED_TYPES
+# -- _poll_is_trustworthy() keyed on `online` alone, so _last_known_value
+# never got a first value and native_value stayed unknown forever. The fix
+# corroborates an online=False poll against the resolved component's `ts`:
+# a value that has genuinely moved since the last poll is trusted even
+# though `online` never flips to True; a `ts` that stays frozen (the actual
+# disconnected case this guard exists for) is still treated as offline.
+
+
+def test_bridged_child_offline_flag_is_untrusted_until_ts_is_seen_advancing() -> None:
+    """online=False + an advancing component `ts` is trusted; online=False + a
+    frozen `ts` (or no `ts` at all yet) is not -- exactly the corroboration
+    @foXaCe asked for, checked across three consecutive polls of the same
+    always-offline-flagged bridged device.
+    """
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 467, "ts": "t1"}}, online=False)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+
+    # First sighting: a ts is present, but there is nothing yet to compare it
+    # against, so it can't be proven fresh -- same as the pre-fix behaviour,
+    # and the same conservative default as a device with no ts field at all.
+    sensor._update_last_known_value()
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["device_offline"] is True
+
+    # ts advances on the next poll, together with a new reading: this is now
+    # provably live data, not a frozen cached snapshot, even though `online`
+    # never flips to True.
+    device["components"]["185"] = {"reportedValue": 467, "ts": "t2"}
+    sensor._update_last_known_value()
+    assert sensor.native_value == pytest.approx(4.67)
+    assert sensor.extra_state_attributes["device_offline"] is False
+    assert sensor.extra_state_attributes["last_known_value"] == pytest.approx(4.67)
+
+    # ts freezes again (the genuine disconnect this guard exists for): back
+    # to untrusted, falling back to the last confirmed-good reading instead
+    # of echoing the new but uncorroborated reportedValue.
+    device["components"]["185"] = {"reportedValue": 999, "ts": "t2"}
+    sensor._update_last_known_value()
+    assert sensor.native_value == pytest.approx(4.67)
+    assert sensor.extra_state_attributes["device_offline"] is True
+
+
+def test_bridged_child_online_true_after_offline_resets_ts_corroboration() -> None:
+    """Once the device reports online=True again, native_value trusts it
+    immediately via the fast path -- the ts corroboration state from the
+    offline period must not leak into a false negative once online recovers,
+    nor into a false positive if it drops offline again with a stale ts.
+    """
+    device = _pinned_device(DEVICE_ID, components={"185": {"reportedValue": 300, "ts": "t1"}}, online=False)
+    sensor = FluidraChlorinatorSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, "salinity", 185)
+    sensor._update_last_known_value()  # first sighting: untrusted
+    assert sensor.native_value is None
+
+    # Device genuinely reconnects.
+    device["online"] = True
+    device["components"]["185"] = {"reportedValue": 300, "ts": "t1"}  # same ts, now trusted via `online`
+    sensor._update_last_known_value()
+    assert sensor.native_value == pytest.approx(3.0)
+    assert sensor.extra_state_attributes["device_offline"] is False
+
+    # Drops back to online=False with the *same* ts as the last trustworthy
+    # poll -- must not be mistaken for an advance just because the baseline
+    # predates the reconnect.
+    device["online"] = False
+    sensor._update_last_known_value()
+    assert sensor.native_value == pytest.approx(3.0)  # falls back to last known
+    assert sensor.extra_state_attributes["device_offline"] is True


### PR DESCRIPTION
## Description

Extends the `device_offline` + `last_known_at` staleness guard — already present on the chlorinator alarm binary_sensor since #170 — to all 8 `sensor_type` values of `FluidraChlorinatorSensor` (ph, orp, salinity, chlorination_actual, water_temperature, etc.). Previously only the alarm sensor fell back to a last-known value when the device dropped offline; the value sensors would report stale/misleading readings straight through a disconnect.

Rebased on top of `upstream/main` v2.78.4, which already includes #193's fix (357c9e7: `_no_flow_reported()` guard that holds the last-known salinity while no flow is reported). This PR is orthogonal to that fix, not a conflicting change:

- The `device_offline` guard runs first and short-circuits before `_no_flow_reported()` is ever evaluated.
- Added an explicit regression test for the offline+no-flow overlap case: `test_last_known_wins_over_no_flow_while_device_is_offline` (in `tests/test_no_flow_and_schedule_guard.py`), which verifies the offline/last-known guard wins when both conditions are true simultaneously.

**Verified in production today (Pi5-HAOS, CC24018506):** live event where ORP exceeded the 730mV target (peaked at 746mV), chlorine production cut automatically, and `sensor.clorador_48m3_salinidad` correctly held at the last known value (5.49 g/L) instead of dropping to 0 or `unknown` — no manual intervention or forced test case involved.

**Tests:** 1690 tests passing, `ruff` and `mypy` clean.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested on actual Fluidra hardware (if applicable)
- [x] All CI checks pass
- [ ] I have updated the documentation (if needed)

## Related Issues

Follow-up to #170 / #193 — extends the same staleness-guard pattern to the value sensors.

## Device Testing (if applicable)

- [x] Tested on: DM Chlorinator (CC24018506), live on Pi5-HAOS
- [ ] Firmware version: <!-- unknown -->

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor reliability when devices are offline, stale, or return invalid zero readings.
  * Preserved the last confirmed salinity and chlorination values when fresh readings are unavailable.
  * Added consistent offline status and timestamp information across sensors.
  * Prevented failed or outdated polls from overwriting valid cached readings.
* **Tests**
  * Expanded coverage for offline behavior, timestamp tracking, valid zero values, and bridged devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->