### PR TITLE
feat(exo): add Aux 1 / Aux 2 schedule entities (c22/c24)

### DIFF
--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -645,6 +645,12 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except (ValueError, TypeError):
                     pass
         else:
+            aux_schedule_components = DeviceIdentifier.get_feature(device, "aux_schedule_components", {})
+            for aux_number, aux_component in aux_schedule_components.items():
+                if component_id == int(aux_component):
+                    schedule_data = reported_value if isinstance(reported_value, list) else []
+                    device.setdefault("aux_schedule_data", {})[str(aux_number)] = schedule_data
+
             schedule_comp = DeviceIdentifier.get_feature(device, "schedule_component")
             if schedule_comp and component_id == schedule_comp:
                 if isinstance(reported_value, dict) and "programs" in reported_value:

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -1009,6 +1009,10 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
             # surfaced as an attribute (Issue #175, @Inervo).
             "aux_outputs": {"1": 30, "2": 31},
             "aux_labels": {"1": 90, "2": 91},
+            # Auxiliary-output schedules: fixed registers independent of the pump
+            # type (Aux 1 = c22, Aux 2 = c24), up to 2 slots per aux (Issue #174).
+            "aux_schedule_components": {"1": 22, "2": 24},
+            "aux_schedule_count": 2,
             # Heating, available once an aux output is assigned to it (c88).
             # c43 is the setpoint in whole °C: an isolated capture moved it
             # 27 -> 23 with nothing else changing (Issue #175, @Inervo).
@@ -1065,6 +1069,8 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 19,
                 20,
                 21,
