### PR TITLE
fix(exo): send schedules in the shape the app sends, and read the LED registers

### DIFF
--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -377,11 +377,27 @@ def _service_schedule_to_fluidra(
     schedule_id: int,
     *,
     use_component_actions: bool = False,
-    include_state: bool = False,
 ) -> dict[str, Any]:
     """Convert service schedule input to the Fluidra CRON schedule shape."""
     start_hour, start_minute = _parse_service_time(schedule["start_time"])
     end_hour, end_minute = _parse_service_time(schedule["end_time"])
+    # A slot is two independent CRON expressions sharing one day set, so an
+    # overnight window has no representation: 22:00 -> 06:00 would be stored as
+    # "start Monday 22:00, end Monday 06:00", an end that precedes its own start.
+    # None of the captured app slots crosses midnight either. Refuse it here,
+    # where the whole window is specified at once and the intent is unambiguous;
+    # split it into an evening slot and a morning slot instead. (The time
+    # entities still tolerate a momentarily inverted pair, because that is a
+    # half-finished edit rather than a stated overnight range.)
+    if (end_hour, end_minute) <= (start_hour, start_minute):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="schedule_overnight_unsupported",
+            translation_placeholders={
+                "start_time": f"{start_hour:02d}:{start_minute:02d}",
+                "end_time": f"{end_hour:02d}:{end_minute:02d}",
+            },
+        )
     days = sorted({int(day) for day in schedule["days"]})
     if not days:
         raise ServiceValidationError(
@@ -400,35 +416,16 @@ def _service_schedule_to_fluidra(
     # previous payload (string "schedule_N" id, no groupId, a spurious
     # componentToChange, plus synthesised endActions and state) was rejected by the
     # server-side JSONata transform ("invalid scheduleUser").
+    # No ``state``: a v2.78.5 attempt added ``"state": "IDLE"`` because the eXO's
+    # own slots report one, but the capture of the app's PUT body settles it --
+    # the app sends id/groupId/enabled/startTime/endTime/startActions and nothing
+    # else. ``state`` is added by the device, not by the client (Issue #174).
     payload: dict[str, Any] = {"id": schedule_id, "groupId": schedule_id}
-    if include_state:
-        # Written as IDLE rather than echoing a running slot's state: this is a
-        # fresh definition, not a live status. Placed here rather than appended,
-        # so the key order matches the device's own slots exactly (Issue #174).
-        payload["state"] = "IDLE"
     payload["enabled"] = schedule["enabled"]
     payload["startTime"] = f"{start_minute:02d} {start_hour:02d} * * {days_str}"
     payload["endTime"] = f"{end_minute:02d} {end_hour:02d} * * {days_str}"
     payload["startActions"] = _schedule_start_actions(schedule["mode"], use_component_actions)
     return payload
-
-
-def _device_uses_schedule_state(coordinator: Any, device_id: str) -> bool:
-    """Return True when this device's own schedule slots carry a ``state`` field.
-
-    The eXO iQ's slots include ``"state": "IDLE"`` — visible in schedules created
-    from the Fluidra app — and a payload without it is not applied: the write
-    lands in ``desiredValue``, mangled, and ``reportedValue`` stays untouched
-    (Issue #174, @Inervo). Other devices rejected a *synthesised* state back on
-    #89, so this mirrors what the device already reports rather than assuming
-    either way, exactly as ``_device_uses_component_actions`` does for the
-    actions shape.
-    """
-    device = coordinator.api.get_device_by_id(device_id) if coordinator else None
-    for sched in (device or {}).get("schedule_data") or []:
-        if isinstance(sched, dict) and isinstance(sched.get("state"), str):
-            return True
-    return False
 
 
 def _schedule_start_actions(mode: Any, use_component_actions: bool) -> dict[str, Any]:
@@ -442,7 +439,12 @@ def _schedule_start_actions(mode: Any, use_component_actions: bool) -> dict[str,
                 translation_key="invalid_schedule_mode",
                 translation_placeholders={"value": str(mode)},
             ) from None
-        return {"componentActions": [{"id": 0, "reportedValue": value}]}
+        # ``desiredValue``, and ``operationName`` kept alongside: that is what the
+        # official app PUTs. Reads echo the same action back as ``reportedValue``,
+        # and sending that key back is a write the backend's transform does not
+        # consume (Issue #174, @Inervo). ``schedule_slots_for_write`` enforces the
+        # same rule on every other write path.
+        return {"operationName": "1", "componentActions": [{"id": 0, "desiredValue": value}]}
     return {"operationName": mode}
 
 
@@ -455,8 +457,16 @@ def _ensure_schedule_write_supported(
     across four runs (Issue #174, @Inervo): a slot sent as 01:02-03:04 on a
     single day was stored as "03 02" / "00 04" on **four** days, and the stored
     days track the sent day deterministically -- sending day *n* yields
-    ``{0, n+2, n+5, n+6}``. The payload matches a slot the Fluidra app itself
-    created field for field, including key order, so the shape is not the cause.
+    ``{0, n+2, n+5, n+6}``.
+
+    That was blamed on the payload matching the device's own *reported* slots
+    field for field. @Inervo's later capture of the app's PUT body shows the two
+    are not the same object: the app sends the action value under
+    ``desiredValue`` with ``operationName`` alongside and no ``state`` at all,
+    where the integration echoed back ``reportedValue`` and synthesised a
+    ``state``. Both are corrected now, which is a plausible cause of the
+    transform producing garbage rather than storing the slot -- but plausible is
+    not verified, and nobody has re-run this on hardware.
 
     Two distinct failures, both worse than the feature being absent:
 
@@ -467,8 +477,10 @@ def _ensure_schedule_write_supported(
       for, and the device *acts* on it: chlorination running at hours nobody
       chose is a worse outcome than an error message.
 
-    Refusing is recoverable; writing is not. Lifted per-register once the
-    backend's transform is understood.
+    Refusing is recoverable; writing is not, so the refusal stands until a
+    hardware run confirms the corrected shape. The aux registers (c22-c25) are
+    deliberately *not* covered: they take the same corrected payload and drive
+    only an auxiliary output, so they are the safe place to confirm it.
     """
     from .device_registry import DeviceIdentifier
 
@@ -512,11 +524,8 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
         # Convert HA format to Fluidra API format
         component_actions = _device_uses_component_actions(coordinator, device_id)
-        include_state = _device_uses_schedule_state(coordinator, device_id)
         fluidra_schedules = [
-            _service_schedule_to_fluidra(
-                schedule, i, use_component_actions=component_actions, include_state=include_state
-            )
+            _service_schedule_to_fluidra(schedule, i, use_component_actions=component_actions)
             for i, schedule in enumerate(schedules_data, start=1)
         ]
 

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -146,6 +146,55 @@ COMPONENT_SCHEDULE: Final = 20
 COMPONENT_LIGHT_COLOR: Final = 45
 COMPONENT_DM24049704_SCHEDULE: Final = 258
 
+# eXO iQ auxiliary-output colour-LED schedule registers. An aux wired to a plain
+# on/off light (or to "Other") keeps its schedule on c22/c24; an aux wired to a
+# colour LED keeps it on c23/c25 instead, with the colour carried as a
+# componentAction under id 0 (Issue #174, @Inervo -- capture of the official app).
+# Which of the pair is live is resolved at runtime, see
+# helpers.resolve_aux_schedule_component.
+COMPONENT_EXO_AUX1_COLOUR_SCHEDULE: Final = 23
+COMPONENT_EXO_AUX2_COLOUR_SCHEDULE: Final = 25
+
+# Colour index -> name for the two LED families the eXO can drive. They share
+# neither a base nor a length, so a single table would be wrong for one of them.
+# Both come from @Inervo's capture; only the LumiPlus-on-Aux-1 and
+# Zodiac-NL-on-Aux-2 pairings were actually exercised, the mirrored ones are
+# inferred. Nothing derives the family from the device yet -- c90/c91 report the
+# assigned function as a plain string but are not known to distinguish the two --
+# so these are surfaced as candidate names, never used to rewrite a value.
+EXO_LED_COLOURS_LUMIPLUS: Final[dict[int, str]] = {
+    0: "white",
+    1: "red",
+    2: "blue",
+    3: "green",
+    4: "magenta",
+    5: "cyan",
+    6: "yellow",
+    7: "sequence_1",
+    8: "sequence_2",
+    9: "sequence_3",
+    10: "sequence_4",
+    11: "sequence_5",
+    12: "sequence_6",
+    13: "sequence_7",
+}
+EXO_LED_COLOURS_ZODIAC_NL: Final[dict[int, str]] = {
+    2: "alpine_white",
+    3: "sky_blue",
+    4: "cobalt_blue",
+    5: "caribbean_blue",
+    6: "spring_green",
+    7: "emerald_green",
+    8: "emerald_rose",
+    9: "magenta",
+    10: "violet",
+    11: "slow_color_splash",
+    12: "fast_color_splash",
+    13: "america",
+    14: "fat_tuesday",
+    15: "disco_tech",
+}
+
 # Pump speed mapping: API level → displayed percentage
 PUMP_SPEED_PERCENTAGES: Final[dict[int, int]] = {
     0: 45,  # Low

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -37,7 +37,7 @@ from ..const import (
 )
 from ..device_registry import DeviceIdentifier
 from ..fluidra_api import FluidraPoolAPI
-from ..helpers import determine_pool_access, resolve_schedule_component
+from ..helpers import determine_pool_access, resolve_aux_schedule_component, resolve_schedule_component
 from ..repairs import (
     async_create_connection_issue,
     async_create_unverified_profile_issue,
@@ -645,11 +645,15 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except (ValueError, TypeError):
                     pass
         else:
-            aux_schedule_components = DeviceIdentifier.get_feature(device, "aux_schedule_components", {})
-            for aux_number, aux_component in aux_schedule_components.items():
-                if component_id == int(aux_component):
-                    schedule_data = reported_value if isinstance(reported_value, list) else []
-                    device.setdefault("aux_schedule_data", {})[str(aux_number)] = schedule_data
+            # An aux keeps its schedules on one of two registers depending on
+            # what it drives (plain output c22/c24, colour LED c23/c25), so both
+            # are decoded here and the live one is picked after the full scan by
+            # _apply_resolved_aux_schedules (Issue #174).
+            for feature in ("aux_schedule_components", "aux_colour_schedule_components"):
+                for aux_number, aux_component in (DeviceIdentifier.get_feature(device, feature, {}) or {}).items():
+                    if component_id == int(aux_component):
+                        schedule_data = reported_value if isinstance(reported_value, list) else []
+                        device.setdefault("aux_schedule_data", {})[str(aux_number)] = schedule_data
 
             schedule_comp = DeviceIdentifier.get_feature(device, "schedule_component")
             if schedule_comp and component_id == schedule_comp:
@@ -685,6 +689,29 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device["schedule_data"] = schedule_data
         device["schedule_component_resolved"] = component_id
         self._track_schedule_count(pool_id, device_id, schedule_data)
+
+    def _apply_resolved_aux_schedules(self, device: dict[str, Any]) -> None:
+        """Point each aux's schedule_data at the register that output honours.
+
+        Aux 1 keeps its slots on c22 when it drives a plain on/off output and on
+        c23 when it drives a colour LED; Aux 2 uses c24/c25 the same way. Both
+        are scanned, so this runs after the full pass and keeps only the live
+        one -- otherwise whichever register happened to come last in scan order
+        would win (Issue #174, @Inervo).
+        """
+        aux_numbers = set(DeviceIdentifier.get_feature(device, "aux_schedule_components", {}) or {})
+        aux_numbers |= set(DeviceIdentifier.get_feature(device, "aux_colour_schedule_components", {}) or {})
+        if not aux_numbers:
+            return
+
+        components = device.get("components", {})
+        resolved: dict[str, int] = {}
+        for aux_number in aux_numbers:
+            component_id = resolve_aux_schedule_component(device, aux_number)
+            reported = components.get(str(component_id), {}).get("reportedValue")
+            device.setdefault("aux_schedule_data", {})[str(aux_number)] = reported if isinstance(reported, list) else []
+            resolved[str(aux_number)] = component_id
+        device["aux_schedule_components_resolved"] = resolved
 
     def _process_victoria_component(
         self, device: dict[str, Any], component_id: int, component_state: dict[str, Any]
@@ -1104,6 +1131,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # everyone else keeps the single fixed register (Issue #174).
             if DeviceIdentifier.get_feature(device, "schedule_component_map", None):
                 self._apply_resolved_schedule(device, pool_id, device_id)
+            self._apply_resolved_aux_schedules(device)
 
             # Recompute auto-mode pump speed AFTER the whole component scan: the
             # speed (component 11) is processed before the schedule (component 20)

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -1012,6 +1012,12 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
             # Auxiliary-output schedules: fixed registers independent of the pump
             # type (Aux 1 = c22, Aux 2 = c24), up to 2 slots per aux (Issue #174).
             "aux_schedule_components": {"1": 22, "2": 24},
+            # ... unless the output is wired to a colour LED, which moves its
+            # schedules to c23/c25 and carries the colour as a componentAction.
+            # That accounts for all seven schedulers the unit declares (c19-c25).
+            # Which register of a pair is live is resolved at runtime, from the
+            # one that holds slots (helpers.resolve_aux_schedule_component).
+            "aux_colour_schedule_components": {"1": 23, "2": 25},
             "aux_schedule_count": 2,
             # Heating, available once an aux output is assigned to it (c88).
             # c43 is the setpoint in whole °C: an isolated capture moved it
@@ -1070,7 +1076,9 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 20,
                 21,
                 22,
+                23,
                 24,
+                25,
                 30,
                 31,
                 35,

--- a/custom_components/fluidra_pool/fluidra_api/_schedules.py
+++ b/custom_components/fluidra_pool/fluidra_api/_schedules.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 
 from ..api_resilience import FluidraAuthError, FluidraError
 from ..const import COMPONENT_DM24049704_SCHEDULE, COMPONENT_SCHEDULE
+from ..helpers import schedule_slots_for_write
 from ..utils import CRON_DAY_TO_NAME, extract_cron_days
 from ._base import FluidraAPIBase
 from ._constants import CONNECTED_PARAMS, FLUIDRA_EMEA_BASE
@@ -113,7 +114,7 @@ class SchedulesMixin(FluidraAPIBase):
         headers["content-type"] = "application/json; charset=utf-8"
 
         url = f"{FLUIDRA_EMEA_BASE}/generic/devices/{quote(str(device_id), safe='')}/components/{int(component_id)}"
-        desired_value: Any = schedules
+        desired_value: Any = schedule_slots_for_write(schedules)
         if int(component_id) == COMPONENT_DM24049704_SCHEDULE:
             desired_value = self._convert_schedules_to_dm24049704_format(schedules)
         payload = {"desiredValue": desired_value}

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -8,7 +8,12 @@ introducing coupling between platforms.
 from __future__ import annotations
 
 from datetime import time
+import logging
 from typing import Any
+
+from .const import EXO_LED_COLOURS_LUMIPLUS, EXO_LED_COLOURS_ZODIAC_NL
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def resolve_schedule_component(device_data: dict[str, Any], default: int = 20) -> int:
@@ -92,6 +97,144 @@ def get_aux_schedule_data(device_data: dict[str, Any], aux_number: Any, schedule
             return result
 
     return None
+
+
+def resolve_aux_schedule_component(device_data: dict[str, Any], aux_number: Any, default: int = 22) -> int:
+    """Return the schedule register an auxiliary output is currently honouring.
+
+    An eXO iQ aux has two schedule registers, not one: a plain on/off output
+    (or one assigned to "Other") keeps its slots on c22/c24, while an output
+    wired to a colour LED keeps them on c23/c25 and carries the colour as a
+    componentAction (Issue #174, @Inervo -- capture of the official app). Seven
+    schedulers are declared by the device, c19-c25, and c22/c23 and c24/c25 are
+    the two aux pairs.
+
+    Nothing on the device is known to name which of a pair is live: c90/c91
+    report the assigned function as a plain string, but no capture shows them
+    distinguishing a colour LED from a plain light. So the register that
+    actually holds slots decides, which is safe here in a way it was not for the
+    pump registers: the aux pair is selected by what the output is *wired to*,
+    not by a setting the owner flips back and forth, so a stale populated
+    register is far less likely than after a pump-type change.
+
+    When both registers hold slots the choice is genuinely ambiguous. Rather
+    than guess, keep the plain register (the pre-existing behaviour, so no
+    entity moves under the owner) and log the assigned-function label at
+    warning level so the next diagnostic pins the real discriminator.
+    """
+    # Imported here to keep this module free of package-level import cycles.
+    from .device_registry import DeviceIdentifier
+
+    plain_map = DeviceIdentifier.get_feature(device_data, "aux_schedule_components", {}) or {}
+    plain = int(plain_map.get(str(aux_number), default))
+
+    colour_map = DeviceIdentifier.get_feature(device_data, "aux_colour_schedule_components", {}) or {}
+    colour_raw = colour_map.get(str(aux_number))
+    if colour_raw is None:
+        return plain
+    colour = int(colour_raw)
+
+    components = device_data.get("components", {})
+
+    def _has_slots(register: int) -> bool:
+        value = components.get(str(register), {}).get("reportedValue")
+        return isinstance(value, list) and bool(value)
+
+    plain_has = _has_slots(plain)
+    colour_has = _has_slots(colour)
+
+    if colour_has and not plain_has:
+        return colour
+    if plain_has and colour_has:
+        labels = DeviceIdentifier.get_feature(device_data, "aux_labels", {}) or {}
+        label_component = labels.get(str(aux_number))
+        label = components.get(str(label_component), {}).get("reportedValue") if label_component else None
+        _LOGGER.warning(
+            "Aux %s has schedules on both c%s and c%s; keeping c%s. "
+            "The device reports its assigned function as %r -- please report this "
+            "on Issue #174 so the live register can be identified",
+            aux_number,
+            plain,
+            colour,
+            plain,
+            label,
+        )
+    return plain
+
+
+def describe_led_colour(colour_index: Any) -> dict[str, str] | None:
+    """Return the candidate colour names for a raw aux-LED colour index.
+
+    The eXO drives two LED families with incompatible colour tables -- LumiPlus
+    runs 0-13, Zodiac NL runs 2-15 -- and nothing read from the device is known
+    to say which one an aux is wired to. Naming the colour outright would be
+    wrong for one family, so both candidates are surfaced and the raw index is
+    kept authoritative. Returns ``None`` when the index is not an integer or
+    matches neither table.
+    """
+    try:
+        index = int(colour_index)
+    except (TypeError, ValueError):
+        return None
+
+    candidates = {}
+    if index in EXO_LED_COLOURS_LUMIPLUS:
+        candidates["lumiplus"] = EXO_LED_COLOURS_LUMIPLUS[index]
+    if index in EXO_LED_COLOURS_ZODIAC_NL:
+        candidates["zodiac_nl"] = EXO_LED_COLOURS_ZODIAC_NL[index]
+    return candidates or None
+
+
+def _action_for_write(action: Any) -> Any:
+    """Return one ``componentActions`` entry with its value under ``desiredValue``."""
+    if not isinstance(action, dict):
+        return action
+    entry = {key: value for key, value in action.items() if key != "reportedValue"}
+    if "desiredValue" not in entry and "reportedValue" in action:
+        entry["desiredValue"] = action["reportedValue"]
+    return entry
+
+
+def schedule_slots_for_write(schedules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return ``schedules`` in the exact shape the Fluidra app PUTs.
+
+    Every write path funnels through here so none of them can drift. Three
+    things separate a slot as *read* from a slot as *written*, all three taken
+    from @Inervo's capture of the official app (Issue #174):
+
+    * ``startActions.componentActions`` entries carry ``desiredValue`` on the
+      way out. Reads echo them as ``reportedValue``, and the integration used to
+      send that back verbatim -- a key the backend's transform does not consume,
+      which is consistent with writes landing mangled rather than rejected.
+    * ``operationName`` is sent *alongside* ``componentActions``, not instead of
+      it. All five captured bodies carry ``"operationName": "1"``, including the
+      two that also carry a colour or an RPM.
+    * ``state`` and ``endActions`` are runtime fields the device adds itself;
+      the app's PUT body has neither.
+
+    Fields the slot already carries are left alone, order included: a slot is
+    otherwise passed through untouched, so a key this integration does not know
+    about survives a round trip instead of being dropped.
+    """
+    normalised: list[dict[str, Any]] = []
+    for slot in schedules:
+        if not isinstance(slot, dict):
+            continue
+        entry = dict(slot)
+        entry.pop("state", None)
+        entry.pop("endActions", None)
+        entry.setdefault("groupId", entry.get("id"))
+
+        start_actions = entry.get("startActions")
+        if isinstance(start_actions, dict):
+            actions = dict(start_actions)
+            component_actions = actions.get("componentActions")
+            if isinstance(component_actions, list):
+                actions["componentActions"] = [_action_for_write(action) for action in component_actions]
+                actions.setdefault("operationName", "1")
+            entry["startActions"] = actions
+        normalised.append(entry)
+    return normalised
 
 
 def resolve_component_rw(cfg: int | dict[str, Any]) -> tuple[Any, Any]:

--- a/custom_components/fluidra_pool/select/schedule.py
+++ b/custom_components/fluidra_pool/select/schedule.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _component_action_value(action: Any) -> Any:
+    """Return a componentAction's value under whichever key carries it."""
+    if not isinstance(action, dict):
+        return 1
+    if "reportedValue" in action:
+        return action["reportedValue"]
+    return action.get("desiredValue", 1)
+
+
+def _start_actions_with_mode(start_actions: Any, mode: int) -> dict[str, Any]:
+    """Return ``startActions`` with componentAction id 0 set to ``mode``.
+
+    Every other action is preserved: a variable-speed eXO slot carries the
+    target RPM under id 1 alongside the chlorination mode under id 0, and this
+    entity only knows the latter (Issue #174).
+    """
+    actions = start_actions.get("componentActions") if isinstance(start_actions, dict) else None
+    kept = [action for action in actions if isinstance(action, dict) and action.get("id") != 0] if actions else []
+    return {"componentActions": [{"id": 0, "reportedValue": mode}, *kept]}
+
+
 class FluidraScheduleModeSelect(FluidraPoolControlEntity, SelectEntity):
     """Select entity for choosing schedule mode (speed level) for existing pump schedules."""
 
@@ -232,8 +253,9 @@ class FluidraChlorinatorScheduleSpeedSelect(FluidraPoolControlEntity, SelectEnti
             start_actions = schedule.get("startActions", {})
             component_actions = start_actions.get("componentActions", [])
             if component_actions:
-                # EXO format: componentActions[0].reportedValue.
-                value = str(component_actions[0].get("reportedValue", 1))
+                # eXO format: componentActions[0]. Reads echo the value as
+                # reportedValue; a slot we just wrote carries desiredValue.
+                value = str(_component_action_value(component_actions[0]))
             else:
                 # DM format: operationName.
                 value = str(start_actions.get("operationName", "1"))
@@ -280,20 +302,24 @@ class FluidraChlorinatorScheduleSpeedSelect(FluidraPoolControlEntity, SelectEnti
                     start_actions = sched.get("startActions", {})
                     component_actions = start_actions.get("componentActions", [])
                     if component_actions:
-                        operation_name = str(component_actions[0].get("reportedValue", 1))
+                        operation_name = str(_component_action_value(component_actions[0]))
                     else:
                         operation_name = str(start_actions.get("operationName", "1"))
 
                 if self._output_type == "output":
-                    # EXO format: componentActions with reportedValue.
+                    # eXO format: the mode lives in componentActions under id 0.
+                    # The rest of the list is copied through -- a variable-speed
+                    # slot also carries the target RPM under id 1, and rebuilding
+                    # the list from id 0 alone dropped it, which leaves the
+                    # Fluidra app unable to load the device at all until the pump
+                    # type is changed on the unit itself (Issue #174, @Inervo).
                     scheduler = {
                         "id": sched.get("id"),
                         "groupId": sched.get("groupId", sched.get("id")),
-                        "state": sched.get("state", "IDLE"),
                         "enabled": sched.get("enabled", True),
                         "startTime": start_time,
                         "endTime": end_time,
-                        "startActions": {"componentActions": [{"id": 0, "reportedValue": int(operation_name)}]},
+                        "startActions": _start_actions_with_mode(sched.get("startActions"), int(operation_name)),
                     }
                 elif schedule_component == 258:
                     # DM24049704 format: operationName with CRON padding.

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -466,6 +466,9 @@
     "schedule_overlap": {
       "message": "This schedule overlaps another active schedule"
     },
+    "schedule_overnight_unsupported": {
+      "message": "Cannot set a schedule from {start_time} to {end_time}: the end time must come after the start time. A schedule cannot cross midnight — use two schedules instead, one until 23:59 and one from 00:00."
+    },
     "schedule_set_failed": {
       "message": "Fluidra API call failed while setting the schedule for {device_id}"
     },

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -11,8 +11,13 @@ from homeassistant.exceptions import HomeAssistantError
 
 from ..api_resilience import FluidraError
 from ..const import DOMAIN
-from ..device_registry import DeviceIdentifier
-from ..helpers import get_aux_schedule_data, get_schedule_data, resolve_schedule_component
+from ..helpers import (
+    describe_led_colour,
+    get_aux_schedule_data,
+    get_schedule_data,
+    resolve_aux_schedule_component,
+    resolve_schedule_component,
+)
 from .base import FluidraPoolSwitchEntity
 
 if TYPE_CHECKING:
@@ -122,8 +127,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
     def _get_schedule_component(self) -> int:
         """Get the schedule component used by this device."""
         if self._aux_number is not None:
-            aux_map = DeviceIdentifier.get_feature(self.device_data, "aux_schedule_components", {})
-            return int(aux_map.get(str(self._aux_number), 22))
+            # c22/c24 for a plain output, c23/c25 for a colour LED (Issue #174).
+            return resolve_aux_schedule_component(self.device_data, self._aux_number)
         value: int = resolve_schedule_component(self.device_data)
         return value
 
@@ -262,6 +267,22 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                     "end_action": schedule.get("endActions", {}),
                 }
             )
+
+        if self._aux_number is not None:
+            attrs["schedule_component"] = self._get_schedule_component()
+            # A colour-LED slot carries the colour under componentActions id 0.
+            # The raw index is authoritative: the eXO drives two LED families
+            # whose colour tables share neither base nor length, and nothing
+            # read from the device names which one is wired here, so both
+            # candidate names are offered rather than one guessed (Issue #174).
+            for action in (schedule or {}).get("startActions", {}).get("componentActions", []) or []:
+                if isinstance(action, dict) and action.get("id") == 0:
+                    colour_index = action.get("desiredValue", action.get("reportedValue"))
+                    candidates = describe_led_colour(colour_index)
+                    if candidates is not None:
+                        attrs["colour_index"] = colour_index
+                        attrs["colour_candidates"] = candidates
+                    break
 
         attrs.update({"pending_action": self._pending_state is not None, "action_timestamp": self._last_action_time})
 

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -15,7 +15,12 @@ from ..api_resilience import FluidraError
 from ..const import DEVICE_MODEL_FALLBACK, DEVICE_MODEL_MAP, DOMAIN
 from ..device_registry import DeviceIdentifier
 from ..entity import FluidraPoolControlEntity
-from ..helpers import get_aux_schedule_data, get_schedule_data, resolve_schedule_component
+from ..helpers import (
+    get_aux_schedule_data,
+    get_schedule_data,
+    resolve_aux_schedule_component,
+    resolve_schedule_component,
+)
 from ..utils import extract_cron_days
 
 if TYPE_CHECKING:
@@ -162,8 +167,8 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
     def _get_schedule_component(self) -> int:
         """Get the correct schedule component ID for this device."""
         if self._aux_number is not None:
-            aux_map = DeviceIdentifier.get_feature(self.device_data, "aux_schedule_components", {})
-            return int(aux_map.get(str(self._aux_number), 22))
+            # c22/c24 for a plain output, c23/c25 for a colour LED (Issue #174).
+            return resolve_aux_schedule_component(self.device_data, self._aux_number)
         device_data = self.device_data
         # Per-device override (e.g. 258 for DM24049704 chlorinator).
         schedule_comp: int = resolve_schedule_component(device_data)

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -466,6 +466,9 @@
     "schedule_overlap": {
       "message": "This schedule overlaps another active schedule"
     },
+    "schedule_overnight_unsupported": {
+      "message": "Cannot set a schedule from {start_time} to {end_time}: the end time must come after the start time. A schedule cannot cross midnight — use two schedules instead, one until 23:59 and one from 00:00."
+    },
     "schedule_set_failed": {
       "message": "Fluidra API call failed while setting the schedule for {device_id}"
     },

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -326,6 +326,9 @@
       "auto_mode": {
         "name": "Modo Auto"
       },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Horario {schedule_id}"
+      },
       "boost_mode": {
         "name": "Modo Turbo"
       },
@@ -352,6 +355,12 @@
       }
     },
     "time": {
+      "aux_schedule_end": {
+        "name": "Aux {aux_number} Horario {schedule_id} Fin"
+      },
+      "aux_schedule_start": {
+        "name": "Aux {aux_number} Horario {schedule_id} Inicio"
+      },
       "light_schedule_end": {
         "name": "Programación Luz {schedule_id} Fin"
       },
@@ -456,6 +465,9 @@
     },
     "schedule_overlap": {
       "message": "Esta programación se solapa con otra programación activa"
+    },
+    "schedule_overnight_unsupported": {
+      "message": "No se puede definir un horario de {start_time} a {end_time}: la hora de fin debe ser posterior a la de inicio. Un horario no puede cruzar la medianoche: use dos horarios, uno hasta las 23:59 y otro desde las 00:00."
     },
     "schedule_set_failed": {
       "message": "La llamada a la API de Fluidra falló al establecer el horario para {device_id}"

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -466,6 +466,9 @@
     "schedule_overlap": {
       "message": "Cet horaire chevauche un autre horaire actif"
     },
+    "schedule_overnight_unsupported": {
+      "message": "Impossible de définir un planning de {start_time} à {end_time} : l'heure de fin doit être postérieure à l'heure de début. Un planning ne peut pas traverser minuit — utilisez deux plannings, l'un jusqu'à 23:59 et l'autre à partir de 00:00."
+    },
     "schedule_set_failed": {
       "message": "L'appel à l'API Fluidra a échoué lors de la définition du programme pour {device_id}"
     },

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -326,6 +326,9 @@
       "auto_mode": {
         "name": "Modo Automático"
       },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Horário {schedule_id}"
+      },
       "boost_mode": {
         "name": "Modo Turbo"
       },
@@ -352,6 +355,12 @@
       }
     },
     "time": {
+      "aux_schedule_end": {
+        "name": "Aux {aux_number} Horário {schedule_id} Fim"
+      },
+      "aux_schedule_start": {
+        "name": "Aux {aux_number} Horário {schedule_id} Início"
+      },
       "light_schedule_end": {
         "name": "Programação Luz {schedule_id} Fim"
       },
@@ -456,6 +465,9 @@
     },
     "schedule_overlap": {
       "message": "Esta programação sobrepõe-se a outra programação ativa"
+    },
+    "schedule_overnight_unsupported": {
+      "message": "Não é possível definir um horário das {start_time} às {end_time}: a hora de fim tem de ser posterior à de início. Um horário não pode atravessar a meia-noite — use dois horários, um até às 23:59 e outro a partir das 00:00."
     },
     "schedule_set_failed": {
       "message": "A chamada à API Fluidra falhou ao definir o programa para {device_id}"

--- a/tests/test_aux_schedule.py
+++ b/tests/test_aux_schedule.py
@@ -477,3 +477,61 @@ def test_get_aux_schedule_data_finds_slot() -> None:
     assert get_aux_schedule_data(device, "2", "1") == {"id": 1, "enabled": False}
     assert get_aux_schedule_data(device, "1", "99") is None
     assert get_aux_schedule_data({}, "1", "1") is None
+
+
+# --- Issue #174: a colour-LED aux carries its colour in the slot --------------
+
+
+COLOUR_SLOT = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "startTime": "00 10 * * 5",
+    "endTime": "00 11 * * 5",
+    "startActions": {"operationName": "1", "componentActions": [{"id": 0, "reportedValue": 7}]},
+}
+
+
+def test_aux_switch_reports_the_raw_colour_and_both_candidate_names() -> None:
+    """The two LED tables disagree on index 7, so neither name is asserted."""
+    device = _aux_device({"1": [COLOUR_SLOT]})
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    attrs = entity.extra_state_attributes
+    assert attrs["colour_index"] == 7
+    assert attrs["colour_candidates"] == {"lumiplus": "sequence_1", "zodiac_nl": "emerald_green"}
+    assert attrs["schedule_component"] == 22
+
+
+def test_aux_switch_omits_colour_for_a_plain_on_off_slot() -> None:
+    """An output with no componentActions has no colour to report."""
+    device = _aux_device({"1": [AUX1_SCHEDULE]})
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    attrs = entity.extra_state_attributes
+    assert "colour_index" not in attrs
+    assert "colour_candidates" not in attrs
+
+
+def test_aux_switch_omits_colour_when_the_index_is_off_both_tables() -> None:
+    """An unknown index is not dressed up with a name it may not have."""
+    slot = {**COLOUR_SLOT, "startActions": {"componentActions": [{"id": 0, "reportedValue": 99}]}}
+    device = _aux_device({"1": [slot]})
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", aux_number="1")
+    _attach_ha(entity)
+
+    assert "colour_index" not in entity.extra_state_attributes
+
+
+def test_main_schedule_switch_reports_no_colour_attributes() -> None:
+    """Only aux outputs drive LEDs; the pump switch must be untouched."""
+    device = _aux_device({"1": [COLOUR_SLOT]})
+    device["schedule_data"] = [dict(AUX1_SCHEDULE)]
+    entity = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1")
+    _attach_ha(entity)
+
+    attrs = entity.extra_state_attributes
+    assert "schedule_component" not in attrs
+    assert "colour_index" not in attrs

--- a/tests/test_aux_schedule_registers.py
+++ b/tests/test_aux_schedule_registers.py
@@ -1,0 +1,163 @@
+"""The eXO iQ aux outputs have two schedule registers each (Issue #174).
+
+@Inervo's capture of the official app shows Aux 1 writing to c22 when it drives
+a plain on/off light and to c23 when it drives a colour LED, with Aux 2 using
+c24/c25 the same way. Together with the pump registers c19-c21 that accounts
+for all seven schedulers the unit declares.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.fluidra_pool.helpers import describe_led_colour, resolve_aux_schedule_component
+
+PLAIN_SLOT = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "startTime": "09 08 * * 1,0",
+    "endTime": "11 10 * * 1,0",
+    "startActions": {"operationName": "1"},
+}
+COLOUR_SLOT = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "startTime": "00 10 * * 5",
+    "endTime": "00 11 * * 5",
+    "startActions": {"operationName": "1", "componentActions": [{"id": 0, "reportedValue": 3}]},
+}
+
+
+def _exo(**components: Any) -> dict[str, Any]:
+    return {
+        "device_id": "NS25007212",
+        "name": "Zodiac EXO iQ 35",
+        "family": "Chlorinators",
+        "type": "connected",
+        "components": {str(k): {"reportedValue": v} for k, v in components.items()},
+    }
+
+
+@pytest.mark.parametrize(
+    ("components", "aux", "expected"),
+    [
+        # Slots on the plain register only → that one.
+        ({"22": [PLAIN_SLOT], "23": None}, "1", 22),
+        ({"24": [PLAIN_SLOT], "25": None}, "2", 24),
+        # Slots on the colour register only → the aux drives a colour LED.
+        ({"22": None, "23": [COLOUR_SLOT]}, "1", 23),
+        ({"24": [], "25": [COLOUR_SLOT]}, "2", 25),
+        # Nothing configured anywhere → keep the plain register.
+        ({"22": None, "23": None}, "1", 22),
+        ({}, "2", 24),
+    ],
+)
+def test_live_aux_register_follows_the_one_holding_slots(components: dict[str, Any], aux: str, expected: int) -> None:
+    assert resolve_aux_schedule_component(_exo(**components), aux) == expected
+
+
+def test_both_registers_populated_keeps_the_plain_one_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ambiguous is not guessable; say so instead of picking silently."""
+    device = _exo(**{"22": [PLAIN_SLOT], "23": [COLOUR_SLOT], "90": "Lighting"})
+
+    with caplog.at_level("WARNING"):
+        assert resolve_aux_schedule_component(device, "1") == 22
+
+    assert "c22" in caplog.text
+    assert "c23" in caplog.text
+    assert "Lighting" in caplog.text
+
+
+def test_profiles_without_a_colour_register_are_untouched() -> None:
+    """A device declaring only the plain map keeps its single register."""
+    device = {
+        "device_id": "DM24049704",
+        "family": "Chlorinators",
+        "name": "Chlorinator",
+        "components": {},
+    }
+    assert resolve_aux_schedule_component(device, "1", default=22) == 22
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        # 0 and 1 only exist on the LumiPlus table (it starts at 0).
+        (0, {"lumiplus": "white"}),
+        (1, {"lumiplus": "red"}),
+        # The overlap: the tables disagree, so both names are offered.
+        (3, {"lumiplus": "green", "zodiac_nl": "sky_blue"}),
+        (7, {"lumiplus": "sequence_1", "zodiac_nl": "emerald_green"}),
+        # 14 and 15 only exist on the Zodiac NL table (it runs to 15).
+        (14, {"zodiac_nl": "fat_tuesday"}),
+        (15, {"zodiac_nl": "disco_tech"}),
+        # Outside both tables, and non-numeric.
+        (16, None),
+        (-1, None),
+        (None, None),
+        ("green", None),
+    ],
+)
+def test_colour_index_never_resolves_to_a_single_guessed_name(index: Any, expected: Any) -> None:
+    """LumiPlus runs 0-13 and Zodiac NL runs 2-15; one table would be wrong."""
+    assert describe_led_colour(index) == expected
+
+
+# --- coordinator wiring ------------------------------------------------------
+
+
+def _apply_aux(device: dict[str, Any]) -> dict[str, Any]:
+    from unittest.mock import MagicMock
+
+    from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
+
+    FluidraDataUpdateCoordinator._apply_resolved_aux_schedules(MagicMock(), device)
+    return device
+
+
+def test_coordinator_surfaces_the_colour_register_for_a_led_aux() -> None:
+    """Aux 1 on a LumiPlus keeps its slots on c23, which was never scanned."""
+    device = _apply_aux(_exo(**{"22": None, "23": [COLOUR_SLOT], "24": [PLAIN_SLOT], "25": None}))
+
+    assert device["aux_schedule_data"]["1"] == [COLOUR_SLOT]
+    assert device["aux_schedule_data"]["2"] == [PLAIN_SLOT]
+    assert device["aux_schedule_components_resolved"] == {"1": 23, "2": 24}
+
+
+def test_coordinator_leaves_an_unconfigured_aux_empty() -> None:
+    """No slots on either register is "no schedule", not a fallback hunt."""
+    device = _apply_aux(_exo(**{"22": None, "23": None}))
+
+    assert device["aux_schedule_data"]["1"] == []
+    assert device["aux_schedule_components_resolved"]["1"] == 22
+
+
+def test_devices_with_no_aux_registers_are_untouched() -> None:
+    device = {"device_id": "DM24008702.nn_1", "family": "Chlorinators", "name": "Chlorinator", "components": {}}
+    _apply_aux(device)
+    assert "aux_schedule_data" not in device
+
+
+def test_exo_profile_declares_and_scans_both_registers_of_each_pair() -> None:
+    from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS
+
+    features = DEVICE_CONFIGS["ns25_exo_chlorinator"].features
+    assert features["aux_schedule_components"] == {"1": 22, "2": 24}
+    assert features["aux_colour_schedule_components"] == {"1": 23, "2": 25}
+
+    scanned = set(features["specific_components"])
+    # A register that is mapped but never polled would resolve to nothing.
+    for register in (22, 23, 24, 25):
+        assert register in scanned, register
+
+    # All seven schedulers the device declares (c19-c25) are accounted for.
+    mapped = {features["schedule_component_map"][key] for key in ("none", "simple", "vs")}
+    mapped |= {int(v) for v in features["aux_schedule_components"].values()}
+    mapped |= {int(v) for v in features["aux_colour_schedule_components"].values()}
+    assert mapped == {19, 20, 21, 22, 23, 24, 25}

