### PR TITLE
fix(config_flow): distinct login errors per Cognito error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The login form now says what actually went wrong instead of always blaming the password.**
+  Every AWS Cognito rejection used to render as the same "check your email and password" message,
+  with the real cause reachable only in a debug log nobody enables before opening an issue. The
+  Cognito error type is now mapped to its own message: account not found on the EMEA servers,
+  account not yet confirmed, password reset required by Fluidra, and too many attempts each get
+  distinct, actionable wording in all five translation files. `NotAuthorizedException` keeps the
+  generic message on purpose — Cognito returns it both for a genuinely wrong password and for an
+  account absent from this user pool. Any unknown error type falls back to the same generic message
+  rather than failing, and the raw Cognito response body never reaches a displayed string; it stays
+  in the debug log exactly as before (Refs #201).
+
 ## [2.80.0] - 2026-08-17
 
 ### Changed

--- a/custom_components/fluidra_pool/api_resilience.py
+++ b/custom_components/fluidra_pool/api_resilience.py
@@ -47,7 +47,20 @@ class FluidraError(Exception):
 
 
 class FluidraAuthError(FluidraError):
-    """Exception for authentication errors."""
+    """Exception for authentication errors.
+
+    ``error_code`` carries the Cognito ``__type`` (``UserNotFoundException``,
+    ``PasswordResetRequiredException``, …) when the failure came from a Cognito
+    reply. The config flow maps it to a message that tells the user what to
+    actually do, instead of blaming their password for every failure mode
+    (Issue #201). It stays None for auth failures raised outside a Cognito
+    response — the generic message is the right answer there.
+    """
+
+    def __init__(self, message: str, error_code: str | None = None) -> None:
+        """Initialise with an optional Cognito error type."""
+        super().__init__(message)
+        self.error_code = error_code
 
 
 class FluidraConnectionError(FluidraError):

--- a/custom_components/fluidra_pool/config_flow.py
+++ b/custom_components/fluidra_pool/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, Final
 
 import aiohttp
 from homeassistant.config_entries import (
@@ -47,6 +47,38 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): _PASSWORD_SELECTOR,
     }
 )
+
+# Cognito rejects a sign-in for very different reasons, and every one of them
+# used to surface as "check your email and password" — so users opened issues
+# with no idea what had happened, and the real cause only existed in a debug log
+# nobody enables before reporting (Issue #201). The ``__type`` in the reply is
+# the only reliable discriminator; map the ones that change what the user should
+# DO next, and let everything else fall back to the generic message.
+#
+# Deliberately absent: ``NotAuthorizedException``. Cognito returns it both for a
+# genuinely wrong password AND — when the app client hides user-existence errors,
+# which is the default — for an account that simply isn't in this user pool. It
+# is a true "check your credentials", which is what ``invalid_auth`` already says.
+COGNITO_ERROR_KEYS: Final[Mapping[str, str]] = {
+    "UserNotFoundException": "account_not_found",
+    "UserNotConfirmedException": "account_not_confirmed",
+    "PasswordResetRequiredException": "password_reset_required",
+    "TooManyRequestsException": "too_many_attempts",
+    "TooManyFailedAttemptsException": "too_many_attempts",
+    "LimitExceededException": "too_many_attempts",
+}
+
+
+def cognito_error_key(error_code: str | None) -> str:
+    """Map a Cognito ``__type`` to a config-flow error translation key.
+
+    An unknown type — or None, when the failure carried no Cognito body at all —
+    falls back to the existing generic ``invalid_auth`` message. New Cognito
+    error types therefore degrade to today's behaviour instead of raising.
+    """
+    if not error_code:
+        return "invalid_auth"
+    return COGNITO_ERROR_KEYS.get(error_code, "invalid_auth")
 
 
 class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -322,7 +354,8 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             (None, None) on success.
             (None, {"session": ..., "challenge_name": ...}) when MFA is required.
