### PR TITLE
fix: route tecnoLC2 by thingType before registers are scanned

### DIFF
--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -128,7 +128,9 @@ def _identify_device_uncached(
     return best_match
 
 
-def _tecnolc2_signature_override(config: DeviceConfig | None, components: dict[str, Any]) -> DeviceConfig | None:
+def _tecnolc2_signature_override(
+    config: DeviceConfig | None, components: dict[str, Any], thing_type: str = ""
+) -> DeviceConfig | None:
     """Re-route the domoticS2 catch-all to the tecnoLC2 profile when the components say so.
 
     Applied *after* identification (and outside the device-level cache) so it re-reads
@@ -139,6 +141,12 @@ def _tecnolc2_signature_override(config: DeviceConfig | None, components: dict[s
     """
     if config is not DEVICE_CONFIGS.get("chlorinator"):
         return config
+    # The Fluidra cloud labels the unit thingType "tecnoLC2" (GenSalt OE iQ family) as
+    # soon as the device tree is fetched — before c8/c172 are even scanned. That is the
+    # most reliable signal, so use it directly (case-insensitive) in addition to the
+    # component signature, which only becomes usable after the first register scan.
+    if thing_type and "tecnolc2" in thing_type.lower():
+        return DEVICE_CONFIGS.get("tecnolc2_signature", config)
     comp8_value = str(components["8"].get("reportedValue", "")) if isinstance(components.get("8"), dict) else ""
     comp172_value = str(components["172"].get("reportedValue", "")) if isinstance(components.get("172"), dict) else ""
     if _looks_like_tecnolc2(comp8_value, comp172_value):
@@ -196,6 +204,10 @@ class DeviceIdentifier:
         # signature so a signature change (first vs subsequent polls) invalidates it.
         raw_components = device.get("components")
         components: dict[str, Any] = raw_components if isinstance(raw_components, dict) else {}
+        # The Fluidra cloud exposes the unit's thingType (e.g. "tecnoLC2") on the
+        # status tree from the very first fetch — available before any register scan.
+        status = device.get("status")
+        thing_type = str(status.get("thingType", "")) if isinstance(status, dict) else ""
         comp7_value = ""
         if "7" in components and isinstance(components["7"], dict):
             comp7_value = str(components["7"].get("reportedValue", ""))
@@ -211,7 +223,7 @@ class DeviceIdentifier:
         if isinstance(cache, dict) and cache.get("key") == cache_key:
             # The tecnoLC2 signature is re-evaluated here (not baked into the cache) so
             # it activates as soon as c8/c172 are scanned, without a key change.
-            return _tecnolc2_signature_override(cache.get("config"), components)
+            return _tecnolc2_signature_override(cache.get("config"), components, thing_type)
 
         result = _identify_device_uncached(
             device_id=str(cache_key[0]),
@@ -222,7 +234,7 @@ class DeviceIdentifier:
             comp7_value=comp7_value,
         )
         device["_identify_cache"] = {"key": cache_key, "config": result}
-        return _tecnolc2_signature_override(result, components)
+        return _tecnolc2_signature_override(result, components, thing_type)
 
     @staticmethod
     def should_create_entity(device: dict[str, Any], entity_type: str) -> bool:

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -1062,6 +1062,20 @@ class TestTecnoLC2Signature:
         config = DeviceIdentifier.identify_device(self._device("CC29999998.nn_1", **{"8": 0}))
         assert self._name(config) == "chlorinator"
 
+    def test_thing_type_tecnoLC2_routes_before_components_scanned(self):
+        """thingType from the status tree is enough, even before c8/c172 are scanned."""
+        device = self._device("CC29990003.nn_1")
+        device["status"] = {"thingType": "tecnoLC2"}
+        device["components"] = {}
+        assert self._name(DeviceIdentifier.identify_device(device)) == "tecnolc2_signature"
+        assert DeviceIdentifier.has_feature(device, "skip_mode_select") is True
+
+    def test_thing_type_other_value_keeps_component_signature(self):
+        """Non-tecnoLC2 thingType does not short-circuit the existing component check."""
+        device = self._device("CC29990004.nn_1", **{"8": 0, "172": 303})
+        device["status"] = {"thingType": "domoticS2"}
+        assert self._name(DeviceIdentifier.identify_device(device)) == "tecnolc2_signature"
+
     def test_signature_activates_after_components_are_scanned(self):
         """The override is re-evaluated post-cache: it flips once c8/c172 are present."""
         device = self._device("CC29990002.nn_1")


### PR DESCRIPTION
## Description

Fixes #195 — GenSalt OE iQ chlorinator mode select stuck on `Off`.

### Root cause
Unknown-serial tecnoLC2 units fall to the generic `chlorinator` catch-all, which reads c20 as the mode (0/1/2). On tecnoLC2 units c20 is the **ORP setpoint in mV** (e.g. 700), outside the mapping → select always shows `Off` and reverts when set to On/Auto.

The existing component-signature fallback (blank c8 + c172 in the temperature band) only fires once those registers have been scanned — which happens *after* the mode-select entity is already created at setup.

### Fix
The Fluidra cloud exposes `thingType: "tecnoLC2"` on the device status tree from the **very first fetch**. Use it as the primary tecnoLC2 signal in `_tecnolc2_signature_override` (alongside the existing component check, kept for devices without a status tree).

Result: unknown-serial GenSalt OE iQ units get the standard tecnoLC2 profile immediately — `skip_mode_select` → no bogus mode select, correct pH/ORP/temperature/salinity registers.

### Tests
- `test_thing_type_tecnoLC2_routes_before_components_scanned` — thingType alone is enough, before any register scan (the #195 case).
- `test_thing_type_other_value_keeps_component_signature` — non-tecnoLC2 thingType does not short-circuit the existing component check.

Verified against the diagnostics export from #195: `thingType: tecnoLC2`, c8=0, c172=317 (31.7 °C).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification for devices labeled `tecnoLC2`.
  * Ensured these devices are assigned the correct profile before component-based detection.
  * Preserved existing detection behavior for devices without the `tecnoLC2` label.

* **Tests**
  * Added coverage for labeled and non-labeled device identification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->