+                22,
+                24,
                 30,
                 31,
                 35,

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -69,6 +69,31 @@ def get_schedule_data(device_data: dict[str, Any], schedule_id: Any) -> dict[str
     return None
 
 
+def get_aux_schedule_data(device_data: dict[str, Any], aux_number: Any, schedule_id: Any) -> dict[str, Any] | None:
+    """Return the schedule dict for an auxiliary output (eXO iQ c22/c24).
+
+    Aux schedules live on fixed registers independent of the pump type, so they
+    are stored separately from the pump/chlorination ``schedule_data``, keyed by
+    aux number (``device_data["aux_schedule_data"]["1"]`` etc.). Looks up an
+    entry whose ``id`` matches ``schedule_id`` (string-compared like the main
+    schedule lookup). Returns ``None`` when there is no data for that aux.
+    """
+    if not device_data:
+        return None
+
+    aux_schedules = device_data.get("aux_schedule_data") or {}
+    schedules = aux_schedules.get(str(aux_number))
+    if not schedules:
+        return None
+
+    for schedule in schedules:
+        if str(schedule.get("id")) == str(schedule_id):
+            result: dict[str, Any] = schedule
+            return result
+
+    return None
+
+
 def resolve_component_rw(cfg: int | dict[str, Any]) -> tuple[Any, Any]:
     """Resolve a component config that may be a plain int or a read/write dict.
 

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -345,9 +345,18 @@
       },
       "schedule_enable": {
         "name": "Schedule {schedule_id}"
+      },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Schedule {schedule_id}"
       }
     },
     "time": {
+      "aux_schedule_end": {
+        "name": "Aux {aux_number} Schedule {schedule_id} End"
+      },
+      "aux_schedule_start": {
+        "name": "Aux {aux_number} Schedule {schedule_id} Start"
+      },
       "light_schedule_end": {
         "name": "Light Schedule {schedule_id} End"
       },

--- a/custom_components/fluidra_pool/switch/__init__.py
+++ b/custom_components/fluidra_pool/switch/__init__.py
@@ -92,6 +92,24 @@ async def async_setup_entry(
                     FluidraScheduleEnableSwitch(coordinator, coordinator.api, pool_id, device_id, schedule_id)
                 )
 
+        # Auxiliary-output schedules on the eXO iQ (Aux 1 = c22, Aux 2 = c24),
+        # up to two slots per aux (Issue #174).
+        aux_schedule_components = DeviceIdentifier.get_feature(device, "aux_schedule_components", {})
+        if aux_schedule_components:
+            aux_schedule_count = DeviceIdentifier.get_feature(device, "aux_schedule_count", 2)
+            for aux_number in sorted(aux_schedule_components):
+                for i in range(1, aux_schedule_count + 1):
+                    entities.append(
+                        FluidraScheduleEnableSwitch(
+                            coordinator,
+                            coordinator.api,
+                            pool_id,
+                            device_id,
+                            str(i),
+                            aux_number=str(aux_number),
+                        )
+                    )
+
         if DeviceIdentifier.has_feature(device, "boost_mode"):
             entities.append(FluidraChlorinatorBoostSwitch(coordinator, coordinator.api, pool_id, device_id))
 

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -11,7 +11,8 @@ from homeassistant.exceptions import HomeAssistantError
 
 from ..api_resilience import FluidraError
 from ..const import DOMAIN
-from ..helpers import get_schedule_data, resolve_schedule_component
+from ..device_registry import DeviceIdentifier
+from ..helpers import get_aux_schedule_data, get_schedule_data, resolve_schedule_component
 from .base import FluidraPoolSwitchEntity
 
 if TYPE_CHECKING:
@@ -69,14 +70,21 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         pool_id: str,
         device_id: str,
         schedule_id: str,
+        aux_number: str | None = None,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._schedule_id = schedule_id
+        self._aux_number = aux_number
 
-        self._attr_translation_key = "schedule_enable"
-        self._attr_translation_placeholders = {"schedule_id": schedule_id}
-        self._attr_unique_id = f"fluidra_{self._device_id}_schedule_{schedule_id}_enabled"
+        if aux_number is not None:
+            self._attr_translation_key = "aux_schedule_enable"
+            self._attr_translation_placeholders = {"aux_number": aux_number, "schedule_id": schedule_id}
+            self._attr_unique_id = f"fluidra_{self._device_id}_aux{aux_number}_schedule_{schedule_id}_enabled"
+        else:
+            self._attr_translation_key = "schedule_enable"
+            self._attr_translation_placeholders = {"schedule_id": schedule_id}
+            self._attr_unique_id = f"fluidra_{self._device_id}_schedule_{schedule_id}_enabled"
         self._attr_entity_category = EntityCategory.CONFIG
 
     @property
@@ -94,13 +102,28 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
     def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
+            if self._aux_number is not None:
+                return get_aux_schedule_data(self.device_data, self._aux_number, self._schedule_id)
             return get_schedule_data(self.device_data, self._schedule_id)
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
             return None
 
+    def _get_schedule_list(self) -> list[dict[str, Any]]:
+        """Return the schedule list this switch edits (main or per-aux)."""
+        if self._aux_number is not None:
+            aux_schedules: list[dict[str, Any]] = (self.device_data.get("aux_schedule_data") or {}).get(
+                str(self._aux_number), []
+            )
+            return aux_schedules
+        schedules: list[dict[str, Any]] = self.device_data.get("schedule_data", [])
+        return schedules
+
     def _get_schedule_component(self) -> int:
         """Get the schedule component used by this device."""
+        if self._aux_number is not None:
+            aux_map = DeviceIdentifier.get_feature(self.device_data, "aux_schedule_components", {})
+            return int(aux_map.get(str(self._aux_number), 22))
         value: int = resolve_schedule_component(self.device_data)
         return value
 
@@ -134,12 +157,7 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         self._ensure_pool_writable()
         try:
             self._set_pending_state(True)
-            device_data = self.device_data
-            if "schedule_data" not in device_data:
-                self._clear_pending_state()
-                return
-
-            current_schedules = device_data["schedule_data"]
+            current_schedules = self._get_schedule_list()
             if not current_schedules:
                 self._clear_pending_state()
                 return
@@ -186,12 +204,7 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         self._ensure_pool_writable()
         try:
             self._set_pending_state(False)
-            device_data = self.device_data
-            if "schedule_data" not in device_data:
-                self._clear_pending_state()
-                return
-
-            current_schedules = device_data["schedule_data"]
+            current_schedules = self._get_schedule_list()
             if not current_schedules:
                 self._clear_pending_state()
                 return

--- a/custom_components/fluidra_pool/time/__init__.py
+++ b/custom_components/fluidra_pool/time/__init__.py
@@ -14,6 +14,7 @@ from ..const import (
 )
 from ..device_registry import DeviceIdentifier
 from ..platform_setup import async_setup_dynamic_platform
+from .aux_schedule import FluidraAuxScheduleEndTimeEntity, FluidraAuxScheduleStartTimeEntity
 from .base import (
     FluidraLightScheduleTimeEntity,
     FluidraScheduleTimeEntity,
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 __all__ = [
+    "FluidraAuxScheduleEndTimeEntity",
+    "FluidraAuxScheduleStartTimeEntity",
     "FluidraLightScheduleEndTimeEntity",
     "FluidraLightScheduleStartTimeEntity",
     "FluidraLightScheduleTimeEntity",
@@ -104,6 +107,26 @@ async def async_setup_entry(
                 entities.append(
                     FluidraScheduleEndTimeEntity(coordinator, coordinator.api, pool_id, device_id, schedule_id)
                 )
+
+        # Auxiliary-output schedules on the eXO iQ (Aux 1 = c22, Aux 2 = c24),
+        # up to two slots per aux, fixed registers independent of the pump type
+        # (Issue #174). Entities are gated on the profile declaring the feature.
+        aux_schedule_components = DeviceIdentifier.get_feature(device, "aux_schedule_components", {})
+        if aux_schedule_components:
+            aux_schedule_count = DeviceIdentifier.get_feature(device, "aux_schedule_count", 2)
+            for aux_number in sorted(aux_schedule_components):
+                for i in range(1, aux_schedule_count + 1):
+                    schedule_id = str(i)
+                    entities.append(
+                        FluidraAuxScheduleStartTimeEntity(
+                            coordinator, coordinator.api, pool_id, device_id, aux_number, schedule_id
+                        )
+                    )
+                    entities.append(
+                        FluidraAuxScheduleEndTimeEntity(
+                            coordinator, coordinator.api, pool_id, device_id, aux_number, schedule_id
+                        )
+                    )
 
         return entities
 

--- a/custom_components/fluidra_pool/time/aux_schedule.py
+++ b/custom_components/fluidra_pool/time/aux_schedule.py
@@ -1,0 +1,227 @@
+"""Auxiliary-output schedule start & end time entities (eXO iQ c22/c24).
+
+The eXO iQ keeps aux-output schedules on fixed registers independent of the
+pump type — Aux 1 on c22, Aux 2 on c24 — with up to two slots each (Issue
+#174). They behave exactly like the pump/chlorination schedule time entities
+but read from / write to the aux-specific register.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import time
+import logging
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from ..api_resilience import FluidraError
+from ..const import COMMAND_CONFIRMATION_DELAY, DOMAIN
+from .base import FluidraScheduleTimeEntity
+from .schedule import _replace_cron_time
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _FluidraAuxScheduleTimeEntity(FluidraScheduleTimeEntity):
+    """Shared start/end logic for one auxiliary-output schedule slot."""
+
+    __slots__ = ("_aux_number",)
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        aux_number: str,
+        schedule_id: str,
+        time_type: str,
+    ) -> None:
+        """Initialize the aux schedule time entity."""
+        super().__init__(coordinator, api, pool_id, device_id, schedule_id, time_type, aux_number=aux_number)
+        self._aux_number = aux_number
+
+        self._attr_translation_placeholders = {"aux_number": aux_number, "schedule_id": schedule_id}
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def _async_set_time(self, value: time) -> None:
+        """Rewrite only the target slot's time field and PUT the aux register."""
+        self._optimistic_value = value
+        self.async_write_ha_state()
+
+        current_schedules = self._get_schedule_list()
+        if not current_schedules:
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            return
+
+        field = "startTime" if self._time_type == "start" else "endTime"
+        current_schedule = self._get_schedule_data()
+        if current_schedule and self._time_type == "start":
+            current_end_time = self._parse_cron_time(current_schedule.get("endTime", ""))
+            if current_end_time and value < current_end_time:
+                is_valid, error_msg = self._validate_schedule_overlap(value, current_end_time, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+        elif current_schedule and self._time_type == "end":
+            current_start_time = self._parse_cron_time(current_schedule.get("startTime", ""))
+            if current_start_time and value > current_start_time:
+                is_valid, error_msg = self._validate_schedule_overlap(current_start_time, value, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+
+        updated_schedules: list[dict[str, Any]] = []
+        for sched in current_schedules:
+            entry = dict(sched)
+            if str(entry.get("id")) == str(self._schedule_id):
+                entry[field] = _replace_cron_time(entry.get(field, ""), value)
+            entry.setdefault("groupId", entry.get("id"))
+            entry.pop("state", None)
+            entry.pop("endActions", None)
+            updated_schedules.append(entry)
+
+        component_id = self._get_schedule_component()
+        success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
+        if not success:
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_rejected",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
+        await self.coordinator.async_request_refresh()
+        self._optimistic_value = None
+        self.async_write_ha_state()
+
+
+class FluidraAuxScheduleStartTimeEntity(_FluidraAuxScheduleTimeEntity):
+    """Start time for one auxiliary-output schedule slot."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        aux_number: str,
+        schedule_id: str,
+    ) -> None:
+        """Initialize the aux schedule start time entity."""
+        super().__init__(coordinator, api, pool_id, device_id, aux_number, schedule_id, "start")
+        self._attr_translation_key = "aux_schedule_start"
+        self._attr_unique_id = f"fluidra_{self._device_id}_aux{aux_number}_schedule_{schedule_id}_start_time"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the entity."""
+        return "mdi:clock-start"
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the current start time."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        schedule = self._get_schedule_data()
+        if schedule:
+            return self._parse_cron_time(schedule.get("startTime", ""))
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the start time."""
+        self._ensure_pool_writable()
+        try:
+            await self._async_set_time(value)
+        except HomeAssistantError:
+            raise
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            FluidraError,
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+        ) as err:
+            _LOGGER.error("Failed to set aux %s schedule start time for %s: %s", self._aux_number, self._device_id, err)
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_failed",
+                translation_placeholders={"device_id": self._device_id},
+            ) from err
+
+
+class FluidraAuxScheduleEndTimeEntity(_FluidraAuxScheduleTimeEntity):
+    """End time for one auxiliary-output schedule slot."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        aux_number: str,
+        schedule_id: str,
+    ) -> None:
+        """Initialize the aux schedule end time entity."""
+        super().__init__(coordinator, api, pool_id, device_id, aux_number, schedule_id, "end")
+        self._attr_translation_key = "aux_schedule_end"
+        self._attr_unique_id = f"fluidra_{self._device_id}_aux{aux_number}_schedule_{schedule_id}_end_time"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the entity."""
+        return "mdi:clock-end"
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the current end time."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        schedule = self._get_schedule_data()
+        if schedule:
+            return self._parse_cron_time(schedule.get("endTime", ""))
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the end time."""
+        self._ensure_pool_writable()
+        try:
+            await self._async_set_time(value)
+        except HomeAssistantError:
+            raise
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            FluidraError,
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+        ) as err:
+            _LOGGER.error("Failed to set aux %s schedule end time for %s: %s", self._aux_number, self._device_id, err)
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_failed",
+                translation_placeholders={"device_id": self._device_id},
+            ) from err

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -15,7 +15,7 @@ from ..api_resilience import FluidraError
 from ..const import DEVICE_MODEL_FALLBACK, DEVICE_MODEL_MAP, DOMAIN
 from ..device_registry import DeviceIdentifier
 from ..entity import FluidraPoolControlEntity