-            (error_key, None) on failure.
+            (error_key, None) on failure — the key is derived from the Cognito
+            error type so the form explains the actual cause.
         """
         api = FluidraPoolAPI(email, password)
 
@@ -333,9 +366,15 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         except FluidraMFARequired as mfa_err:
             _LOGGER.info("MFA required for %s (%s)", mask_email(email), mfa_err.challenge_name)
             return None, {"session": mfa_err.session, "challenge_name": mfa_err.challenge_name}
-        except FluidraAuthError:
-            _LOGGER.warning("Invalid credentials for %s", mask_email(email))
-            return "invalid_auth", None
+        except FluidraAuthError as err:
+            # Only the Cognito error *type* is logged and mapped; the reply body
+            # itself never leaves the debug log in fluidra_api._auth.
+            _LOGGER.warning(
+                "Authentication rejected for %s (Cognito: %s)",
+                mask_email(email),
+                err.error_code or "no error type",
+            )
+            return cognito_error_key(err.error_code), None
         except (FluidraConnectionError, aiohttp.ClientError, TimeoutError):
             _LOGGER.warning("Cannot reach Fluidra API for %s", mask_email(email))
             return "cannot_connect", None
@@ -361,9 +400,19 @@ class FluidraPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             await api.respond_to_mfa(code, session, challenge_name)
             _LOGGER.info("MFA verification successful for %s", mask_email(email))
             return None, api.refresh_token
-        except FluidraAuthError:
-            _LOGGER.warning("MFA verification rejected for %s", mask_email(email))
-            return "invalid_mfa_code", None
+        except FluidraAuthError as err:
+            # Same Cognito surface, different step. A rate-limit rejection here is
+            # not a bad code, and telling the user to re-read their authenticator
+            # would send them round in circles. Every other failure on this step
+            # really is about the code (CodeMismatch / ExpiredCode / dead session).
+            mapped = cognito_error_key(err.error_code)
+            error_key = mapped if mapped == "too_many_attempts" else "invalid_mfa_code"
+            _LOGGER.warning(
+                "MFA verification rejected for %s (Cognito: %s)",
+                mask_email(email),
+                err.error_code or "no error type",
+            )
+            return error_key, None
         except (FluidraConnectionError, aiohttp.ClientError, TimeoutError):
             _LOGGER.warning("Cannot reach Fluidra API during MFA for %s", mask_email(email))
             return "cannot_connect", None

--- a/custom_components/fluidra_pool/fluidra_api/_auth.py
+++ b/custom_components/fluidra_pool/fluidra_api/_auth.py
@@ -29,6 +29,35 @@ from ._constants import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def cognito_error_type(data: Any, raw_text: str) -> str | None:
+    """Extract the Cognito ``__type`` from a failed authentication reply.
+
+    Cognito answers every failure with ``{"__type": "NotAuthorizedException",
+    "message": "..."}``, and sometimes qualifies the type as
+    ``com.amazonaws...#NotAuthorizedException`` — only the trailing segment is
+    kept. ``data`` is the already-parsed body; ``raw_text`` is a fallback for
+    the case where parsing happened elsewhere or produced a non-dict.
+
+    Returns None when there is no usable ``__type``: callers then fall back to
+    the generic "check your credentials" message rather than failing. Only the
+    type name is ever returned — the ``message`` field stays out, so nothing
+    from the raw body can reach a user-facing string.
+    """
+    payload: Any = data
+    if not isinstance(payload, dict):
+        try:
+            payload = json.loads(raw_text)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(payload, dict):
+        return None
+
+    raw_type = payload.get("__type")
+    if not isinstance(raw_type, str):
+        return None
+    return raw_type.strip().rpartition("#")[2] or None
+
+
 class AuthMixin(FluidraAPIBase):
     """Cognito sign-in, MFA, refresh-token rotation, and standard auth headers.
 
@@ -101,7 +130,10 @@ class AuthMixin(FluidraAPIBase):
 
         if status != 200 or data is None:
             _LOGGER.debug("Cognito auth failed body: %s", raw_text[:500])
-            raise FluidraAuthError(f"Cognito auth failed with status {status}")
+            raise FluidraAuthError(
+                f"Cognito auth failed with status {status}",
+                cognito_error_type(data, raw_text),
+            )
 
         auth_result = data.get("AuthenticationResult")
         if not auth_result:
