### PR TITLE
feat(chlorinator): expose actual chlorination on GenSalt OE iQ Evo (c154)

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -150,6 +150,13 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # to the generic chlorinator profile, which put the OFF/ON/AUTO mode select on c20 —
         # so the select read 700, fell through to "Off", and writing On/Auto wrote 1 or 2
         # into the ORP setpoint.
+        # chlorination_actual on c154 (Issue #207, @albo-yo): the real cell-output %,
+        # distinct from the c10 setpoint, as confirmed on every other tecnoLC2 profile
+        # where it was checked. Exposed here following that same convention — the
+        # reporter can validate it live against the app (production falls to 0 once the
+        # ORP target is reached). c154 was previously absent from specific_components,
+        # so it never appeared in any diagnostics capture from this unit; it is now
+        # polled, so a mismatch against the app can be settled by a single export.
         identifier_patterns=["CC25051112*", "CC26009948*"],
         family_patterns=["chlorinator"],
         components_range=25,
@@ -167,8 +174,9 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
                 "orp": 170,  # ORP measured (mV) — matches the app (c177 is uncalibrated).
                 "temperature": 172,  # Water temperature (°C × 10).
                 "salinity": 174,  # Salinity (g/L × 100).
+                "chlorination_actual": 154,  # Real cell output % (Issue #207) — pending live confirmation vs the app.
             },
-            "specific_components": [0, 10, 16, 20, 103, 165, 170, 172, 174],
+            "specific_components": [0, 10, 16, 20, 103, 154, 165, 170, 172, 174],
         },
         priority=90,
     ),

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -130,7 +130,9 @@ class TestDeviceConfigRegistry:
         assert sensors["orp"] == 170  # calibrated ORP (663 mV), not the raw c177 (725)
         assert sensors["temperature"] == 172
         assert sensors["salinity"] == 174
+        assert sensors["chlorination_actual"] == 154  # real cell output % (Issue #207)
         assert config.features["orp_setpoint"] == 20  # this variant exposes the ORP setpoint (c20 = 750)
+        assert 154 in config.features["specific_components"]  # c154 polled → shows up in diagnostics
 
     def test_dm24008702_neolysis_connect_identifies_over_generic(self):
         """Neolysis Connect (DM24008702, domoticS2) resolves to its verified profile, not the catch-all (Issue #141)."""


### PR DESCRIPTION
Closes #207

## What

The `cc25051112_chlorinator` profile (which covers `CC26009948*`, the reporter's GenSalt OE iQ pH Evo with ORP kit) now:

- maps **`chlorination_actual`** to register **c154** — the real cell-output %, distinct from the c10 setpoint
- polls **c154** (`specific_components`)

## Why

c154 is the confirmed actual-production register on every other tecnoLC2 profile where it was checked, and the issue itself asks for that convention. Crucially, c154 was previously **absent from specific_components**, so it never appeared in any diagnostics capture from this unit — the two exports requested in #207 could never have settled the question. It is now polled, so a mismatch against the app can be settled by a single export.

## Validation

- Reporter can confirm live: HA sensor vs app production % (falls to 0 once the ORP target is reached)
- ruff clean, full suite green (1858 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into the chlorinator’s actual live cell output, separate from the configured chlorination setpoint.
  * Added polling support for the live chlorination output.

* **Bug Fixes**
  * Corrected chlorinator monitoring to use the appropriate component for actual output readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->