### PR TITLE
fix(number): return None instead of inventing 7.2 pH / 700 mV ORP setpoints

### DIFF
--- a/custom_components/fluidra_pool/number.py
+++ b/custom_components/fluidra_pool/number.py
@@ -191,7 +191,7 @@ class FluidraChlorinatorPhSetpoint(FluidraPoolControlEntity, NumberEntity):
         raw_value = component_data.get("desiredValue", component_data.get("reportedValue"))
 
         if raw_value is None:
-            return 7.2  # Default value
+            return None
 
         # Divisor: 100 by default (e.g., 720 = 7.20), 10 for EXO (e.g., 72 = 7.2)
         divisor = DeviceIdentifier.get_feature(self.device_data, "ph_setpoint_divisor", 100)
@@ -199,7 +199,8 @@ class FluidraChlorinatorPhSetpoint(FluidraPoolControlEntity, NumberEntity):
         try:
             value: float = float(raw_value) / divisor
         except (ValueError, TypeError):
-            return 7.2
+            _LOGGER.debug("Failed to parse pH setpoint value %s for %s", raw_value, self._device_id)
+            return None
         return value
 
     async def async_set_native_value(self, value: float) -> None:
@@ -384,12 +385,12 @@ class FluidraChlorinatorOrpSetpoint(FluidraPoolControlEntity, NumberEntity):
         raw_value = component_data.get("desiredValue", component_data.get("reportedValue"))
 
         if raw_value is None:
-            return 700.0
+            return None
         try:
             return float(raw_value)
         except (ValueError, TypeError):
             _LOGGER.debug("Failed to parse ORP setpoint value %s for %s", raw_value, self._device_id)
-            return 700.0
+            return None
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the ORP setpoint."""

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -215,15 +215,15 @@ def test_ph_setpoint_native_value_divides_by_100() -> None:
     assert number.native_value == 7.2
 
 
-def test_ph_setpoint_default_when_no_reading() -> None:
-    """Missing reading falls back to 7.2 rather than returning None."""
+def test_ph_setpoint_none_when_no_reading() -> None:
+    """Missing reading returns None so the entity reads `unknown`, not an invented 7.2."""
     device = _chlorinator_device(
         components={},
         features={"ph_setpoint": {"write": 8, "read": 172}},
     )
     number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
     _attach_ha(number)
-    assert number.native_value == 7.2
+    assert number.native_value is None
 
 
 async def test_ph_setpoint_async_set_multiplies_by_divisor_and_writes() -> None:
@@ -267,14 +267,14 @@ def test_ph_setpoint_native_value_simple_int_reads_same_component() -> None:
 
 
 def test_ph_setpoint_native_value_guards_non_numeric() -> None:
-    """A non-numeric pH reading falls back to the 7.2 default instead of raising."""
+    """A non-numeric pH reading returns None instead of raising or inventing a value."""
     device = _chlorinator_device(
         components={"172": {"reportedValue": "bad"}},
         features={"ph_setpoint": {"write": 8, "read": 172}},
     )
     number = FluidraChlorinatorPhSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
     _attach_ha(number)
-    assert number.native_value == 7.2
+    assert number.native_value is None
 
 
 def test_ph_setpoint_icon_is_ph() -> None:
@@ -379,14 +379,14 @@ async def test_orp_setpoint_async_set_writes_integer_value() -> None:
 
 
 def test_orp_setpoint_native_value_guards_non_numeric() -> None:
-    """A non-numeric ORP value returns the 700.0 default instead of raising (climate_light_number-7)."""
+    """A non-numeric ORP value returns None instead of raising (climate_light_number-7)."""
     device = _chlorinator_device(
         components={"177": {"reportedValue": "n/a"}},
         features={"orp_setpoint": {"write": 11, "read": 177}},
     )
     number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
     _attach_ha(number)
-    assert number.native_value == 700.0
+    assert number.native_value is None
 
 
 def test_orp_setpoint_native_value_simple_int_reads_same_component() -> None:
@@ -400,15 +400,15 @@ def test_orp_setpoint_native_value_simple_int_reads_same_component() -> None:
     assert number.native_value == 680.0
 
 
-def test_orp_setpoint_native_value_default_when_no_reading() -> None:
-    """Missing ORP reading falls back to 700.0 rather than returning None."""
+def test_orp_setpoint_native_value_none_when_no_reading() -> None:
+    """Missing ORP reading returns None so the entity reads `unknown`, not an invented 700 mV."""
     device = _chlorinator_device(
         components={},
         features={"orp_setpoint": {"write": 11, "read": 177}},
     )
     number = FluidraChlorinatorOrpSetpoint(_coord_with(device), _api(), POOL_ID, DEVICE_ID)
     _attach_ha(number)
-    assert number.native_value == 700.0
+    assert number.native_value is None
 
 
 def test_orp_setpoint_icon_is_lightning_bolt() -> None:


### PR DESCRIPTION
Follow-up to #206, which documented this from the outside. This is the cause.

### The behaviour

`FluidraChlorinatorPhSetpoint.native_value` and `FluidraChlorinatorOrpSetpoint.native_value` fall back to hard-coded values when the component data is missing or unparseable:

```python
if raw_value is None:
    return 7.2  # Default value      # number.py:194, and again at :202
...
if raw_value is None:
    return 700.0                     # number.py:387, and again at :392
```

### Why it matters in practice

On a live tecnoLC2 this fires on **every reconnection** — the coordinator has no component data yet on the first refresh, so each power cycle writes one fabricated value to the recorder before the real one arrives ~35 s later:

| Entity | 1st value after reconnect | 2nd value (real) |
|---|---|---|
| pH setpoint | **7.2** | 7.7 |
| ORP setpoint | **700** | 750 |

My pH setpoint has never been 7.2 and my ORP setpoint has never been 700. Both numbers are plausible enough that nothing looks wrong — which is the problem.

These are **control** entities. A fabricated value is indistinguishable from a real one, so:

- an automation that reads the setpoint acts on a value the equipment never held;
- any statistic or average computed across a power cycle is skewed by it;
- someone debugging their pool chemistry sees a setpoint change that never happened. (That last one is not hypothetical — I spent a while today convinced my chlorinator had a second setpoint.)

Returning `None` makes the entity read `unknown`, which is exactly what is known at that moment. `NumberEntity.native_value` is already typed `float | None`.

### Consistency argument

`FluidraHeatingSetpoint` in the same module **already does this** — `test_heating_setpoint.py` asserts `native_value is None` for both the missing-data and the unparseable case. This change aligns the three setpoint entities on that behaviour.

### About the tests

I want to be upfront: **this behaviour was deliberate and tested.** `test_ph_setpoint_default_when_no_reading` carried the docstring *"Missing reading falls back to 7.2 rather than returning None"*. I have updated the four existing tests rather than adding new ones, so the diff shows exactly which contract changes and nothing else.

If the fallback was protecting something I have not spotted — a UI concern with sliders on `unknown`, for instance — say so and I will close this. The observation in #206 stands either way.

### Checks

- `ruff check` — clean
- `ruff format --check` — 120 files already formatted
- `pytest` — **1858 passed** (Linux, Python 3.14, matching CI)
- `mypy` — same 11 pre-existing errors before and after; none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbMMSajYT2cFbHtbDijDPB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * pH and ORP setpoints now report unavailable readings instead of displaying fallback values when source data is missing or invalid.
  * Invalid setpoint readings are handled more accurately, preventing misleading values from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->