@@ -144,7 +176,10 @@ class AuthMixin(FluidraAPIBase):
 
         if status != 200 or data is None:
             _LOGGER.debug("MFA verification failed body: %s", raw_text[:500])
-            raise FluidraAuthError(f"MFA verification failed with status {status}")
+            raise FluidraAuthError(
+                f"MFA verification failed with status {status}",
+                cognito_error_type(data, raw_text),
+            )
 
         auth_result = data.get("AuthenticationResult", {})
         self._store_tokens(auth_result)

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -6,10 +6,14 @@
       "reconfigure_successful": "Configuration updated successfully"
     },
     "error": {
+      "account_not_confirmed": "This account hasn't been confirmed yet. Open the Fluidra Pool app, finish the email verification Fluidra sent you, then try again.",
+      "account_not_found": "No Fluidra account exists for this email address on the EMEA (Europe) servers. Check it for a typo — and note that accounts registered outside EMEA are not supported yet.",
       "cannot_connect": "Unable to connect to Fluidra API",
       "invalid_auth": "Login failed. Check your email and password. If your account is registered outside the EMEA region (Europe), it is not currently supported.",
       "invalid_mfa_code": "Invalid or expired verification code. Please try again.",
       "no_pools": "No pools found. Make sure your equipment is configured in the Fluidra Pool app",
+      "password_reset_required": "Fluidra requires a password reset for this account. Reset it in the Fluidra Pool app or on the Fluidra website, then sign in here with the new password.",
+      "too_many_attempts": "Too many sign-in attempts. Fluidra has temporarily blocked this account — wait a few minutes before trying again.",
       "unknown": "Unexpected error"
     },
     "step": {

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -6,10 +6,14 @@
       "reconfigure_successful": "Configuration updated successfully"
     },
     "error": {
+      "account_not_confirmed": "This account hasn't been confirmed yet. Open the Fluidra Pool app, finish the email verification Fluidra sent you, then try again.",
+      "account_not_found": "No Fluidra account exists for this email address on the EMEA (Europe) servers. Check it for a typo — and note that accounts registered outside EMEA are not supported yet.",
       "cannot_connect": "Unable to connect to Fluidra API",
       "invalid_auth": "Login failed. Check your email and password. If your account is registered outside the EMEA region (Europe), it is not currently supported.",
       "invalid_mfa_code": "Invalid or expired verification code. Please try again.",
       "no_pools": "No pools found. Make sure your equipment is configured in the Fluidra Pool app",
+      "password_reset_required": "Fluidra requires a password reset for this account. Reset it in the Fluidra Pool app or on the Fluidra website, then sign in here with the new password.",
+      "too_many_attempts": "Too many sign-in attempts. Fluidra has temporarily blocked this account — wait a few minutes before trying again.",
       "unknown": "Unexpected error"
     },
     "step": {

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -6,10 +6,14 @@
       "reconfigure_successful": "Configuración actualizada correctamente"
     },
     "error": {
+      "account_not_confirmed": "Esta cuenta aún no ha sido confirmada. Abre la app Fluidra Pool, completa la verificación del correo que te envió Fluidra y vuelve a intentarlo.",
+      "account_not_found": "No existe ninguna cuenta de Fluidra con este correo en los servidores EMEA (Europa). Comprueba que no haya errores al escribirlo — y ten en cuenta que las cuentas registradas fuera de EMEA aún no son compatibles.",
       "cannot_connect": "No se puede conectar a la API de Fluidra",
       "invalid_auth": "Error de inicio de sesión. Verifica tu correo y contraseña. Si tu cuenta está registrada fuera de la región EMEA (Europa), no es compatible actualmente.",
       "invalid_mfa_code": "Código de verificación inválido o caducado. Inténtalo de nuevo.",
       "no_pools": "No se encontraron piscinas. Asegúrate de que tus equipos estén configurados en la app Fluidra Pool",
+      "password_reset_required": "Fluidra exige restablecer la contraseña de esta cuenta. Restablécela en la app Fluidra Pool o en la web de Fluidra y luego inicia sesión aquí con la nueva.",
+      "too_many_attempts": "Demasiados intentos de inicio de sesión. Fluidra ha bloqueado temporalmente esta cuenta — espera unos minutos antes de volver a intentarlo.",
       "unknown": "Error inesperado"
     },
     "step": {

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -6,10 +6,14 @@
       "reconfigure_successful": "Configuration mise à jour avec succès"
     },
     "error": {
+      "account_not_confirmed": "Ce compte n'a pas encore été confirmé. Ouvrez l'app Fluidra Pool, terminez la vérification de l'adresse e-mail envoyée par Fluidra, puis réessayez.",
+      "account_not_found": "Aucun compte Fluidra n'existe pour cette adresse e-mail sur les serveurs EMEA (Europe). Vérifiez la saisie — et notez que les comptes enregistrés hors EMEA ne sont pas encore pris en charge.",
       "cannot_connect": "Impossible de se connecter à l'API Fluidra",
       "invalid_auth": "Échec de la connexion. Vérifiez votre e-mail et votre mot de passe. Si votre compte est enregistré hors de la région EMEA (Europe), il n'est pas pris en charge actuellement.",
       "invalid_mfa_code": "Code de vérification invalide ou expiré. Veuillez réessayer.",
       "no_pools": "Aucune piscine trouvée. Assurez-vous que vos équipements sont configurés dans l'app Fluidra Pool",
+      "password_reset_required": "Fluidra exige une réinitialisation du mot de passe pour ce compte. Réinitialisez-le dans l'app Fluidra Pool ou sur le site Fluidra, puis connectez-vous ici avec le nouveau mot de passe.",
+      "too_many_attempts": "Trop de tentatives de connexion. Fluidra a temporairement bloqué ce compte — patientez quelques minutes avant de réessayer.",
       "unknown": "Erreur inattendue"
     },
     "step": {

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -6,10 +6,14 @@
       "reconfigure_successful": "Configuração atualizada com sucesso"
     },
     "error": {
+      "account_not_confirmed": "Esta conta ainda não foi confirmada. Abra o app Fluidra Pool, conclua a verificação do e-mail enviado pela Fluidra e tente novamente.",
+      "account_not_found": "Não existe nenhuma conta Fluidra com este e-mail nos servidores EMEA (Europa). Verifique se não há erros de digitação — e note que contas registradas fora da EMEA ainda não são suportadas.",
       "cannot_connect": "Não foi possível conectar à API Fluidra",
       "invalid_auth": "Falha no login. Verifique seu e-mail e senha. Se sua conta estiver registrada fora da região EMEA (Europa), não é suportada no momento.",
       "invalid_mfa_code": "Código de verificação inválido ou expirado. Tente novamente.",
       "no_pools": "Nenhuma piscina encontrada. Certifique-se de que seus equipamentos estão configurados no app Fluidra Pool",
+      "password_reset_required": "A Fluidra exige a redefinição da senha desta conta. Redefina-a no app Fluidra Pool ou no site da Fluidra e depois faça login aqui com a nova senha.",
+      "too_many_attempts": "Muitas tentativas de login. A Fluidra bloqueou temporariamente esta conta — aguarde alguns minutos antes de tentar novamente.",
       "unknown": "Erro inesperado"
     },
     "step": {

--- a/tests/test_config_flow_cognito_errors.py
+++ b/tests/test_config_flow_cognito_errors.py
@@ -1,0 +1,251 @@
+"""Tests for the Cognito error-type → config-flow message mapping.
+
+Every Cognito rejection used to surface as the single "check your email and
+password" message, so a user whose account was unconfirmed, rate-limited or
+simply absent from the EMEA pool had no way to know (Issue #201). These tests
+pin the extraction of the Cognito ``__type``, the mapping table, the fallback
+for unknown types, and the fact that the raw Cognito body never reaches a
+displayed string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.fluidra_pool.api_resilience import FluidraAuthError, FluidraMFARequired
+from custom_components.fluidra_pool.config_flow import (
+    COGNITO_ERROR_KEYS,
+    cognito_error_key,
+)
+from custom_components.fluidra_pool.const import DOMAIN
+from custom_components.fluidra_pool.fluidra_api._auth import AuthMixin, cognito_error_type
+
+_PATCH_TARGET = "custom_components.fluidra_pool.config_flow.FluidraPoolAPI"
+_COMPONENT_DIR = Path(__file__).parent.parent / "custom_components" / "fluidra_pool"
+_TRANSLATION_FILES = [
+    _COMPONENT_DIR / "strings.json",
+    *sorted((_COMPONENT_DIR / "translations").glob("*.json")),
+]
+
+
+class _FakeAPI(AuthMixin):
+    """Stub exposing only what the Cognito auth path touches."""
+
+    def __init__(self) -> None:
+        self.email = "user@example.com"
+        self.password = "pwd"
+        self.access_token: str | None = None
+        self.refresh_token: str | None = None
+        self.token_expires_at: int | None = None
+        self._last_token_store: float = 0.0
+        self._on_token_persist = None
+        self._token_lock = asyncio.Lock()
+        self._request = AsyncMock()
+
+
+def _cognito_failure(error_type: str, message: str = "Some Cognito detail") -> tuple[int, dict, str]:
+    """Build a realistic Cognito error triple as ``_request`` returns it."""
+    body = {"__type": error_type, "message": message}
+    return 400, body, json.dumps(body)
+
+
+# --- cognito_error_type --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"__type": "NotAuthorizedException"}, "NotAuthorizedException"),
+        # Cognito sometimes qualifies the type with its service namespace.
+        ({"__type": "com.amazonaws.cognito.idp#UserNotFoundException"}, "UserNotFoundException"),
+        ({"__type": "  UserNotConfirmedException  "}, "UserNotConfirmedException"),
+        ({"__type": ""}, None),
+        ({"__type": "#"}, None),
+        ({"__type": 42}, None),
+        ({"message": "no type at all"}, None),
+        ({}, None),
+    ],
+)
+def test_cognito_error_type_extraction(payload: dict, expected: str | None) -> None:
+    """The type name is extracted, unqualified, or None when unusable."""
+    assert cognito_error_type(payload, json.dumps(payload)) == expected
+
+
+def test_cognito_error_type_falls_back_to_raw_text() -> None:
+    """When the parsed body isn't a dict, the raw text is parsed instead."""
+    assert cognito_error_type(None, '{"__type": "LimitExceededException"}') == "LimitExceededException"
+
+
+@pytest.mark.parametrize("raw_text", ["", "not json at all", "[1, 2, 3]", '"a string"'])
+def test_cognito_error_type_returns_none_on_unparseable_body(raw_text: str) -> None:
+    """A body that isn't a JSON object never raises — it just yields None."""
+    assert cognito_error_type(None, raw_text) is None
+
+
+# --- cognito_error_key ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected"),
+    [
+        ("UserNotFoundException", "account_not_found"),
+        ("UserNotConfirmedException", "account_not_confirmed"),
+        ("PasswordResetRequiredException", "password_reset_required"),
+        ("TooManyRequestsException", "too_many_attempts"),
+        ("TooManyFailedAttemptsException", "too_many_attempts"),
+        ("LimitExceededException", "too_many_attempts"),
+        # NotAuthorizedException really does mean "check your credentials":
+        # Cognito returns it for a wrong password and for an account that isn't
+        # in this user pool at all.
+        ("NotAuthorizedException", "invalid_auth"),
+        # Unknown / absent types degrade to today's generic message.
+        ("SomeFutureCognitoException", "invalid_auth"),
+        ("", "invalid_auth"),
+        (None, "invalid_auth"),
+    ],
+)
+def test_cognito_error_key_mapping(error_code: str | None, expected: str) -> None:
+    """Each known type maps to its own message key; anything else falls back."""
+    assert cognito_error_key(error_code) == expected
+
+
+@pytest.mark.parametrize("translation_file", _TRANSLATION_FILES, ids=lambda p: p.name)
+def test_every_mapped_key_is_translated(translation_file: Path) -> None:
+    """A mapped key with no translation would render as a raw key in the UI."""
+    errors = json.loads(translation_file.read_text(encoding="utf-8"))["config"]["error"]
+    for key in {*COGNITO_ERROR_KEYS.values(), "invalid_auth"}:
+        assert errors.get(key), f"{key} missing or empty in {translation_file.name}"
+
+
+def test_french_strings_are_actually_translated() -> None:
+    """French is mandatory here — and a copy of the English string isn't one."""
+    fr = json.loads((_COMPONENT_DIR / "translations" / "fr.json").read_text(encoding="utf-8"))["config"]["error"]
+    en = json.loads((_COMPONENT_DIR / "translations" / "en.json").read_text(encoding="utf-8"))["config"]["error"]
+    for key in COGNITO_ERROR_KEYS.values():
+        assert fr[key] != en[key], f"{key} is still the English string in fr.json"
+
+
+# --- the API layer attaches the type -------------------------------------
+
+
+async def test_initial_auth_attaches_cognito_error_code() -> None:
+    """A Cognito rejection carries its ``__type`` on the raised exception."""
+    api = _FakeAPI()
+    api._request.return_value = _cognito_failure("PasswordResetRequiredException")
+
+    with pytest.raises(FluidraAuthError) as excinfo:
+        await api._cognito_initial_auth()
+
+    assert excinfo.value.error_code == "PasswordResetRequiredException"
+
+
+async def test_initial_auth_error_message_never_leaks_the_cognito_body() -> None:
+    """The displayed/raised message carries the status only, never the body."""
+    api = _FakeAPI()
+    api._request.return_value = _cognito_failure("NotAuthorizedException", "Incorrect username or password.")
+
+    with pytest.raises(FluidraAuthError) as excinfo:
+        await api._cognito_initial_auth()
+
+    assert "Incorrect username or password" not in str(excinfo.value)
+    assert "__type" not in str(excinfo.value)
+    assert str(excinfo.value) == "Cognito auth failed with status 400"
+
+
+async def test_initial_auth_error_code_is_none_without_a_cognito_body() -> None:
+    """An empty/garbled body leaves error_code None, so the flow stays generic."""
+    api = _FakeAPI()
+    api._request.return_value = (503, None, "<html>gateway error</html>")
+
+    with pytest.raises(FluidraAuthError) as excinfo:
+        await api._cognito_initial_auth()
+
+    assert excinfo.value.error_code is None
+    assert cognito_error_key(excinfo.value.error_code) == "invalid_auth"
+
+
+async def test_mfa_failure_attaches_cognito_error_code() -> None:
+    """The MFA step reports its Cognito type the same way the login step does."""
+    api = _FakeAPI()
+    api._request.return_value = _cognito_failure("TooManyRequestsException")
+
+    with pytest.raises(FluidraAuthError) as excinfo:
+        await api._cognito_respond_to_mfa("123456", "session-token")
+
+    assert excinfo.value.error_code == "TooManyRequestsException"
+
+
+# --- end-to-end through the config flow ----------------------------------
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected_key"),
+    [
+        ("UserNotFoundException", "account_not_found"),
+        ("UserNotConfirmedException", "account_not_confirmed"),
+        ("PasswordResetRequiredException", "password_reset_required"),
+        ("TooManyRequestsException", "too_many_attempts"),
+        ("NotAuthorizedException", "invalid_auth"),
+        ("SomeFutureCognitoException", "invalid_auth"),
+        (None, "invalid_auth"),
+    ],
+)
+async def test_user_flow_surfaces_the_matching_error(
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    error_code: str | None,
+    expected_key: str,
+) -> None:
+    """The form shows the message matching the Cognito type, not a catch-all."""
+    mock_api.initial_auth.side_effect = FluidraAuthError("Cognito auth failed with status 400", error_code)
+
+    with patch(_PATCH_TARGET, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "whatever"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_key}
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected_key"),
+    [
+        ("TooManyRequestsException", "too_many_attempts"),
+        ("CodeMismatchException", "invalid_mfa_code"),
+        ("ExpiredCodeException", "invalid_mfa_code"),
+        (None, "invalid_mfa_code"),
+    ],
+)
+async def test_mfa_step_distinguishes_rate_limiting_from_a_bad_code(
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    error_code: str | None,
+    expected_key: str,
+) -> None:
+    """A rate-limited MFA attempt must not be reported as a wrong code."""
+    mock_api.initial_auth.side_effect = FluidraMFARequired("SOFTWARE_TOKEN_MFA", "session-token")
+    mock_api.respond_to_mfa.side_effect = FluidraAuthError("MFA verification failed with status 400", error_code)
+
+    with patch(_PATCH_TARGET, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "whatever"},
+        )
+        assert result["step_id"] == "mfa"
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"mfa_code": "000000"})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_key}