-from ..helpers import get_schedule_data, resolve_schedule_component
+from ..helpers import get_aux_schedule_data, get_schedule_data, resolve_schedule_component
 from ..utils import extract_cron_days
 
 if TYPE_CHECKING:
@@ -97,8 +97,11 @@ class _FluidraTimeEntityBase(FluidraPoolControlEntity, TimeEntity):
         self._time_type = time_type  # "start" or "end"
 
     def _get_schedule_data(self) -> dict[str, Any] | None:
-        """Get schedule data from coordinator."""
+        """Get schedule data from coordinator (main or per-aux list)."""
         try:
+            aux_number = getattr(self, "_aux_number", None)
+            if aux_number is not None:
+                return get_aux_schedule_data(self.device_data, aux_number, self._schedule_id)
             return get_schedule_data(self.device_data, self._schedule_id)
         except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
             _LOGGER.debug("Failed to get schedule data for %s", self._device_id)
@@ -129,7 +132,7 @@ class _FluidraTimeEntityBase(FluidraPoolControlEntity, TimeEntity):
 class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
     """Base class for Fluidra pump/chlorinator schedule time entities."""
 
-    __slots__ = ("_optimistic_value",)
+    __slots__ = ("_aux_number", "_optimistic_value")
 
     def __init__(
         self,
@@ -139,13 +142,28 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
         device_id: str,
         schedule_id: str,
         time_type: str,
+        aux_number: str | None = None,
     ) -> None:
         """Initialize the time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, time_type)
         self._optimistic_value: time | None = None
+        self._aux_number = aux_number
+
+    def _get_schedule_list(self) -> list[dict[str, Any]]:
+        """Return the schedule list this entity edits (main or per-aux)."""
+        if self._aux_number is not None:
+            aux_schedules: list[dict[str, Any]] = (self.device_data.get("aux_schedule_data") or {}).get(
+                str(self._aux_number), []
+            )
+            return aux_schedules
+        schedules: list[dict[str, Any]] = self.device_data.get("schedule_data", [])
+        return schedules
 
     def _get_schedule_component(self) -> int:
         """Get the correct schedule component ID for this device."""
+        if self._aux_number is not None:
+            aux_map = DeviceIdentifier.get_feature(self.device_data, "aux_schedule_components", {})
+            return int(aux_map.get(str(self._aux_number), 22))
         device_data = self.device_data
         # Per-device override (e.g. 258 for DM24049704 chlorinator).
         schedule_comp: int = resolve_schedule_component(device_data)
@@ -184,11 +202,9 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
     ) -> tuple[bool, str]:
         """Validate that the new schedule doesn't overlap with existing enabled schedules."""
         try:
-            device_data = self.device_data
-            if "schedule_data" not in device_data:
+            current_schedules = self._get_schedule_list()
+            if not current_schedules:
                 return True, ""
-
-            current_schedules = device_data["schedule_data"]
             current_schedule = next(
                 (schedule for schedule in current_schedules if str(schedule.get("id")) == str(schedule_id_to_update)),
                 None,

--- a/custom_components/fluidra_pool/time/schedule.py
+++ b/custom_components/fluidra_pool/time/schedule.py
@@ -79,13 +79,7 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
             self._optimistic_value = value
             self.async_write_ha_state()
 
-            device_data = self.device_data
-            if "schedule_data" not in device_data:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                return
-
-            current_schedules = device_data["schedule_data"]
+            current_schedules = self._get_schedule_list()
             if not current_schedules:
                 self._optimistic_value = None
                 self.async_write_ha_state()
@@ -220,13 +214,7 @@ class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
             self._optimistic_value = value
             self.async_write_ha_state()
 
-            device_data = self.device_data
-            if "schedule_data" not in device_data:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                return
-
-            current_schedules = device_data["schedule_data"]
+            current_schedules = self._get_schedule_list()
             if not current_schedules:
                 self._optimistic_value = None
                 self.async_write_ha_state()

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -322,6 +322,9 @@
       "auto_mode": {
         "name": "Auto Mode"
       },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Schedule {schedule_id}"
+      },
       "boost_mode": {
         "name": "Boost Mode"
       },
