### PR TITLE
docs(heat-pump): state the Z250iQ's real feature set and lock it to the Z260iQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The README no longer under-sells the Z250iQ.** It still described the model as on/off,
+  target temperature and current temperature only — the state it was in before v2.48.0
+  (2026-07-08) promoted it to the full Z260iQ feature set. The profile has carried HVAC modes, presets,
+  the no-flow alarm, running hours and the WiFi signal since then, so a Z250iQ owner reading
+  the supported-devices list was told their unit does less than it does. The two profiles are
+  now also locked together by a test: their entity lists and feature dicts must stay equal,
+  and a Z250iQ must resolve to the Z260iQ climate behaviour. @Kal42's register-by-register
+  comparison on #139 is the evidence that both models ship the same firmware; the profiles
+  stay separate only for identification, never for behaviour (Issue #139, @Kal42).
+
 - **The login form now says what actually went wrong instead of always blaming the password.**
   Every AWS Cognito rejection used to render as the same "check your email and password" message,
   with the real cause reachable only in a debug log nobody enables before opening an issue. The

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ profile, so unknown equipment is usually still usable.
 
 ### 🔥 Heat Pumps
 - **LG Eco Elyo** — reversible: Smart Heating / Cooling, Boost, Silence presets; target temp; water-temp sensor
-- **Z250iQ / Z25iQ** — on/off, target temperature, current temperature
+- **Z250iQ / Z25iQ** — same firmware family as the Z260iQ, so the same feature set:
+  HVAC modes (heat / cool / heat-cool), presets, no-flow alarm, water/air temperatures,
+  running hours, WiFi signal
 - **Z260iQ** — HVAC modes (heat / cool / heat-cool), presets, no-flow alarm, water/air temperatures
 - **Z550iQ+** — HVAC modes (heat / cool / auto), presets, HVAC action (heating/cooling/idle/no-flow), water/air temperatures
 - **Z650iQ** — HVAC modes (heat / cool / heat-cool), Smart+/Smart/Ecosilence/Boost presets,

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -265,6 +265,66 @@ class TestDeviceConfigRegistry:
         }
         assert DeviceIdentifier.identify_device(device) is config
 