### PR DESCRIPTION
## Why

Issue #201 arrived with an empty log section, and that is not the reporter's fault: the config flow answers **every** AWS Cognito rejection with the same sentence — *"Login failed. Check your email and password."* Account unknown, account not confirmed, password reset demanded by Fluidra, too many attempts, wrong password: one message for all of them. The real cause is written to `_LOGGER.debug`, which nobody enables before opening an issue.

This PR makes that message useful. It does **not** fix #201 — the reporter's own problem still needs his log line — it makes sure the next person reads what actually happened.

## What changed

`FluidraAuthError` now carries the Cognito `__type` (`error_code`), extracted by a new `cognito_error_type()` helper in `fluidra_api/_auth.py`. The config flow maps it to a distinct translation key:

| Cognito `__type` | Message key |
|---|---|
| `UserNotFoundException` | `account_not_found` |
| `UserNotConfirmedException` | `account_not_confirmed` |
| `PasswordResetRequiredException` | `password_reset_required` |
| `TooManyRequestsException` / `TooManyFailedAttemptsException` / `LimitExceededException` | `too_many_attempts` |
| `NotAuthorizedException` | `invalid_auth` (unchanged, deliberately) |
| anything else, or no Cognito body at all | `invalid_auth` (fallback) |

`NotAuthorizedException` is deliberately **not** remapped: Cognito returns it both for a genuinely wrong password and — when the app client hides user-existence errors, which is the default — for an account that simply isn't in this user pool. "Check your credentials" is the honest answer there, and it's what the existing message already says.