--- a/tests/test_no_flow_and_schedule_guard.py
+++ b/tests/test_no_flow_and_schedule_guard.py
@@ -207,7 +207,23 @@ def _coordinator_with_schedules(schedules: list) -> Any:
     return coordinator
 
 
-EXO_SLOT = {
+# The PUT body @Inervo captured from the official app, for the same device
+# family and endpoint the integration writes to. Its full key set is
+# id/groupId/enabled/startTime/endTime/startActions -- no ``state``, and the
+# componentActions value under ``desiredValue`` with ``operationName``
+# alongside, not instead.
+APP_PUT_SLOT = {
+    "id": 3,
+    "groupId": 3,
+    "enabled": False,
+    "startTime": "11 21 * * 1",
+    "endTime": "19 21 * * 1",
+    "startActions": {"operationName": "1", "componentActions": [{"id": 0, "desiredValue": 1}]},
+}
+
+# The same slot as the device *reports* it back: it adds ``state`` itself and
+# echoes the action under ``reportedValue``.
+EXO_REPORTED_SLOT = {
     "id": 3,
     "groupId": 3,
     "state": "IDLE",
@@ -218,32 +234,41 @@ EXO_SLOT = {
 }
 
 
-def test_payload_matches_the_shape_the_exo_itself_reports() -> None:
-    """Field for field, against a slot the Fluidra app created (Issue #174)."""
+def test_payload_matches_the_apps_own_put_body() -> None:
+    """Field for field, against the app's captured PUT body (Issue #174)."""
     from custom_components.fluidra_pool import _service_schedule_to_fluidra
 
     ours = _service_schedule_to_fluidra(
         {"enabled": False, "start_time": "21:11", "end_time": "21:19", "mode": "1", "days": [1]},
         3,
         use_component_actions=True,
-        include_state=True,
     )
-    assert ours == EXO_SLOT
+    assert ours == APP_PUT_SLOT
 
 
-def test_state_is_mirrored_from_the_device_not_assumed() -> None:
-    """Devices that reject a synthesised state (#89) must not receive one."""
-    from custom_components.fluidra_pool import _device_uses_schedule_state
+def test_a_reported_slot_is_converted_to_the_write_shape() -> None:
+    """Echoing a read slot back verbatim is what landed mangled (Issue #174)."""
+    from custom_components.fluidra_pool.helpers import schedule_slots_for_write
 
-    assert _device_uses_schedule_state(_coordinator_with_schedules([EXO_SLOT]), "NS25007212") is True
-
-    without_state = {k: v for k, v in EXO_SLOT.items() if k != "state"}
-    assert _device_uses_schedule_state(_coordinator_with_schedules([without_state]), "DM1") is False
-    assert _device_uses_schedule_state(_coordinator_with_schedules([]), "DM1") is False
-    assert _device_uses_schedule_state(_coordinator_with_schedules(["junk", None]), "DM1") is False
+    assert schedule_slots_for_write([EXO_REPORTED_SLOT]) == [APP_PUT_SLOT]
 
 
-def test_state_is_omitted_unless_requested() -> None:
+def test_write_shape_leaves_operation_name_devices_alone() -> None:
+    """Units carrying the mode as operationName keep their payload untouched."""
+    from custom_components.fluidra_pool.helpers import schedule_slots_for_write
+
+    slot = {
+        "id": 1,
+        "groupId": 1,
+        "enabled": True,
+        "startTime": "09 08 * * 1,0",
+        "endTime": "11 10 * * 1,0",
+        "startActions": {"operationName": "1"},
+    }
+    assert schedule_slots_for_write([slot]) == [slot]
+
+
+def test_state_is_never_sent() -> None:
     from custom_components.fluidra_pool import _service_schedule_to_fluidra
 
     ours = _service_schedule_to_fluidra(
@@ -298,14 +323,53 @@ def test_sunday_is_not_duplicated_when_sent_both_ways() -> None:
     assert slot["startTime"] == "00 01 * * 0,1"
 
 
-def test_key_order_matches_the_devices_own_slots() -> None:
-    """Ordered as the eXO reports them, state third (Issue #174)."""
+def test_key_order_matches_the_apps_own_put_body() -> None:
+    """Ordered as the app sends them (Issue #174)."""
     from custom_components.fluidra_pool import _service_schedule_to_fluidra
 
     slot = _service_schedule_to_fluidra(
         {"enabled": False, "start_time": "21:11", "end_time": "21:19", "mode": "1", "days": [1]},
         3,
         use_component_actions=True,
-        include_state=True,
     )
-    assert list(slot) == list(EXO_SLOT)
+    assert list(slot) == list(APP_PUT_SLOT)
+
+
+# --- Issue #174: a slot cannot cross midnight --------------------------------
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        ("22:00", "06:00"),  # The overnight case named on the issue.
+        ("08:00", "08:00"),  # Zero-length.
+        ("10:30", "10:29"),  # One minute backwards.
+        ("23:59", "00:00"),  # Straddling midnight by a minute.
+    ],
+)
+def test_a_slot_that_does_not_end_after_it_starts_is_refused(start: str, end: str) -> None:
+    """start and end are two CRONs on one day set, so overnight has no shape."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.fluidra_pool import _service_schedule_to_fluidra
+
+    with pytest.raises(ServiceValidationError) as err:
+        _service_schedule_to_fluidra(
+            {"enabled": True, "start_time": start, "end_time": end, "mode": "1", "days": [1]},
+            1,
+        )
+    assert err.value.translation_key == "schedule_overnight_unsupported"
+
+
+def test_the_two_halves_of_an_overnight_window_are_both_accepted() -> None:
+    """The documented workaround: an evening slot and a morning slot."""
+    from custom_components.fluidra_pool import _service_schedule_to_fluidra
+
+    evening = _service_schedule_to_fluidra(
+        {"enabled": True, "start_time": "22:00", "end_time": "23:59", "mode": "1", "days": [1]}, 1
+    )
+    morning = _service_schedule_to_fluidra(
+        {"enabled": True, "start_time": "00:00", "end_time": "06:00", "mode": "1", "days": [2]}, 2
+    )
+    assert evening["startTime"] == "00 22 * * 1"
+    assert morning["endTime"] == "00 06 * * 2"

--- a/tests/test_schedule_corruption.py
+++ b/tests/test_schedule_corruption.py
@@ -147,7 +147,7 @@ def test_service_builds_component_actions_for_exo_devices() -> None:
         1,
         use_component_actions=True,
     )
-    assert built["startActions"] == {"componentActions": [{"id": 0, "reportedValue": 1}]}
+    assert built["startActions"] == {"operationName": "1", "componentActions": [{"id": 0, "desiredValue": 1}]}
     assert built["startTime"] == "00 08 * * 1,2,3"
 
 

--- a/tests/test_schedules_api.py
+++ b/tests/test_schedules_api.py
@@ -187,7 +187,8 @@ async def test_set_schedule_success_returns_true_and_puts_payload() -> None:
     assert url.startswith("https://api.fluidra-emea.com/generic/devices/DEV-1/components/")
     assert url.endswith(f"/components/{COMPONENT_SCHEDULE}")
     assert kwargs.get("params") == {"deviceType": "connected"}
-    assert kwargs["json_data"] == {"desiredValue": schedules}
+    # groupId is filled in from id on the way out (schedule_slots_for_write).
+    assert kwargs["json_data"] == {"desiredValue": [{"id": 1, "enabled": True, "groupId": 1}]}
     # content-type header is set on the auth headers.
     assert kwargs["headers"]["content-type"] == "application/json; charset=utf-8"
 
@@ -334,3 +335,90 @@ async def test_get_pool_schedulers_returns_none_on_error_status() -> None:
     api = _FakeAPI()
     api._request.return_value = (404, None, "")
     assert await api.get_pool_schedulers("pool-1") is None
+
+
+# --- Issue #174: the PUT body must match the official app's, byte for byte ----
+
+
+async def test_put_body_matches_the_captured_app_body_for_a_vs_pump_slot() -> None:
+    """@Inervo's capture: PUT /components/21, chlorination on, 05:06-07:08, 2332 rpm.
+
+    Fed to us as the device reports the slot back — ``reportedValue``, a runtime
+    ``state``, no ``groupId`` — which is what every write path hands over after
+    an edit. What leaves must be the app's shape regardless.
+    """
+    api = _make_api(status=200)
+    reported_slot: dict[str, Any] = {
+        "id": 1,
+        "state": "IDLE",
+        "enabled": True,
+        "startTime": "06 05 * * 1",
+        "endTime": "08 07 * * 1",
+        "endActions": {},
+        "startActions": {"componentActions": [{"id": 0, "reportedValue": 1}, {"id": 1, "reportedValue": 2332}]},
+    }
+
+    assert await api.set_schedule("NS25007212", [reported_slot], component_id=21) is True
+
+    _args, kwargs = api._request.await_args
+    assert kwargs["json_data"] == {
+        "desiredValue": [
+            {
+                "id": 1,
+                "groupId": 1,
+                "enabled": True,
+                "startTime": "06 05 * * 1",
+                "endTime": "08 07 * * 1",
+                "startActions": {
+                    "operationName": "1",
+                    "componentActions": [{"id": 0, "desiredValue": 1}, {"id": 1, "desiredValue": 2332}],
+                },
+            }
+        ]
+    }
+
+
+async def test_put_body_matches_the_captured_app_body_for_a_colour_led_slot() -> None:
+    """@Inervo's capture: PUT /components/23, Friday 10:00-11:00, colour index 3."""
+    api = _make_api(status=200)
+    reported_slot: dict[str, Any] = {
+        "id": 1,
+        "groupId": 1,
+        "enabled": True,
+        "startTime": "00 10 * * 5",
+        "endTime": "00 11 * * 5",
+        "startActions": {"componentActions": [{"id": 0, "reportedValue": 3}]},
+    }
+
+    assert await api.set_schedule("NS25007212", [reported_slot], component_id=23) is True
+
+    _args, kwargs = api._request.await_args
+    assert kwargs["json_data"]["desiredValue"][0]["startActions"] == {
+        "operationName": "1",
+        "componentActions": [{"id": 0, "desiredValue": 3}],
+    }
+
+
+async def test_a_simple_on_off_aux_slot_is_sent_unchanged() -> None:
+    """@Inervo's capture: PUT /components/22 carries operationName and nothing else."""
+    api = _make_api(status=200)
+    slot: dict[str, Any] = {
+        "id": 1,
+        "groupId": 1,
+        "enabled": True,
+        "startTime": "09 08 * * 1,0",
+        "endTime": "11 10 * * 1,0",
+        "startActions": {"operationName": "1"},
+    }
+
+    assert await api.set_schedule("NS25007212", [slot], component_id=22) is True
+
+    _args, kwargs = api._request.await_args
+    assert kwargs["json_data"] == {"desiredValue": [slot]}
+
+
+async def test_clearing_a_register_still_sends_an_empty_list() -> None:
+    api = _make_api(status=200)
+    assert await api.clear_schedule("NS25007212", component_id=23) is True
+    _args, kwargs = api._request.await_args
+    assert kwargs["json_data"] == {"desiredValue": []}

--- a/tests/test_select_schedule.py
+++ b/tests/test_select_schedule.py
@@ -376,6 +376,39 @@ async def test_chlor_schedule_speed_select_writes_component_actions_for_exo() ->
     assert sent[0]["startActions"]["componentActions"][0]["reportedValue"] == 2
 
 
+async def test_chlor_schedule_speed_keeps_the_variable_speed_target_rpm() -> None:
+    """A VS slot carries the RPM under id 1; changing the mode must not drop it.
+
+    An RPM-less slot leaves the Fluidra app unable to load the device at all,
+    recoverable only by changing the pump type on the unit (Issue #174).
+    """
+    schedule = {
+        **SCHEDULE,
+        "id": 1,
+        "startActions": {"componentActions": [{"id": 0, "reportedValue": 1}, {"id": 1, "reportedValue": 2332}]},
+    }
+    device = _chlor_device(schedule_data=[schedule], output_type="output")
+    api = _api()
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), api, POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+
+    await select.async_select_option("aux1")
+
+    sent = api.set_schedule.call_args.args[1]
+    actions = {action["id"]: action["reportedValue"] for action in sent[0]["startActions"]["componentActions"]}
+    assert actions == {0: 2, 1: 2332}
+
+
+async def test_chlor_schedule_speed_reads_a_freshly_written_slot() -> None:
+    """A slot echoed back under desiredValue must still resolve to an option."""
+    schedule = {**SCHEDULE, "id": 1, "startActions": {"componentActions": [{"id": 0, "desiredValue": 2}]}}
+    device = _chlor_device(schedule_data=[schedule], output_type="output")
+    select = FluidraChlorinatorScheduleSpeedSelect(_coord(device), _api(), POOL_ID, CHLOR_ID, schedule_id="1")
+    _attach_ha(select)
+
+    assert select.current_option == "aux1"
+
+
 async def test_chlor_schedule_speed_clears_optimistic_after_success() -> None:
     """After a successful API call, the optimistic option is cleared."""
     device = _chlor_device(schedule_data=[SCHEDULE])