+    def test_z250iq_and_z260iq_expose_the_same_feature_set(self):
+        """The two profiles must stay equal on everything behavioural (Issue #139).
+
+        @Kal42 read every register on a Z250iQ and found them identical to the
+        Z260iQ — HVAC modes, no-flow, running hours — and concluded both models
+        ship the same firmware. The profiles are kept separate only for
+        *identification* (the Z260iQ has no name patterns and both share the
+        LF* prefix with the BXWAD), never for behaviour. This guards that
+        split: a feature added to one model and forgotten on the other is a
+        regression, not a design choice. If a genuine hardware difference is
+        ever measured, change this test deliberately.
+        """
+        z250 = DEVICE_CONFIGS["z250iq_heat_pump"]
+        z260 = DEVICE_CONFIGS["z260iq_heat_pump"]
+        assert z250.features == z260.features
+        assert z250.entities == z260.entities
+        assert z250.device_type == z260.device_type
+        # Identification stays distinct — that is the whole reason for two profiles.
+        assert z250.priority != z260.priority
+        assert z250.name_patterns
+        assert not z260.name_patterns
+
+    def test_z250iq_device_resolves_to_the_z260iq_climate_behavior(self):
+        """A Z250iQ unit must be driven by the Z260iQ behaviour at runtime.
+
+        Equal feature dicts are only worth something if the climate layer acts
+        on them: resolve_behavior() dispatches on the z260iq_mode feature, so a
+        Z250iQ that lands on its own profile still gets Z260iqBehavior. This is
+        the end-to-end proof for Issue #139 — same reported values, same driver.
+        """
+        from custom_components.fluidra_pool.climate_behaviors import (
+            Z260iqBehavior,
+            resolve_behavior,
+        )
+
+        z250 = {
+            "device_id": "LF25001234",
+            "name": "Z250iQ",
+            "family": "Heat Pump",
+            "type": "heat_pump",
+            "model": "Z250iQ",
+            "components": {},
+        }
+        z260 = {
+            "device_id": "LF26005678",
+            "name": "Heat Pump",
+            "family": "Heat Pump",
+            "type": "heat_pump",
+            "model": "Z260iQ",
+            # The Z260iQ profile is gated on the comp-7 BXWAD signature: without
+            # it the identifier scores it zero, and the unit falls through to the
+            # Z250iQ profile. Harmless now that the two carry the same features —
+            # which is exactly what the parity test above locks in.
+            "components": {"7": {"reportedValue": "BXWAD0103544325004"}},
+        }
+        assert DeviceIdentifier.identify_device(z250) is DEVICE_CONFIGS["z250iq_heat_pump"]
+        assert DeviceIdentifier.identify_device(z260) is DEVICE_CONFIGS["z260iq_heat_pump"]
+        assert isinstance(resolve_behavior(z250), Z260iqBehavior)
+        assert type(resolve_behavior(z250)) is type(resolve_behavior(z260))
+
     def test_cc24018506_energy_connect_full_profile_fix(self):
         """Energy Connect CC24018506 profile fix, covering four write/read pairs
         inherited from the generic catch-all and never verified against real


### PR DESCRIPTION
Closes #139.

## What this changes

Nothing about how a Z250iQ behaves — that part shipped in **v2.48.0** (2026-07-08), commit `10a2681`, which promoted the profile to the full Z260iQ feature set after @Kal42's live register dump. What was still wrong is the **documentation**, and the fact that nothing stopped the two profiles from drifting apart again.

- **README** — the supported-devices list still described the Z250iQ as *"on/off, target temperature, current temperature"*, its pre-promotion state. A Z250iQ owner reading it was told their unit does less than it does. It now lists the real set: HVAC modes, presets, no-flow alarm, water/air temperatures, running hours, WiFi signal.
- **Two new tests** hold the invariant @Kal42 measured.

## Why the profiles stay separate

They are already identical where it counts. Diffed field by field:

| field | Z250iQ | Z260iQ | |
|---|---|---|---|
| `entities` | — | — | **identical** |
| `features` | — | — | **identical** |
| `device_type` | `heat_pump` | `heat_pump` | identical |
| `identifier_patterns` | `["LF*"]` | `["LF*"]` | identical |
| `name_patterns` | `["z250", "z25"]` | `[]` | **differs — on purpose** |
| `priority` | 95 | 97 | **differs — on purpose** |

The split is about *identification only*. The Z260iQ profile carries no name patterns and is gated on the comp-7 `BXWAD` signature (`identifier.py` scores it zero without it); the Z250iQ matches on `LF*` + a `z250`/`z25` name. Merging them would mean re-deciding how BXWAD units, which share the `LF*` prefix, get routed — a change nobody's measurements ask for.

So instead of merging, this PR locks the two together on behaviour:

- `test_z250iq_and_z260iq_expose_the_same_feature_set` — asserts `entities` and `features` are equal, and that identification stays distinct. A feature added to one model and forgotten on the other now fails CI. Mutation-checked: flipping the Z250iQ's `max_temp` to 38.0 makes it fail.
- `test_z250iq_device_resolves_to_the_z260iq_climate_behavior` — equal dicts are only worth something if the climate layer acts on them, so this asserts a Z250iQ device resolves to `Z260iqBehavior` through `resolve_behavior()`, same as a Z260iQ.

## Gate

```
ruff check custom_components/fluidra_pool/ tests/   All checks passed!
ruff format --check                                 118 files already formatted
pre-commit run --files <the 3 changed>              all Passed
pytest -q                                           1813 passed in 23.42s
```

Not merged here — that call is the maintainer's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Z250iQ heat pumps now provide the same climate controls and feature data as Z260iQ models, including HVAC modes, presets, alarms, temperature readings, running hours, and WiFi signal strength.
  * Login errors now display distinct translated messages, with safe generic fallbacks for unauthorized or unknown errors.
* **Documentation**
  * Updated the heat-pump support documentation to reflect the expanded Z250iQ feature set.
* **Quality Improvements**
  * Added coverage to help ensure consistent behavior across Z250iQ and Z260iQ devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->