An unknown `__type` falls back to today's generic message rather than raising, so a Cognito error type we've never seen degrades to current behaviour instead of breaking the flow.

**The raw Cognito body never reaches a displayed string.** Only the type name is extracted; the body stays in the same `_LOGGER.debug` line as before. The warning log gained the type name only.

The MFA step reuses the table for one case: a rate-limited attempt is no longer reported as a wrong verification code. Everything else on that step still maps to `invalid_mfa_code`.

## Translations

New keys in `strings.json` and all four locales — `en`, `fr`, `es`, `pt` — keeping the files at full parity.

## Tests

New `tests/test_config_flow_cognito_errors.py`, 44 cases:

- `cognito_error_type()` — plain type, namespace-qualified (`com.amazonaws...#X`), padded, empty, non-string, missing, and unparseable bodies (never raises)
- `cognito_error_key()` — one case per mapped type, plus `NotAuthorizedException`, an unknown future type, `""` and `None`
- the API layer attaches the type on both the login and the MFA path
- the raised message contains neither the Cognito body nor `__type`
- every mapped key exists and is non-empty in all five translation files, and the French strings are not English copies
- end-to-end through the config flow: each type produces its own `errors["base"]`, including the fallbacks

## Gate

```
ruff check           All checks passed!
ruff format --check  117 files already formatted
mypy (strict)        Success: no issues found in 61 source files
pytest               1773 passed — coverage 96.68% (threshold 90%)
pre-commit           bandit, codespell, json hygiene: all passed
```

Refs #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer login messages for unconfirmed or missing accounts, required password resets, and excessive sign-in attempts.
  - Added localized authentication messages in English, Spanish, French, and Portuguese.
  - Improved MFA error feedback, including clearer handling of invalid codes and rate limits.

- **Bug Fixes**
  - Authentication failures now display more specific guidance while retaining generic messaging for unknown errors.
  - Sensitive raw authentication responses remain excluded from user-facing errors and are limited to debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->