@@ -348,6 +351,12 @@
       }
     },
     "time": {
+      "aux_schedule_end": {
+        "name": "Aux {aux_number} Schedule {schedule_id} End"
+      },
+      "aux_schedule_start": {
+        "name": "Aux {aux_number} Schedule {schedule_id} Start"
+      },
       "light_schedule_end": {
         "name": "Light Schedule {schedule_id} End"
       },

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -322,6 +322,9 @@
       "auto_mode": {
         "name": "Mode Auto"
       },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Planning {schedule_id}"
+      },
       "boost_mode": {
         "name": "Mode Boost"
       },
@@ -348,6 +351,12 @@
       }
     },
     "time": {
+      "aux_schedule_end": {
+        "name": "Aux {aux_number} Planning {schedule_id} Fin"
+      },
+      "aux_schedule_start": {
+        "name": "Aux {aux_number} Planning {schedule_id} Début"
+      },
       "light_schedule_end": {
         "name": "Planning Éclairage {schedule_id} Fin"
       },

--- a/tests/test_aux_schedule.py
+++ b/tests/test_aux_schedule.py
@@ -1,0 +1,479 @@
+"""Tests for aux-output schedules on the eXO iQ (Aux 1 = c22, Aux 2 = c24).
+
+Covers the time entities (start/end) and the enable switch, plus the
+coordinator parsing of the fixed aux schedule registers (Issue #174).
+"""
+
+from __future__ import annotations
+
+from datetime import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from custom_components.fluidra_pool.device_registry import DeviceIdentifier
+from custom_components.fluidra_pool.switch.schedule import FluidraScheduleEnableSwitch
+from custom_components.fluidra_pool.time.aux_schedule import (
+    FluidraAuxScheduleEndTimeEntity,
+    FluidraAuxScheduleStartTimeEntity,
+)
+
+POOL_ID = "pool-1"
+DEVICE_ID = "NS25007212"
+
+AUX_SCHEDULE_COMPONENTS = {"1": 22, "2": 24}
+
+
+@pytest.fixture(autouse=True)
+def _skip_sleeps() -> Any:
+    """Skip optimistic delays so tests don't wait."""
+    with patch("custom_components.fluidra_pool.time.aux_schedule.asyncio.sleep", new=AsyncMock()):
+        yield
+
+
+def _identify_cache() -> dict:
+    return {
+        "_identify_cache": {
+            "key": (DEVICE_ID, "", "", "chlorinator", ""),
+            "config": SimpleNamespace(
+                device_type="chlorinator",
+                features={
+                    "schedule_component": 20,
+                    "aux_schedule_components": AUX_SCHEDULE_COMPONENTS,
+                    "aux_schedule_count": 2,
+                },
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=[],
+            ),
+        },
+    }
+
+
+def _aux_device(aux_schedules: dict[str, list[dict]] | None) -> dict:
+    """eXO device with per-aux schedule data (Aux 1 = c22, Aux 2 = c24)."""
+    device: dict[str, Any] = {
+        "device_id": DEVICE_ID,
+        "name": "eXO iQ 18 R",
+        "family": "",
+        "model": "",
+        "type": "chlorinator",
+        "online": True,
+        "components": {},
+        **_identify_cache(),
+    }
+    if aux_schedules is not None:
+        device["aux_schedule_data"] = aux_schedules
+    return device
+
+
+def _coord(device: dict) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _attach_ha(entity) -> None:
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+
+def _api(*, success: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(set_schedule=AsyncMock(return_value=success))
+
+
+AUX1_SCHEDULE = {
+    "id": 1,
+    "groupId": 1,
+    "state": "IDLE",
+    "enabled": True,
+    "startTime": "0 20 * * 1,2,3",
+    "endTime": "0 21 * * 1,2,3",
+    "startActions": {},
+}
+
+
+# --- coordinator parsing --------------------------------------------------
+
+
+def test_coordinator_parses_aux_schedule_registers() -> None:
+    """c22/c24 reportedValue lists land in device['aux_schedule_data'] keyed by aux."""
+    device = _aux_device(None)
+    device["type"] = "chlorinator"
+    device["family"] = "chlorinator"
+
+    config = DeviceIdentifier.identify_device(device)
+    assert config is not None
+    assert config.features.get("aux_schedule_components") == AUX_SCHEDULE_COMPONENTS
+
+    # Directly exercise the decoder branch without a full coordinator.
+    from custom_components.fluidra_pool.coordinator.coordinator import (
+        FluidraDataUpdateCoordinator as _Coord,
+    )
+
+    coord = _Coord.__new__(_Coord)  # bypass __init__; only _process_component_state is used
+    coord._track_schedule_count = MagicMock()
+    coord._process_component_state(device, POOL_ID, 22, {"reportedValue": [AUX1_SCHEDULE], "id": 22})
+    coord._process_component_state(device, POOL_ID, 24, {"reportedValue": [], "id": 24})
+
+    assert device["aux_schedule_data"]["1"] == [AUX1_SCHEDULE]
+    assert device["aux_schedule_data"]["2"] == []
+
+
+def test_coordinator_does_not_parse_aux_registers_without_feature() -> None:
+    """A device without aux_schedule_components ignores c22/c24 as aux schedules."""
+    from custom_components.fluidra_pool.coordinator.coordinator import (
+        FluidraDataUpdateCoordinator as _Coord,
+    )
+
+    plain_device: dict[str, Any] = {
+        "device_id": "DM-OTHER",
+        "name": "Chlorinator",
+        "family": "",
+        "model": "",
+        "type": "chlorinator",
+        "online": True,
+        "components": {},
+        "_identify_cache": {
+            "key": ("DM-OTHER", "", "", "chlorinator", ""),
+            "config": SimpleNamespace(
+                device_type="chlorinator",
+                features={},  # no aux_schedule_components
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=[],
+            ),
+        },
+    }
+    coord = _Coord.__new__(_Coord)
+    coord._track_schedule_count = MagicMock()
+    coord._process_component_state(plain_device, POOL_ID, 22, {"reportedValue": [AUX1_SCHEDULE], "id": 22})
+
+    assert "aux_schedule_data" not in plain_device
+
+
+# --- time entity native_value --------------------------------------------
+
+
+def test_aux_schedule_start_native_value_decodes_cron() -> None:
+    """The start time entity reads the aux 1 slot from aux_schedule_data."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    assert entity.native_value == time(20, 0)
+    assert entity.available is True
+
+
+def test_aux_schedule_end_native_value_decodes_cron() -> None:
+    """The end time entity reads the aux 1 slot from aux_schedule_data."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    entity = FluidraAuxScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    assert entity.native_value == time(21, 0)
+
+
+def test_aux_schedule_entity_unavailable_without_aux_data() -> None:
+    """No aux schedule data for this aux → the entity stays unavailable."""
+    device = _aux_device({})
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    assert entity.native_value is None
+    assert entity.available is False
+
+
+def test_aux_schedule_entity_unavailable_when_aux_register_empty() -> None:
+    """An empty aux register (no schedules configured) leaves the entity unavailable."""
+    device = _aux_device({"1": []})
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    assert entity.native_value is None
+    assert entity.available is False
+
+
+def test_aux_schedule_icons() -> None:
+    """Start and end time entities expose their clock icons."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    start = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    end = FluidraAuxScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    assert start.icon == "mdi:clock-start"
+    assert end.icon == "mdi:clock-end"
+
+
+def test_aux_schedule_native_value_returns_optimistic() -> None:
+    """While an optimistic value is pending it wins over the API data."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    start = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    end = FluidraAuxScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(start)
+    _attach_ha(end)
+
+    start._optimistic_value = time(6, 0)
+    end._optimistic_value = time(7, 30)
+    assert start.native_value == time(6, 0)
+    assert end.native_value == time(7, 30)
+
+
+# --- time entity write path -----------------------------------------------
+
+
+async def test_aux_schedule_start_set_value_writes_aux_component() -> None:
+    """Setting the start time PUTs the aux 1 register (component 22)."""
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE)]})
+    api = _api()
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(8, 30))
+
+    api.set_schedule.assert_awaited_once()
+    _args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 22
+    sent = _args[1]
+    assert sent[0]["startTime"] == "30 8 * * 1,2,3"
+    assert sent[0]["endTime"] == "0 21 * * 1,2,3"
+    assert sent[0]["enabled"] is True
+    # Read-only runtime fields are stripped for the write (Issue #89/#174).
+    assert "state" not in sent[0]
+    assert "endActions" not in sent[0]
+
+
+async def test_aux_schedule_end_set_value_writes_aux_component() -> None:
+    """Setting the end time PUTs the aux 2 register (component 24)."""
+    device = _aux_device({"2": [dict(AUX1_SCHEDULE)]})
+    api = _api()
+    entity = FluidraAuxScheduleEndTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "2", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(22, 15))
+
+    api.set_schedule.assert_awaited_once()
+    _args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 24
+    sent = _args[1]
+    assert sent[0]["endTime"] == "15 22 * * 1,2,3"
+
+
+async def test_aux_schedule_start_set_value_no_op_without_aux_data() -> None:
+    """No aux schedule data → the write is a no-op (no API call)."""
+    device = _aux_device({})
+    api = _api()
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(8, 0))
+    api.set_schedule.assert_not_awaited()
+
+
+async def test_aux_schedule_start_set_value_raises_on_api_failure() -> None:
+    """A rejected PUT surfaces as HomeAssistantError."""
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE)]})
+    api = _api(success=False)
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_value(time(8, 0))
+
+
+async def test_aux_schedule_set_value_raises_on_connection_error() -> None:
+    """A connection error during the PUT surfaces as HomeAssistantError."""
+    from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
+
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE)]})
+    api = SimpleNamespace(set_schedule=AsyncMock(side_effect=FluidraConnectionError("net down")))
+    start = FluidraAuxScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
+    end = FluidraAuxScheduleEndTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(start)
+    _attach_ha(end)
+
+    with pytest.raises(HomeAssistantError):
+        await start.async_set_value(time(8, 0))
+    with pytest.raises(HomeAssistantError):
+        await end.async_set_value(time(9, 0))
+
+
+async def test_aux_schedule_start_set_value_rejects_overlap() -> None:
+    """A start time overlapping another enabled aux-1 slot is rejected."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    slot2 = {
+        "id": 2,
+        "groupId": 2,
+        "state": "IDLE",
+        "enabled": True,
+        "startTime": "0 20 * * 1,2,3",
+        "endTime": "0 21 * * 1,2,3",
+        "startActions": {},
+    }
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE), slot2]})
+    entity = FluidraAuxScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    # Editing slot 1's start to 20:30 collides with slot 2's 20:00-21:00 window.
+    with pytest.raises(ServiceValidationError):
+        await entity.async_set_value(time(20, 30))
+
+
+async def test_aux_schedule_end_set_value_rejects_overlap() -> None:
+    """An end time overlapping another enabled aux-1 slot is rejected."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    slot2 = {
+        "id": 2,
+        "groupId": 2,
+        "state": "IDLE",
+        "enabled": True,
+        "startTime": "0 20 * * 1,2,3",
+        "endTime": "0 21 * * 1,2,3",
+        "startActions": {},
+    }
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE), slot2]})
+    entity = FluidraAuxScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", "1")
+    _attach_ha(entity)
+
+    # Editing slot 1's end to 20:45 collides with slot 2's 20:00-21:00 window.
+    with pytest.raises(ServiceValidationError):
+        await entity.async_set_value(time(20, 45))
+
+
+# --- enable switch --------------------------------------------------------
+
+
+def test_aux_schedule_enable_switch_is_on_from_aux_data() -> None:
+    """The enable switch reads the aux slot's enabled flag."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    assert entity.is_on is True
+    assert entity.available is True
+
+
+def test_aux_schedule_enable_switch_unique_id() -> None:
+    """The aux enable switch has a distinct unique_id (aux-qualified)."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", aux_number="1")
+    assert entity.unique_id == f"fluidra_{DEVICE_ID}_aux1_schedule_1_enabled"
+
+
+async def test_aux_schedule_enable_switch_turn_off_writes_aux_component() -> None:
+    """Disabling an aux schedule PUTs the aux 1 register (component 22)."""
+    device = _aux_device({"1": [dict(AUX1_SCHEDULE)]})
+    api = _api()
+    entity = FluidraScheduleEnableSwitch(_coord(device), api, POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    await entity.async_turn_off()
+
+    api.set_schedule.assert_awaited_once()
+    _args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 22
+    assert _args[1][0]["enabled"] is False
+
+
+async def test_aux_schedule_enable_switch_turn_on_writes_aux_component() -> None:
+    """Enabling an aux schedule PUTs the aux 2 register (component 24)."""
+    disabled = dict(AUX1_SCHEDULE)
+    disabled["enabled"] = False
+    device = _aux_device({"2": [disabled]})
+    api = _api()
+    entity = FluidraScheduleEnableSwitch(_coord(device), api, POOL_ID, DEVICE_ID, "1", aux_number="2")
+    _attach_ha(entity)
+
+    await entity.async_turn_on()
+
+    api.set_schedule.assert_awaited_once()
+    _args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 24
+    assert _args[1][0]["enabled"] is True
+
+
+async def test_aux_schedule_enable_switch_no_op_without_aux_data() -> None:
+    """No aux data → toggle is a no-op."""
+    device = _aux_device({})
+    api = _api()
+    entity = FluidraScheduleEnableSwitch(_coord(device), api, POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    await entity.async_turn_on()
+    api.set_schedule.assert_not_awaited()
+
+
+# --- platform gating ------------------------------------------------------
+
+
+def test_aux_schedule_entities_only_for_exo_profile() -> None:
+    """Devices without aux_schedule_components get no aux schedule entities.
+
+    Exercises the platform wiring through the shared builder for a non-eXO
+    device (a plain pump) to prove no aux entities are produced.
+    """
+    from homeassistant.components.switch import SwitchEntity
+    from homeassistant.components.time import TimeEntity
+
+    from custom_components.fluidra_pool.switch.__init__ import async_setup_entry as switch_setup
+    from custom_components.fluidra_pool.time.__init__ import async_setup_entry as time_setup
+
+    pump_device: dict[str, Any] = {
+        "device_id": "PUMP-1",
+        "name": "Pump",
+        "family": "",
+        "model": "E30iQ",
+        "type": "pump",
+        "online": True,
+        "components": {},
+        "schedule_data": [],
+        "_identify_cache": {
+            "key": ("PUMP-1", "", "", "pump", ""),
+            "config": SimpleNamespace(
+                device_type="pump",
+                features={"skip_schedules": True},
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=[],
+            ),
+        },
+    }
+    coordinator = _coord(pump_device)
+    coordinator.api.cached_pools = [{"id": POOL_ID, "devices": [pump_device]}]
+    coordinator.get_pools_from_data = MagicMock(return_value=[])
+    config_entry = MagicMock(runtime_data=SimpleNamespace(coordinator=coordinator))
+    config_entry.async_on_unload = lambda _callback: None
+
+    added_switch: list[SwitchEntity] = []
+    added_time: list[TimeEntity] = []
+
+    import asyncio
+
+    async def _run() -> None:
+        await switch_setup(None, config_entry, added_switch.append)
+        await time_setup(None, config_entry, added_time.append)
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+    # No aux schedule entities on a device without the feature.
+    assert not any("aux1" in str(e) for e in added_switch)
+    assert not any("aux1" in str(e) for e in added_time)
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def test_get_aux_schedule_data_finds_slot() -> None:
+    """get_aux_schedule_data matches by string id across aux numbers."""
+    from custom_components.fluidra_pool.helpers import get_aux_schedule_data
+
+    device = _aux_device({"1": [AUX1_SCHEDULE], "2": [{"id": 1, "enabled": False}]})
+    assert get_aux_schedule_data(device, "1", 1) == AUX1_SCHEDULE
+    assert get_aux_schedule_data(device, "2", "1") == {"id": 1, "enabled": False}
+    assert get_aux_schedule_data(device, "1", "99") is None
+    assert get_aux_schedule_data({}, "1", "1") is None


### PR DESCRIPTION
## Summary

Closes the buildable half of **#174**: the Zodiac eXO iQ keeps aux-output schedules on fixed registers independent of the pump type — **Aux 1 = c22, Aux 2 = c24**, up to two slots each. Those registers were missing from the profile's `specific_components`, so they were never scanned and no aux schedule entity existed.

## Changes

- **Profile** (`device_registry/configs/chlorinators.py`): declare `aux_schedule_components: {1: 22, 2: 24}` + `aux_schedule_count: 2`, add c22/c24 to the scan
- **Coordinator**: decode c22/c24 into `device['aux_schedule_data']` keyed by aux number
- **Time** (`time/aux_schedule.py`, new): start/end time entities per aux slot, reusing the shared schedule base (optimistic values, overlap validation, runtime-field stripping)
- **Switch**: enable/disable switch per aux slot, component-aware (writes to 22 vs 24)
- **Translations**: EN + FR (`aux_schedule_start/end/enable`)

## Safety

- Entities are only created for profiles declaring `aux_schedule_components` — a device without the feature gets none
- An empty aux register (no schedule configured) leaves the entity **unavailable**, never pretending a schedule exists
- Write path preserves `startActions` and strips read-only runtime fields (`state`/`endActions`), same contract as the pump schedules (Issue #89/#174)

## Tests

- 22 new tests in `tests/test_aux_schedule.py` (coordinator parsing, native_value, write component id, overlap rejection, enable switch, platform gating)
- Full suite: **1721 passed**, coverage 96.3%
- ruff, mypy strict, pre-commit all green
- Deployed on HA dev: boot clean, 0 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auxiliary-output scheduling for supported eXO chlorinators, including Aux 1 and Aux 2.
  * Added controls to enable or disable each auxiliary schedule.
  * Added start and end time controls for multiple schedule slots.
  * Added schedule validation to prevent overlapping times and provide safer updates.
  * Added English and French translations for the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->