### PR DESCRIPTION
@Inervo's network capture of the official Fluidra app (Issue #174) is the first
direct look at the PUT body the app actually sends for an eXO iQ scheduler. It
differs from what this integration sends, and it shows the aux outputs use twice
as many registers as we scan.

## The write shape

Three differences, all corrected in `fluidra_api.set_schedule` so no write path
can drift from the others:

| | integration sent | app sends |
|---|---|---|
| `componentActions` value | `reportedValue` | `desiredValue` |
| `operationName` | omitted when `componentActions` present | always present, alongside |
| `state` | synthesised as `"IDLE"` (v2.78.5) | never sent |

The `reportedValue` one matters most: reads echo an action back under that key
and every write path re-sent it verbatim. It is a key the backend's transform
does not consume, which fits writes landing mangled rather than rejected —
the behaviour v2.80.0 responded to by refusing eXO schedule writes outright.

**The chlorination write guard stays.** The corrected payload is a plausible
cause of the mangling, not a verified one, and nobody has re-run it on hardware.
Lifting it is a separate decision on separate evidence.

## The aux registers

The device declares seven schedulers, c19–c25. We scanned five. The capture
shows why: an aux output uses **two** registers, not one — c22 for a plain
on/off output and c23 when it drives a colour LED, with c24/c25 the same way for
Aux 2. An aux wired to a colour LED therefore read as having no schedules at all.

