### PR TITLE
feat(devices): Zodiac Freedom Lite robot, Command Connect cabinet, heat-pump activity

### DIFF
--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -34,6 +34,8 @@ DEVICE_TYPE_HEAT_PUMP: Final = "heat_pump"
 DEVICE_TYPE_HEATER: Final = "heater"
 DEVICE_TYPE_LIGHT: Final = "light"
 DEVICE_TYPE_CHLORINATOR: Final = "chlorinator"
+DEVICE_TYPE_ROBOT: Final = "robot"
+DEVICE_TYPE_CABINET: Final = "cabinet"
 
 # Device-registry model labels shown on the HA device page.
 DEVICE_MODEL_MAP: Final[dict[str, str]] = {
@@ -42,6 +44,8 @@ DEVICE_MODEL_MAP: Final[dict[str, str]] = {
     DEVICE_TYPE_HEAT_PUMP: "Heat Pump",
     DEVICE_TYPE_LIGHT: "Light",
     DEVICE_TYPE_HEATER: "Heater",
+    DEVICE_TYPE_ROBOT: "Pool Robot",
+    DEVICE_TYPE_CABINET: "Cabinet",
 }
 DEVICE_MODEL_FALLBACK: Final = "Pool Equipment"
 

--- a/custom_components/fluidra_pool/device_registry/configs/__init__.py
+++ b/custom_components/fluidra_pool/device_registry/configs/__init__.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 from ..types import DeviceConfig
+from .cabinets import CABINET_CONFIGS
 from .chlorinators import CHLORINATOR_CONFIGS
 from .generic import GENERIC_CONFIGS
 from .heat_pumps import HEAT_PUMP_CONFIGS
 from .probes import PROBE_CONFIGS
 from .pumps import PUMP_CONFIGS
+from .robots import ROBOT_CONFIGS
 
 DEVICE_CONFIGS: dict[str, DeviceConfig] = {
     **HEAT_PUMP_CONFIGS,
     **CHLORINATOR_CONFIGS,
     **PROBE_CONFIGS,
     **PUMP_CONFIGS,
+    **CABINET_CONFIGS,
+    **ROBOT_CONFIGS,
     **GENERIC_CONFIGS,
 }
 

--- a/custom_components/fluidra_pool/device_registry/configs/cabinets.py
+++ b/custom_components/fluidra_pool/device_registry/configs/cabinets.py
@@ -1,0 +1,44 @@
+"""Cabinet configurations (AstralPool Command Connect, Issue #210)."""
+
+from __future__ import annotations
+
+from ..types import DeviceConfig
+
+CABINET_CONFIGS: dict[str, DeviceConfig] = {
+    "command_connect_cabinet": DeviceConfig(
+        device_type="cabinet",
+        # One API device (behind an iQBridge ZB gateway) driving several
+        # independent outputs, each with its own on/off and auto-mode register.
+        # Component map verified on hardware by @efgonzalez (Issue #210):
+        #   c13 filtration pump on/off, c24 pool lights on/off,
+        #   c15 pump auto mode, c26 lights auto mode,
+        #   c35/c36 the two schedulers (r1/r2) — not written by this
+        #   integration yet; c16 packs schedule times as a string.
+        family_patterns=["Cabinets"],
+        model_patterns=["Command Connect"],
+        components_range=40,
+        required_components=[13, 24],
+        entities=["switch"],
+        features={
+            # Component registers (verified on hardware, Issue #210); the
+            # toggle_switches list below drives one boolean switch per key.
+            "cabinet_pump": 13,
+            "cabinet_lights": 24,
+            "cabinet_pump_auto_mode": 15,
+            "cabinet_lights_auto_mode": 26,
+            "specific_components": [13, 15, 24, 26],
+            # ⚠ The cabinet silently ignores integer writes: PUT {"desiredValue": 1}
+            # returns HTTP 200 and does nothing, while true/false applies within
+            # ~5-10 s (Issue #210). Every control entity for this profile must go
+            # through a boolean write path — never 1/0.
+            "boolean_writes": True,
+            "toggle_switches": [
+                ("cabinet_pump", "cabinet_pump", "mdi:pump"),
+                ("cabinet_lights", "cabinet_lights", "mdi:string-lights"),
+                ("cabinet_pump_auto_mode", "cabinet_pump_auto_mode", "mdi:calendar-clock"),
+                ("cabinet_lights_auto_mode", "cabinet_lights_auto_mode", "mdi:calendar-clock"),
+            ],
+        },
+        priority=85,
+    ),
+}

--- a/custom_components/fluidra_pool/device_registry/configs/generic.py
+++ b/custom_components/fluidra_pool/device_registry/configs/generic.py
@@ -9,7 +9,7 @@ GENERIC_CONFIGS: dict[str, DeviceConfig] = {
         device_type="heat_pump",
         components_range=5,
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info"],
+        entities=["climate", "switch", "sensor_info", "sensor_activity"],
         features={
             "temperature_control": True,
             "hvac_modes": ["off", "heat"],

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -13,7 +13,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         model_patterns=["astralpool"],
         components_range=5,  # Minimal scan; specific components below.
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info"],
+        entities=["climate", "switch", "sensor_info", "sensor_activity"],
         features={
             "preset_modes": True,
             "temperature_control": True,
@@ -44,6 +44,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             # Z260iQ one, so declaring it there alone left the sensor unreachable for
             # every Z250iQ owner (Issue #183, @paradox37).
             "sensor_wifi_signal",
+            "sensor_activity",
         ],
         features={
             # Same firmware family as the Z260iQ — full register-by-register
@@ -89,6 +90,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             # No-flow is surfaced on the climate entity (no_flow_alarm attribute /
             # hvac_action "no_flow"), not as a separate binary_sensor: there is no
             # binary_sensor platform, so "binary_sensor_no_flow" was a dead token.
+            "sensor_activity",
         ],
         features={
             "z260iq_mode": True,
@@ -128,7 +130,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         family_patterns=["heat pump"],
         components_range=5,
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours"],
+        entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours", "sensor_activity"],
         features={
             "temperature_control": True,
             # preset_modes stay disabled: component 17 is a read-only status whose
@@ -176,7 +178,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         model_patterns=["hpgic"],
         components_range=5,
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info"],
+        entities=["climate", "switch", "sensor_info", "sensor_activity"],
         features={
             "preset_modes": True,
             "temperature_control": True,
@@ -211,6 +213,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             "sensor_wifi_signal",
             "sensor_power",
             "sensor_compressor_modulation",
+            "sensor_activity",
         ],
         features={
             "z260iq_mode": True,

--- a/custom_components/fluidra_pool/device_registry/configs/robots.py
+++ b/custom_components/fluidra_pool/device_registry/configs/robots.py
@@ -1,0 +1,29 @@
+"""Robotic cleaner configurations (Zodiac Freedom Lite, Issue #212)."""
+
+from __future__ import annotations
+
+from ..types import DeviceConfig
+
+ROBOT_CONFIGS: dict[str, DeviceConfig] = {
+    "freedom_lite_robot": DeviceConfig(
+        device_type="robot",
+        # Registers reported from the coordinator dump by @MDBENNANI (Issue #212):
+        #   c25 automatic scheduling days as day-name strings
+        #     (e.g. ['wednesday', 'saturday']),
+        #   c26 battery charge in percent (e.g. 79).
+        # The remaining registers of the dump (27-37: timestamps, counters,
+        # firmware '1.1.3', run-duration blocks) are deliberately unmapped until
+        # someone correlates them with an app toggle.
+        identifier_patterns=["NLX*"],
+        model_patterns=["Freedom Lite"],
+        components_range=40,
+        required_components=[25, 26],
+        entities=["sensor_battery", "sensor_schedule_days"],
+        features={
+            "specific_components": [25, 26],
+            "battery_component": 26,
+            "schedule_days_component": 25,
+        },
+        priority=60,
+    ),
+}

--- a/custom_components/fluidra_pool/fluidra_api/_devices.py
+++ b/custom_components/fluidra_pool/fluidra_api/_devices.py
@@ -132,6 +132,19 @@ class DevicesMixin(FluidraAPIBase):
             device_type = classify_device_type(family, device_name)
             is_bridge = "bridge" in family.lower() or bool(device.get("devices"))
 
+            if device_type == "unknown":
+                # An unclassified device is dropped by every platform before any
+                # entity logging happens, so say here what it would take to
+                # classify it (Issue #210): the (family, name) pair is exactly
+                # what classify_device_type() matches on.
+                _LOGGER.debug(
+                    "Unclassified device %s (%s): family=%r name=%r — no profile will match",
+                    mask_device_id(str(device_id)),
+                    connection_type,
+                    family,
+                    device_name,
+                )
+
             if is_bridge:
                 children = device.get("devices") or []
                 if isinstance(children, list):
@@ -144,6 +157,15 @@ class DevicesMixin(FluidraAPIBase):
 
                         child_device_type = classify_device_type(child_family, child_device_name)
                         child_is_pump = child_device_type == "pump"
+                        if child_device_type == "unknown":
+                            # Same rationale as the top-level log above (Issue #210).
+                            _LOGGER.debug(
+                                "Unclassified bridge child %s (%s): family=%r name=%r — no profile will match",
+                                mask_device_id(str(child_device_id)),
+                                child_connection_type,
+                                child_family,
+                                child_device_name,
+                            )
 
                         _add(
                             child_device_id,

--- a/custom_components/fluidra_pool/fluidra_api/_helpers.py
+++ b/custom_components/fluidra_pool/fluidra_api/_helpers.py
@@ -36,6 +36,10 @@ def classify_device_type(family: str, device_name: str) -> str:
 
     if "pump" in family_lower and any(kw in family_lower for kw in ("heat", "eco", "elyo", "thermal")):
         return "heat_pump"
+    if "cabinet" in family_lower:
+        # AstralPool Command Connect (Issue #210): one API device driving several
+        # outputs (filtration pump, pool lights), each with on/off + auto mode.
+        return "cabinet"
     if "pump" in family_lower:
         return "pump"
     if any(kw in family_lower for kw in ("heat", "thermal", "eco elyo", "astralpool")):
@@ -48,4 +52,7 @@ def classify_device_type(family: str, device_name: str) -> str:
         return "heater"
     if "light" in family_lower or "lumiplus" in device_name_lower:
         return "light"
+    if "robot" in family_lower or "cleaner" in family_lower or "cleaner" in device_name_lower:
+        # Robotic cleaners (e.g. Zodiac Freedom Lite, Issue #212).
+        return "robot"
     return "unknown"

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorEntity
 
-from ..const import DEVICE_TYPE_CHLORINATOR, FluidraPoolConfigEntry
+from ..const import (
+    DEVICE_TYPE_CHLORINATOR,
+    DEVICE_TYPE_HEAT_PUMP,
+    DEVICE_TYPE_PUMP,
+    FluidraPoolConfigEntry,
+)
 from ..device_registry import DeviceIdentifier
 from ..platform_setup import async_setup_dynamic_platform
 from .base import FluidraPoolSensorBase, FluidraPoolSensorEntity
@@ -14,7 +19,9 @@ from .chlorinator import FluidraBoostRemainingSensor, FluidraChlorinatorSensor
 from .device import (
     FluidraCompressorHoursSensor,
     FluidraCompressorModulationSensor,
+    FluidraDeviceBatterySensor,
     FluidraDeviceInfoSensor,
+    FluidraHeatPumpActivitySensor,
     FluidraLightBrightnessSensor,
     FluidraPumpActivitySensor,
     FluidraPumpFlowSensor,
@@ -23,6 +30,7 @@ from .device import (
     FluidraPumpScheduleSensor,
     FluidraPumpSpeedSensor,
     FluidraRunningHoursSensor,
+    FluidraScheduleDaysSensor,
     FluidraTemperatureSensor,
     FluidraWifiSignalSensor,
 )
@@ -42,7 +50,9 @@ __all__ = [
     "FluidraChlorinatorSensor",
     "FluidraCompressorHoursSensor",
     "FluidraCompressorModulationSensor",
+    "FluidraDeviceBatterySensor",
     "FluidraDeviceInfoSensor",
+    "FluidraHeatPumpActivitySensor",
     "FluidraLightBrightnessSensor",
     "FluidraPoolLocationSensor",
     "FluidraPoolSensorBase",
@@ -57,6 +67,7 @@ __all__ = [
     "FluidraPumpScheduleSensor",
     "FluidraPumpSpeedSensor",
     "FluidraRunningHoursSensor",
+    "FluidraScheduleDaysSensor",
     "FluidraTemperatureSensor",
     "FluidraWifiSignalSensor",
     "async_setup_entry",
@@ -98,7 +109,18 @@ async def async_setup_entry(
             entities.append(FluidraPumpFlowSensor(coordinator, coordinator.api, pool_id, device_id))
 
         if DeviceIdentifier.should_create_entity(device, "sensor_activity"):
-            entities.append(FluidraPumpActivitySensor(coordinator, coordinator.api, pool_id, device_id))
+            # Same token for both families, but the meaning differs: pumps report
+            # their run phase from their own registers, heat pumps reuse the
+            # per-model hvac_action logic of the climate entity (Issue #211).
+            device_type = getattr(
+                DeviceIdentifier.identify_device(device),
+                "device_type",
+                device.get("type", ""),
+            )
+            if device_type == DEVICE_TYPE_HEAT_PUMP:
+                entities.append(FluidraHeatPumpActivitySensor(coordinator, coordinator.api, pool_id, device_id))
+            elif device_type == DEVICE_TYPE_PUMP:
+                entities.append(FluidraPumpActivitySensor(coordinator, coordinator.api, pool_id, device_id))
 
         if DeviceIdentifier.should_create_entity(device, "sensor_temperature"):
             # Temperature sensors for heaters / heat pumps.
@@ -128,6 +150,12 @@ async def async_setup_entry(
 
         if DeviceIdentifier.should_create_entity(device, "sensor_wifi_signal"):
             entities.append(FluidraWifiSignalSensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_battery"):
+            entities.append(FluidraDeviceBatterySensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_schedule_days"):
+            entities.append(FluidraScheduleDaysSensor(coordinator, coordinator.api, pool_id, device_id))
 
         # Chlorinator sensors - create based on sensors_config from device registry
         config = DeviceIdentifier.identify_device(device)

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -859,7 +859,8 @@ class FluidraDeviceBatterySensor(FluidraPoolSensorEntity):
             return None
         try:
             return round(float(reported))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: float("inf") rounds fine in concept but raises.
             return None
 
     @property

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
+from homeassistant.components.climate.const import HVACAction
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
@@ -19,7 +20,8 @@ from homeassistant.const import (
 from homeassistant.util import dt as dt_util
 
 from ..api_resilience import FluidraError
-from ..const import LUMIPLUS_COMPONENT_BRIGHTNESS
+from ..climate_behaviors import resolve_behavior
+from ..const import HEAT_COOL_ACTION_DEADBAND, LUMIPLUS_COMPONENT_BRIGHTNESS
 from ..device_registry import DeviceIdentifier
 from ..helpers import parse_cron_time
 from .base import FluidraPoolSensorEntity
@@ -819,3 +821,152 @@ class FluidraDeviceInfoSensor(FluidraPoolSensorEntity):
             attrs["error"] = str(e)
 
         return attrs
+
+
+class FluidraDeviceBatterySensor(FluidraPoolSensorEntity):
+    """Battery charge sensor for battery-powered equipment (Issue #212).
+
+    The Zodiac Freedom Lite cleaner reports its charge in percent on a
+    profile-declared register (``battery_component``). A real HA battery
+    (device class BATTERY, %) so dashboards and low-battery automations work
+    out of the box.
+    """
+
+    _attr_translation_key = "battery_level"
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the battery sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "battery")
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the reported charge percentage."""
+        component = DeviceIdentifier.get_feature(self.device_data, "battery_component", None)
+        if component is None:
+            return None
+        comp = self.device_data.get("components", {}).get(str(component), {})
+        reported = comp.get("reportedValue")
+        if reported is None:
+            return None
+        try:
+            return round(float(reported))
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def icon(self) -> str:
+        """Return a battery icon reflecting the charge level."""
+        value = self.native_value
+        if value is None:
+            return "mdi:battery-unknown"
+        if value >= 95:
+            return "mdi:battery"
+        if value <= 10:
+            return "mdi:battery-outline"
+        return f"mdi:battery-{value // 10 * 10}"
+
+
+class FluidraScheduleDaysSensor(FluidraPoolSensorEntity):
+    """Days on which the automatic schedule runs (Issue #212).
+
+    The Freedom Lite stores its auto-schedule as day-name strings on one
+    register (e.g. ``['wednesday', 'saturday']``); the sensor shows them in
+    week order as a comma-separated list, empty when nothing is scheduled.
+    """
+
+    _attr_translation_key = "schedule_days"
+    _attr_icon = "mdi:calendar-week"
+
+    _DAY_ORDER = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the schedule-days sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "schedule_days")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the scheduled days in week order."""
+        component = DeviceIdentifier.get_feature(self.device_data, "schedule_days_component", None)
+        if component is None:
+            return None
+        comp = self.device_data.get("components", {}).get(str(component), {})
+        reported = comp.get("reportedValue")
+        if not isinstance(reported, list):
+            return None
+        days = {str(day).strip().lower() for day in reported if isinstance(day, str)}
+        ordered = [day for day in self._DAY_ORDER if day in days]
+        # Unknown day names (firmware change, translation) still surface rather
+        # than being silently dropped.
+        ordered.extend(sorted(days.difference(self._DAY_ORDER)))
+        return ", ".join(ordered)
+
+
+class FluidraHeatPumpActivitySensor(FluidraPoolSensorEntity):
+    """What a heat pump is doing right now (Issue #211).
+
+    Mirrors the pump activity sensor: one enum state (off/idle/heating/cooling)
+    sourced from the same per-family logic the climate entity uses for its
+    hvac_action, so recording/graphing "when did it actually run" needs no
+    climate-entity spelunking.
+    """
+
+    _attr_translation_key = "heat_pump_activity"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["off", "idle", "heating", "cooling"]
+    _attr_icon = "mdi:heat-pump"
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the heat pump activity sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "heat_pump_activity")
+
+    def _infer_heat_cool_action(self) -> HVACAction:
+        """Infer the direction for Smart Heat+Cool like the climate entity does.
+
+        Same water-vs-setpoint deadband comparison (see
+        FluidraHeatPumpClimate._infer_heat_cool_action): the hardware exposes no
+        direction register in that mode.
+        """
+        current = self.device_data.get("water_temperature")
+        target = self.device_data.get("target_temperature")
+        if current is None or target is None:
+            return HVACAction.IDLE
+        try:
+            current = float(current)
+            target = float(target)
+        except (TypeError, ValueError):
+            return HVACAction.IDLE
+        if target - current > HEAT_COOL_ACTION_DEADBAND:
+            return HVACAction.HEATING
+        if current - target > HEAT_COOL_ACTION_DEADBAND:
+            return HVACAction.COOLING
+        return HVACAction.IDLE
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current activity of the heat pump."""
+        device = self.device_data
+        action = resolve_behavior(device).hvac_action(device, self._infer_heat_cool_action)
+        if action is None:
+            return None
+        return str(action.value)

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -253,7 +253,21 @@
         }
       },
       "heat_pump_activity": {
-        "name": "Activity"
+        "name": "Activity",
+        "state": {
+          "off": {
+            "name": "Off"
+          },
+          "idle": {
+            "name": "Idle"
+          },
+          "heating": {
+            "name": "Heating"
+          },
+          "cooling": {
+            "name": "Cooling"
+          }
+        }
       },
       "pool_location": {
         "name": "Pool Location"

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -198,6 +198,9 @@
       "air_temperature": {
         "name": "Air Temperature"
       },
+      "battery_level": {
+        "name": "Battery"
+      },
       "boost_remaining": {
         "name": "Boost Remaining"
       },
@@ -249,6 +252,9 @@
           "signal_very_low": "Signal Very Low"
         }
       },
+      "heat_pump_activity": {
+        "name": "Activity"
+      },
       "pool_location": {
         "name": "Pool Location"
       },
@@ -290,6 +296,9 @@
       "schedule_count": {
         "name": "Active Schedules"
       },
+      "schedule_days": {
+        "name": "Schedule Days"
+      },
       "speed_mode": {
         "name": "Speed",
         "state": {
@@ -326,8 +335,23 @@
       "auto_mode": {
         "name": "Auto Mode"
       },
+      "aux_schedule_enable": {
+        "name": "Aux {aux_number} Schedule {schedule_id}"
+      },
       "boost_mode": {
         "name": "Boost Mode"
+      },
+      "cabinet_lights": {
+        "name": "Pool Lights"
+      },
+      "cabinet_lights_auto_mode": {
+        "name": "Lights Auto Mode"
+      },
+      "cabinet_pump": {
+        "name": "Filtration Pump"
+      },
+      "cabinet_pump_auto_mode": {
+        "name": "Filtration Auto Mode"
       },
       "chlorinator": {
         "name": "Chlorinator"
@@ -349,9 +373,6 @@
       },
       "schedule_enable": {
         "name": "Schedule {schedule_id}"
-      },
-      "aux_schedule_enable": {
-        "name": "Aux {aux_number} Schedule {schedule_id}"
       }
     },
     "time": {

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -255,18 +255,10 @@
       "heat_pump_activity": {
         "name": "Activity",
         "state": {
-          "off": {
-            "name": "Off"
-          },
-          "idle": {
-            "name": "Idle"
-          },
-          "heating": {
-            "name": "Heating"
-          },
-          "cooling": {
-            "name": "Cooling"
-          }
+          "off": "Off",
+          "idle": "Idle",
+          "heating": "Heating",
+          "cooling": "Cooling"
         }
       },
       "pool_location": {

--- a/custom_components/fluidra_pool/switch/__init__.py
+++ b/custom_components/fluidra_pool/switch/__init__.py
@@ -128,6 +128,27 @@ async def async_setup_entry(
                     )
                 )
 
+        # Profile-declared boolean switches (same toggle class): a list of
+        # (component feature, translation key, icon) under the "toggle_switches"
+        # feature. Used by multi-output devices that don't fit the one main
+        # switch shape — e.g. the Command Connect cabinet drives its filtration
+        # pump and its lights as four independent registers (Issue #210).
+        profile_toggles = DeviceIdentifier.get_feature(device, "toggle_switches", [])
+        if isinstance(profile_toggles, list):
+            for feature, translation_key, icon in profile_toggles:
+                if DeviceIdentifier.has_feature(device, feature):
+                    entities.append(
+                        FluidraChlorinatorToggleSwitch(
+                            coordinator,
+                            coordinator.api,
+                            pool_id,
+                            device_id,
+                            feature,
+                            translation_key,
+                            icon,
+                        )
+                    )
+
         return entities
 
     await async_setup_dynamic_platform(config_entry, async_add_entities, _build)

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -253,7 +253,21 @@
         }
       },
       "heat_pump_activity": {
-        "name": "Activity"
+        "name": "Activity",
+        "state": {
+          "cooling": {
+            "name": "Cooling"
+          },
+          "heating": {
+            "name": "Heating"
+          },
+          "idle": {
+            "name": "Idle"
+          },
+          "off": {
+            "name": "Off"
+          }
+        }
       },
       "pool_location": {
         "name": "Pool Location"

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -198,6 +198,9 @@
       "air_temperature": {
         "name": "Air Temperature"
       },
+      "battery_level": {
+        "name": "Battery"
+      },
       "boost_remaining": {
         "name": "Boost Remaining"
       },
@@ -249,6 +252,9 @@
           "signal_very_low": "Signal Very Low"
         }
       },
+      "heat_pump_activity": {
+        "name": "Activity"
+      },
       "pool_location": {
         "name": "Pool Location"
       },
@@ -289,6 +295,9 @@
       },
       "schedule_count": {
         "name": "Active Schedules"
+      },
+      "schedule_days": {
+        "name": "Schedule Days"
       },
       "speed_mode": {
         "name": "Speed",
@@ -331,6 +340,18 @@
       },
       "boost_mode": {
         "name": "Boost Mode"
+      },
+      "cabinet_lights": {
+        "name": "Pool Lights"
+      },
+      "cabinet_lights_auto_mode": {
+        "name": "Lights Auto Mode"
+      },
+      "cabinet_pump": {
+        "name": "Filtration Pump"
+      },
+      "cabinet_pump_auto_mode": {
+        "name": "Filtration Auto Mode"
       },
       "chlorinator": {
         "name": "Chlorinator"

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -255,18 +255,10 @@
       "heat_pump_activity": {
         "name": "Activity",
         "state": {
-          "cooling": {
-            "name": "Cooling"
-          },
-          "heating": {
-            "name": "Heating"
-          },
-          "idle": {
-            "name": "Idle"
-          },
-          "off": {
-            "name": "Off"
-          }
+          "cooling": "Cooling",
+          "heating": "Heating",
+          "idle": "Idle",
+          "off": "Off"
         }
       },
       "pool_location": {

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -255,18 +255,10 @@
       "heat_pump_activity": {
         "name": "Actividad",
         "state": {
-          "cooling": {
-            "name": "Enfriando"
-          },
-          "heating": {
-            "name": "Calentando"
-          },
-          "idle": {
-            "name": "Inactiva"
-          },
-          "off": {
-            "name": "Apagada"
-          }
+          "cooling": "Enfriando",
+          "heating": "Calentando",
+          "idle": "Inactiva",
+          "off": "Apagada"
         }
       },
       "pool_location": {

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -198,6 +198,9 @@
       "air_temperature": {
         "name": "Temperatura del Aire"
       },
+      "battery_level": {
+        "name": "Batería"
+      },
       "boost_remaining": {
         "name": "Turbo restante"
       },
@@ -249,6 +252,9 @@
           "signal_very_low": "Señal Muy Débil"
         }
       },
+      "heat_pump_activity": {
+        "name": "Actividad"
+      },
       "pool_location": {
         "name": "Ubicación de la Piscina"
       },
@@ -289,6 +295,9 @@
       },
       "schedule_count": {
         "name": "Programaciones Activas"
+      },
+      "schedule_days": {
+        "name": "Días de programación"
       },
       "speed_mode": {
         "name": "Velocidad",
@@ -331,6 +340,18 @@
       },
       "boost_mode": {
         "name": "Modo Turbo"
+      },
+      "cabinet_lights": {
+        "name": "Iluminación de la piscina"
+      },
+      "cabinet_lights_auto_mode": {
+        "name": "Modo automático de iluminación"
+      },
+      "cabinet_pump": {
+        "name": "Bomba de filtración"
+      },
+      "cabinet_pump_auto_mode": {
+        "name": "Modo automático de filtración"
       },
       "chlorinator": {
         "name": "Clorador"

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -253,7 +253,21 @@
         }
       },
       "heat_pump_activity": {
-        "name": "Actividad"
+        "name": "Actividad",
+        "state": {
+          "cooling": {
+            "name": "Enfriando"
+          },
+          "heating": {
+            "name": "Calentando"
+          },
+          "idle": {
+            "name": "Inactiva"
+          },
+          "off": {
+            "name": "Apagada"
+          }
+        }
       },
       "pool_location": {
         "name": "Ubicación de la Piscina"

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -255,18 +255,10 @@
       "heat_pump_activity": {
         "name": "Activité",
         "state": {
-          "cooling": {
-            "name": "Refroidissement"
-          },
-          "heating": {
-            "name": "Chauffage"
-          },
-          "idle": {
-            "name": "Au repos"
-          },
-          "off": {
-            "name": "Arrêté"
-          }
+          "cooling": "Refroidissement",
+          "heating": "Chauffage",
+          "idle": "Au repos",
+          "off": "Arrêté"
         }
       },
       "pool_location": {

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -253,7 +253,21 @@
         }
       },
       "heat_pump_activity": {
-        "name": "Activité"
+        "name": "Activité",
+        "state": {
+          "cooling": {
+            "name": "Refroidissement"
+          },
+          "heating": {
+            "name": "Chauffage"
+          },
+          "idle": {
+            "name": "Au repos"
+          },
+          "off": {
+            "name": "Arrêté"
+          }
+        }
       },
       "pool_location": {
         "name": "Localisation Piscine"

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -198,6 +198,9 @@
       "air_temperature": {
         "name": "Température de l'Air"
       },
+      "battery_level": {
+        "name": "Batterie"
+      },
       "boost_remaining": {
         "name": "Boost restant"
       },
@@ -249,6 +252,9 @@
           "signal_very_low": "Signal Très Faible"
         }
       },
+      "heat_pump_activity": {
+        "name": "Activité"
+      },
       "pool_location": {
         "name": "Localisation Piscine"
       },
@@ -289,6 +295,9 @@
       },
       "schedule_count": {
         "name": "Plannings Actifs"
+      },
+      "schedule_days": {
+        "name": "Jours de planification"
       },
       "speed_mode": {
         "name": "Vitesse",
@@ -331,6 +340,18 @@
       },
       "boost_mode": {
         "name": "Mode Boost"
+      },
+      "cabinet_lights": {
+        "name": "Éclairage du bassin"
+      },
+      "cabinet_lights_auto_mode": {
+        "name": "Mode auto éclairage"
+      },
+      "cabinet_pump": {
+        "name": "Pompe de filtration"
+      },
+      "cabinet_pump_auto_mode": {
+        "name": "Mode auto filtration"
       },
       "chlorinator": {
         "name": "Chlorinateur"

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -253,7 +253,21 @@
         }
       },
       "heat_pump_activity": {
-        "name": "Atividade"
+        "name": "Atividade",
+        "state": {
+          "cooling": {
+            "name": "Arrefecendo"
+          },
+          "heating": {
+            "name": "Aquecendo"
+          },
+          "idle": {
+            "name": "Em repouso"
+          },
+          "off": {
+            "name": "Desligada"
+          }
+        }
       },
       "pool_location": {
         "name": "Localização da Piscina"

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -198,6 +198,9 @@
       "air_temperature": {
         "name": "Temperatura do Ar"
       },
+      "battery_level": {
+        "name": "Bateria"
+      },
       "boost_remaining": {
         "name": "Turbo restante"
       },
@@ -249,6 +252,9 @@
           "signal_very_low": "Sinal Muito Fraco"
         }
       },
+      "heat_pump_activity": {
+        "name": "Atividade"
+      },
       "pool_location": {
         "name": "Localização da Piscina"
       },
@@ -289,6 +295,9 @@
       },
       "schedule_count": {
         "name": "Programações Ativas"
+      },
+      "schedule_days": {
+        "name": "Dias de agendamento"
       },
       "speed_mode": {
         "name": "Velocidade",
@@ -331,6 +340,18 @@
       },
       "boost_mode": {
         "name": "Modo Turbo"
+      },
+      "cabinet_lights": {
+        "name": "Iluminação da piscina"
+      },
+      "cabinet_lights_auto_mode": {
+        "name": "Modo automático da iluminação"
+      },
+      "cabinet_pump": {
+        "name": "Bomba de filtração"
+      },
+      "cabinet_pump_auto_mode": {
+        "name": "Modo automático da filtração"
       },
       "chlorinator": {
         "name": "Clorador"

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -255,18 +255,10 @@
       "heat_pump_activity": {
         "name": "Atividade",
         "state": {
-          "cooling": {
-            "name": "Arrefecendo"
-          },
-          "heating": {
-            "name": "Aquecendo"
-          },
-          "idle": {
-            "name": "Em repouso"
-          },
-          "off": {
-            "name": "Desligada"
-          }
+          "cooling": "Arrefecendo",
+          "heating": "Aquecendo",
+          "idle": "Em repouso",
+          "off": "Desligada"
         }
       },
       "pool_location": {

--- a/tests/test_new_device_support.py
+++ b/tests/test_new_device_support.py
@@ -1,0 +1,357 @@
+"""New device support: Zodiac Freedom Lite robot, Command Connect cabinet and
+heat-pump activity sensor (Issues #210, #211, #212)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.fluidra_pool.device_registry import DeviceIdentifier
+from custom_components.fluidra_pool.device_registry.configs import DEVICE_CONFIGS
+from custom_components.fluidra_pool.fluidra_api._helpers import classify_device_type
+from custom_components.fluidra_pool.sensor import (
+    FluidraDeviceBatterySensor,
+    FluidraHeatPumpActivitySensor,
+    FluidraScheduleDaysSensor,
+)
+from custom_components.fluidra_pool.switch import FluidraChlorinatorToggleSwitch
+from tests.test_sensor_full import _run_setup  # noqa: F401  (reused setup helper)
+
+POOL_ID = "pool-1"
+
+
+def _robot_device() -> dict[str, Any]:
+    """Freedom Lite as the coordinator reports it (Issue #212 dump)."""
+    return {
+        "device_id": "NLX61690448",
+        "name": "Zodiac Freedom Lite",
+        "family": "Robots",
+        "model": "Zodiac Freedom Lite",
+        "type": "robot",
+        "components": {
+            "25": {"reportedValue": ["saturday", "wednesday"]},
+            "26": {"reportedValue": 79},
+        },
+    }
+
+
+def _cabinet_device() -> dict[str, Any]:
+    """Command Connect cabinet as mapped by @efgonzalez (Issue #210)."""
+    return {
+        "device_id": "QR24xxxx.ndsr_1",
+        "name": "Command Connect",
+        "family": "Cabinets",
+        "model": "Command Connect",
+        "type": "cabinet",
+        "components": {
+            "13": {"reportedValue": False},
+            "15": {"reportedValue": True},
+            "24": {"reportedValue": True},
+            "26": {"reportedValue": False},
+        },
+    }
+
+
+def _coordinator(device: dict[str, Any]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+# --------------------------------------------------------------------------- #
+# Classification                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("family", "name", "expected"),
+    [
+        ("Cabinets", "Command Connect", "cabinet"),
+        ("Bridges", "iQBridgeZB", "unknown"),
+        ("Robots", "Freedom Lite", "robot"),
+        ("Cleaners", "Whatever", "robot"),
+        ("Something", "My pool cleaner", "robot"),
+        ("Pumps", "VS Pump", "pump"),
+    ],
+)
+def test_classify_new_families(family: str, name: str, expected: str) -> None:
+    assert classify_device_type(family, name) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Freedom Lite robot profile (Issue #212)                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestFreedomLiteProfile:
+    def test_identifies_by_serial_and_model(self) -> None:
+        device = _robot_device()
+        config = DeviceIdentifier.identify_device(device)
+        assert config is DEVICE_CONFIGS["freedom_lite_robot"]
+        assert config.device_type == "robot"
+        assert config.verified is True
+
+    def test_declared_registers_are_scanned(self) -> None:
+        features = DEVICE_CONFIGS["freedom_lite_robot"].features
+        for component in (25, 26):
+            assert component in features["specific_components"]
+        assert features["battery_component"] == 26
+        assert features["schedule_days_component"] == 25
+
+    def test_entities_declared(self) -> None:
+        entities = DEVICE_CONFIGS["freedom_lite_robot"].entities
+        assert "sensor_battery" in entities
+        assert "sensor_schedule_days" in entities
+
+
+class TestRobotSensors:
+    def test_battery_reads_percent_register(self) -> None:
+        device = _robot_device()
+        sensor = FluidraDeviceBatterySensor(_coordinator(device), None, POOL_ID, device["device_id"])
+        assert sensor.native_value == 79
+        assert sensor.native_unit_of_measurement == "%"
+
+    def test_battery_handles_missing_and_garbage(self) -> None:
+        device = _robot_device()
+        device["components"] = {}
+        sensor = FluidraDeviceBatterySensor(_coordinator(device), None, POOL_ID, device["device_id"])
+        assert sensor.native_value is None
+        device["components"] = {"26": {"reportedValue": "not-a-number"}}
+        assert sensor.native_value is None
+
+    def test_schedule_days_sorted_in_week_order(self) -> None:
+        device = _robot_device()
+        sensor = FluidraScheduleDaysSensor(_coordinator(device), None, POOL_ID, device["device_id"])
+        assert sensor.native_value == "wednesday, saturday"
+
+    def test_schedule_days_empty_and_unknown(self) -> None:
+        device = _robot_device()
+        sensor = FluidraScheduleDaysSensor(_coordinator(device), None, POOL_ID, device["device_id"])
+        device["components"]["25"]["reportedValue"] = []
+        assert sensor.native_value == ""
+        device["components"]["25"]["reportedValue"] = ["monday", "journee"]
+        value = sensor.native_value
+        assert isinstance(value, str)
+        assert value.startswith("monday")
+        assert "journee" in value
+        device["components"]["25"]["reportedValue"] = "bogus"
+        assert sensor.native_value is None
+
+
+# --------------------------------------------------------------------------- #
+# Command Connect cabinet (Issue #210)                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestCabinetProfile:
+    def test_identifies_by_family(self) -> None:
+        device = _cabinet_device()
+        config = DeviceIdentifier.identify_device(device)
+        assert config is DEVICE_CONFIGS["command_connect_cabinet"]
+        assert config.device_type == "cabinet"
+        assert config.verified is True
+
+    def test_boolean_writes_feature_declared(self) -> None:
+        features = DEVICE_CONFIGS["command_connect_cabinet"].features
+        assert features["boolean_writes"] is True
+        for component in (13, 15, 24, 26):
+            assert component in features["specific_components"]
+
+    def test_four_toggles_declared(self) -> None:
+        toggles = DEVICE_CONFIGS["command_connect_cabinet"].features["toggle_switches"]
+        keys = [feature for feature, _key, _icon in toggles]
+        assert sorted(keys) == [
+            "cabinet_lights",
+            "cabinet_lights_auto_mode",
+            "cabinet_pump",
+            "cabinet_pump_auto_mode",
+        ]
+
+    def test_toggle_writes_booleans_not_integers(self) -> None:
+        """The cabinet silently ignores integer writes — the payload must carry
+        a JSON true/false, never 1/0 (Issue #210 measured behaviour)."""
+        device = _cabinet_device()
+        api = SimpleNamespace(control_device_component=AsyncMock(return_value=True))
+        switch = FluidraChlorinatorToggleSwitch(
+            _coordinator(device), api, POOL_ID, device["device_id"], "cabinet_pump", "cabinet_pump", "mdi:pump"
+        )
+        switch.hass = MagicMock()
+        switch.async_write_ha_state = MagicMock()
+
+        assert switch._component() == 13
+        assert switch.is_on is False
+
+        with patch("custom_components.fluidra_pool.switch.chlorinator.asyncio.sleep", new=AsyncMock()):
+            asyncio.run(switch.async_turn_on())
+        args = api.control_device_component.call_args.args
+        assert args[1] == 13
+        assert args[2] is True  # boolean, not 1
+
+
+# --------------------------------------------------------------------------- #
+# Heat pump activity sensor (Issue #211)                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _heat_pump_device(components: dict[int, Any], **extra: Any) -> dict[str, Any]:
+    device: dict[str, Any] = {
+        "device_id": "LF000000",
+        "name": "Z250iQ",
+        "family": "heat pump",
+        "type": "heat_pump",
+        "components": {str(k): {"reportedValue": v} for k, v in components.items()},
+    }
+    device.update(extra)
+    device["_identify_cache"] = {
+        "key": (device["device_id"], device["family"], "", "heat_pump", ""),
+        "config": SimpleNamespace(
+            device_type="heat_pump",
+            features={"z260iq_mode": True},
+            entities=["climate", "switch", "sensor_info", "sensor_activity"],
+            components_range=5,
+            required_components=[0, 1, 2, 3],
+        ),
+    }
+    return device
+
+
+class TestHeatPumpActivitySensor:
+    def _sensor(self, device: dict[str, Any]) -> FluidraHeatPumpActivitySensor:
+        return FluidraHeatPumpActivitySensor(_coordinator(device), None, POOL_ID, device["device_id"])
+
+    def test_options_cover_the_enum(self) -> None:
+        # Read off an instance: HA's cached-properties machinery wraps the
+        # class-level `_attr_options` assignment.
+        sensor = self._sensor(_heat_pump_device({}))
+        assert sensor._attr_options == ["off", "idle", "heating", "cooling"]
+
+    def test_z260iq_off_when_unit_off(self) -> None:
+        # heat_pump_reported=False → OFF branch of the Z260iq behavior.
+        sensor = self._sensor(
+            _heat_pump_device({13: 0}, heat_pump_reported=False, water_temperature=20.0, target_temperature=28.0)
+        )
+        assert sensor.native_value == "off"
+
+    def test_z260iq_idle_inside_deadband(self) -> None:
+        # ON in Smart Heat+Cool (mode 2) with the setpoint satisfied: the same
+        # ±2 °C deadband inference as the climate entity reports IDLE.
+        sensor = self._sensor(
+            _heat_pump_device(
+                {13: 1, 14: 2},
+                heat_pump_reported=True,
+                z260iq_mode_value=2,
+                water_temperature=27.5,
+                target_temperature=28.0,
+            )
+        )
+        assert sensor.native_value == "idle"
+
+    def test_smart_heat_cool_infers_heating_and_cooling(self) -> None:
+        heating = self._sensor(
+            _heat_pump_device(
+                {13: 1, 14: 2},
+                heat_pump_reported=True,
+                z260iq_mode_value=2,
+                water_temperature=24.0,
+                target_temperature=28.0,
+            )
+        )
+        assert heating.native_value == "heating"
+        cooling = self._sensor(
+            _heat_pump_device(
+                {13: 1, 14: 2},
+                heat_pump_reported=True,
+                z260iq_mode_value=2,
+                # Strictly outside the ±2 °C deadband (30-28 would sit inside it).
+                water_temperature=30.5,
+                target_temperature=28.0,
+            )
+        )
+        assert cooling.native_value == "cooling"
+
+    def test_compressor_state_wins_over_mode(self) -> None:
+        # c75 decoded by the coordinator beats c14: a unit set to Smart Heating
+        # whose compressor idles must report idle, not heating (Issue #139).
+        sensor = self._sensor(
+            _heat_pump_device(
+                {13: 1, 14: 0, 75: 0},
+                heat_pump_reported=True,
+                z260iq_mode_value=0,
+                compressor_state=0,
+            )
+        )
+        assert sensor.native_value == "idle"
+
+
+# --------------------------------------------------------------------------- #
+# Platform wiring                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def _setup_coordinator(devices: list[dict[str, Any]]) -> Any:
+    """Coordinator whose .data + .api.cached_pools are both populated for setup."""
+    coordinator = MagicMock()
+    pool = {"id": POOL_ID, "name": "Pool", "devices": devices}
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(
+        cached_pools=[pool],
+        get_pools=AsyncMock(return_value=[pool]),
+    )
+    return coordinator
+
+
+async def _run_platform_setup(platform: Any, devices: list[dict[str, Any]]) -> list[Any]:
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=_setup_coordinator(devices)),
+        async_on_unload=lambda _unsub: None,
+    )
+    added: list[Any] = []
+
+    def _add(entities, *a, **k):
+        added.extend(list(entities))
+
+    async_add = MagicMock(side_effect=_add)
+    await platform.async_setup_entry(MagicMock(), entry, async_add)
+    return added
+
+
+async def test_cabinet_setup_creates_four_switches() -> None:
+    from custom_components.fluidra_pool.switch import async_setup_entry as switch_setup
+
+    device = _cabinet_device()
+    entities = await _run_platform_setup(SimpleNamespace(async_setup_entry=switch_setup), [device])
+    keys = sorted(e._attr_translation_key for e in entities)
+    assert keys == [
+        "cabinet_lights",
+        "cabinet_lights_auto_mode",
+        "cabinet_pump",
+        "cabinet_pump_auto_mode",
+    ]
+
+
+async def test_robot_setup_creates_battery_and_schedule_days() -> None:
+    from custom_components.fluidra_pool.sensor import async_setup_entry as sensor_setup
+
+    device = _robot_device()
+    entities = await _run_platform_setup(SimpleNamespace(async_setup_entry=sensor_setup), [device])
+    keys = sorted(e._attr_translation_key for e in entities)
+    # The pool-level sensors (weather/status/location/water quality) come with
+    # every setup; the robot must contribute exactly its two.
+    assert [k for k in keys if k in ("battery_level", "schedule_days")] == ["battery_level", "schedule_days"]
+
+
+async def test_heat_pump_setup_creates_activity_sensor() -> None:
+    from custom_components.fluidra_pool.sensor import async_setup_entry as sensor_setup
+
+    device = _heat_pump_device({}, heat_pump_reported=False)
+    entities = await _run_platform_setup(SimpleNamespace(async_setup_entry=sensor_setup), [device])
+    activities = [e for e in entities if isinstance(e, FluidraHeatPumpActivitySensor)]
+    assert len(activities) == 1
+    assert activities[0].native_value == "off"

--- a/tests/test_new_device_support.py
+++ b/tests/test_new_device_support.py
@@ -124,6 +124,9 @@ class TestRobotSensors:
         assert sensor.native_value is None
         device["components"] = {"26": {"reportedValue": "not-a-number"}}
         assert sensor.native_value is None
+        # float("inf") survives float() but raises OverflowError on round().
+        device["components"] = {"26": {"reportedValue": float("inf")}}
+        assert sensor.native_value is None
 
     def test_schedule_days_sorted_in_week_order(self) -> None:
         device = _robot_device()


### PR DESCRIPTION
## Description

Three community-driven additions, each answering an open issue with hardware-verified data:

- **Zodiac Freedom Lite robotic cleaner** (#212, @MDBENNANI): new `robot` device type matched on `NLX*` serials + model name. Exposes a real HA battery sensor (%) from register c26 and an automatic-schedule days sensor from c25 (day-name strings, shown in week order). Only the two confirmed registers are mapped; the rest of the dump stays unmapped until correlated with app toggles.

- **AstralPool Command Connect cabinet** (#210, @efgonzalez): the `Cabinets` family now classifies instead of falling to `unknown`. One API device → four switches: filtration pump on/off (c13) + auto mode (c15), pool lights on/off (c24) + auto mode (c26), all mapped and verified on real hardware by the reporter. The cabinet silently ignores integer writes, so all controls use boolean write paths (`true`/`false`), documented in the profile. Profiles can now declare additional boolean toggles via a `toggle_switches` feature.

- **Heat-pump activity sensor** (#211): a new enum sensor (`off`/`idle`/`heating`/`cooling`) driven by the same per-family logic as the climate entity's `hvac_action`, declared on all six heat-pump profiles plus the generic one. Pump activity sensors are unchanged.

Also adds the debug log requested in #210's notes: unclassified devices now log their `(family, name)` pair at debug level, so the next unknown device points straight at the missing classification branch.

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [ ] CI checks pass
- [x] Tests added (25 new tests in `tests/test_new_device_support.py`; full suite 1883 passed)

## Related Issues

Refs #210, refs #211, refs #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zodiac Freedom Lite robotic cleaners, including battery and schedule-day sensors.
  * Added support for Command Connect cabinets with pump, lighting, and automatic-mode controls.
  * Added heat-pump activity sensors across supported heat-pump models.
  * Added English, Spanish, French, and Portuguese translations for the new entities.
* **Bug Fixes**
  * Improved device discovery and classification for previously unrecognized equipment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->