Both are scanned now, and the live one is resolved from the register that holds
slots. When both hold slots the choice is genuinely ambiguous: the pre-existing
register is kept and the assigned-function label (c90/c91) logged at warning,
rather than guessed at.

The two LED colour tables share neither a base nor a length — LumiPlus runs
0–13, Zodiac NL runs 2–15 — and nothing read from the device says which family an
aux drives. The cross-mappings Inervo names (LumiPlus on c25, Zodiac NL on c23)
are his own inference, untested. So a colour index is surfaced raw, with both
candidate names as an attribute, rather than resolved to one that would be wrong
for the other family.

## Two things this exposed

- The schedule mode select rebuilt a slot's `componentActions` from id 0 alone,
  dropping the target RPM a variable-speed slot carries under id 1. That is
  exactly the failure that leaves the Fluidra app unable to load the device
  until the pump type is changed on the unit itself. It now preserves every
  other action.
- A slot is two CRON expressions over one day set, so an overnight window has no
  representation. `22:00 → 06:00` went out as an end preceding its own start.
  The service now refuses it and names the workaround (two slots).

## How to confirm the write shape

The aux registers are deliberately outside the guard — they take the same
corrected payload and drive only an auxiliary output, so they are the safe place
to test. Editing an Aux 1 or Aux 2 schedule time from Home Assistant and checking
it comes back unchanged in the Fluidra app validates the whole correction. If it
holds, the chlorination guard can be lifted per register.

## Out of scope

The auxiliary outputs themselves — exposing Aux 1 / Aux 2 as controllable
entities — remain Issue #175. This PR goes as far as the current entity model
allows: aux *schedules* are read and written, aux *outputs* are not added.

## Verification

- `pytest`: 1811 passed (baseline 1773; 38 new)
- `ruff check` / `ruff format`: clean
- `mypy --strict`: no issues in 61 source files
- repo pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for auxiliary colour-LED schedules, including colour names and effects.
  * Auxiliary schedule controls now display resolved LED colour information when available.
  * Added translated labels and messages for auxiliary schedules.

* **Bug Fixes**
  * Schedule updates now preserve existing actions and use the correct write format.
  * Invalid overnight or zero-length schedules are rejected with guidance to split them.
  * Improved handling of auxiliary schedules across standard and colour-LED outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->