### PR TITLE
fix(devices): a bridged heat pump is no longer read as a chlorinator (#216)

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -2,6 +2,12 @@
 
 Each model lives in its own DeviceConfig because of subtle component-mapping
 differences across the CC/LC/DM/NS lineups.
+
+Only the ``chlorinator`` catch-all declares ``family_patterns``. Every unit of the
+lineup reports ``family: "Chlorinators"``, so a family match carries no model
+information: on a serial-specific profile it would outrank the catch-all on a unit that
+profile was never written for, purely on its higher priority. The serial in
+``identifier_patterns`` is the identity (Issue #216).
 """
 
 from __future__ import annotations
@@ -64,7 +70,7 @@ def _standard_tecnolc2(
     return DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=identifier_patterns,
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -76,7 +82,14 @@ def _standard_tecnolc2(
 CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "chlorinator": DeviceConfig(
         device_type="chlorinator",
-        identifier_patterns=["*.nn_*"],  # Bridged devices.
+        # No identifier_patterns: ".nn_" is the *bridge protocol* marker
+        # (status.bridgedInfo.protocol == "nn"), not a chlorinator serial. Every
+        # device behind an iQBridge/Connect bridge carries it, whatever its family,
+        # so "*.nn_*" scored the 50-point identifier signal on a Zodiac PX50 heat
+        # pump and beat every heat-pump profile — the unit came out as a chlorinator
+        # with no climate entity (Issue #216, @vicsol00-collab). The family match
+        # below is what actually identifies a chlorinator; the serial-specific
+        # profiles still win on their own ids, at their own priority.
         family_patterns=["chlorinator"],
         components_range=25,  # Scan only basic components; specific ones added below.
         required_components=[0, 1, 2, 3],
@@ -114,7 +127,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # fell back to the generic profile (read c172 water temperature as pH → 3.07, and
         # missed c165/c170/c174 so salinity/temperature showed 0).
         identifier_patterns=["CC25052635*", "CC25046312*", "CC26028741*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -158,7 +171,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # so it never appeared in any diagnostics capture from this unit; it is now
         # polled, so a mismatch against the app can be settled by a single export.
         identifier_patterns=["CC25051112*", "CC26009948*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -189,7 +202,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # standard tecnoLC2 layout as the GenSalt OE iQ pH 12 Evo (cc25052635); c20 (ORP
         # setpoint) read null on this unit so it is left unmapped like that sibling.
         identifier_patterns=["CC26009743*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -220,7 +233,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # widened this round so the next capture reveals the real components if c10/c174
         # turn out empty. No pH/ORP probes on this salt-only cell.
         identifier_patterns=["CC25016001.nn_*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["number", "sensor_info"],
@@ -384,7 +397,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # Confirmed by @eabin: salinity on component 174 (e.g. 634 → 6.34 g/L).
         # No pH/ORP probes on the base model — components 13-20 are null.
         identifier_patterns=["CC25064524.nn_*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -412,7 +425,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # layout minus everything ORP: pH c165, temperature c172, salinity c174,
         # setpoint c16, chlorination c10.
         identifier_patterns=["CC26010842*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -454,7 +467,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         #   LC26033146              — IBASEL Evoflex 30 7g/H (@FoxP)
         #   CC25021136              — Zodiac Ei2 iQ Evo (@crdo78) — confirmed c165/170/172/174
         identifier_patterns=["CC25102423.nn_*", "CC25066724*", "CC25106623*", "LC26033146*", "CC25021136*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -494,7 +507,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # CC25060723 — same Clear Connect layout, self-diagnosed by @ClaudeK83 (#152):
         # the existing mapping matched his unit exactly, only the serial was missing.
         identifier_patterns=["CC25019224.nn_*", "CC25009932*", "CC25060723.nn_*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -524,7 +537,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # KLINWASS MARK SALT 12 GR/H (tecnoLC2) — Issue #55 (confirmed by @FernandoArnanz).
         # No ORP / free-chlorine probes on this model.
         identifier_patterns=["LC25012727.nn_*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -576,7 +589,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "lc24056317_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["LC24056317*"],  # Gre chlorinator (I.D. Electroquimica/Fluidra) — Issue #28.
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -667,7 +680,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # cc24042711_chlorinator) -- one fewer outlier in the catalog rather than
         # a second convention for the same feature.
         identifier_patterns=["CC24018506*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -726,7 +739,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "cc25005502_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["CC25005502*"],  # alextoro82 — Issue #15.
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -750,7 +763,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # Energy Connect bridged tecnoLC2 devices — Issue #36.
         # Confirmed on: CC24054221 (cortalys), CC24041107 (StenGarny).
         identifier_patterns=["CC24054221*", "CC24041107*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -776,7 +789,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "cc24058902_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["CC24058902*"],  # Issue #35 — Enkil13.
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -800,7 +813,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "cc24068402_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["CC24068402*"],  # Energy Connect tecnoLC2 — Issue #33.
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -832,7 +845,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # by @Srekcah007 after testing: uses the standard tecnoLC2 layout, not the
         # 164/185 variant first assumed. Matches both the bridge and the bridged child.
         identifier_patterns=["CC24000304*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -852,7 +865,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "cc24042711_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["CC24042711*"],  # tecnoLC2 (AstralPool Clear Connect non-scalable) — Issue #25.
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -886,7 +899,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # c172/c177 the catch-all wrongly reused — so the number entities show 7.20 /
         # 700, not the live readings.
         identifier_patterns=["DM24008702*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "select", "number", "sensor_info"],
@@ -919,7 +932,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # setpoint (c4) / 0 % actual (c164), pH setpoint 7.4 (c8), pH measured 7.04
         # (c172 ÷100), water temperature 28.7 °C (c183 ÷10).
         identifier_patterns=["DM25028908*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "select", "number", "sensor_info"],
@@ -940,7 +953,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "dm24049704_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["DM24049704*"],  # Domotic S2 chlorinator (SheepPool).
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "select", "number", "sensor_info", "time"],
@@ -978,7 +991,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
         # c174 = salinity (g/L × 100) — e.g. 536 = 5.36 g/L.
         # No ORP probe on this model (c20/c170/c177 are None/0).
         identifier_patterns=["LC25050627*", "LC24076417*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "number", "sensor_info"],
@@ -1000,7 +1013,7 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "ns25_exo_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["NS*"],
-        family_patterns=["chlorinator"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
         entities=["switch", "select", "number", "sensor_info", "time"],

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -1,4 +1,14 @@
-"""Heat-pump device configurations (LG Eco Elyo, Z250, Z260, Z550)."""
+"""Heat-pump device configurations (LG Eco Elyo, Z250, Z260, Z550).
+
+Model-specific profiles here declare no ``family_patterns``. The Fluidra cloud reports
+``family: "Heat Pumps"`` for every unit of the lineup, so a family match carries no model
+information: it would let any one of these profiles outrank ``generic_heat_pump`` on a
+unit it was never written for and pin it to a foreign register map. Issue #216 is the
+case in point — a Zodiac PX50 (``thingType`` ``proelyo``) shares no register with the
+Z250/Z260/Z550/Z650 maps. A genuine unit of a listed model always matches on its serial
+prefix, its product name or its component-7 signature; that is the identity. The HPGIC
+profile below spells out the same rule in its own comment.
+"""
 
 from __future__ import annotations
 
@@ -29,7 +39,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         device_type="heat_pump",
         identifier_patterns=["LF*"],
         name_patterns=["z250", "z25"],
-        family_patterns=["heat pump"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=5,
         required_components=[0, 1, 2, 3],
         entities=[
@@ -74,7 +84,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
     "z260iq_heat_pump": DeviceConfig(
         device_type="heat_pump",
         identifier_patterns=["LF*"],
-        family_patterns=["heat pump"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=5,
         required_components=[0, 1, 2, 3],
         entities=[
@@ -127,7 +137,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         device_type="heat_pump",
         identifier_patterns=["LD*"],
         name_patterns=["z550", "z55"],
-        family_patterns=["heat pump"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=5,
         required_components=[0, 1, 2, 3],
         entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours", "sensor_activity"],
@@ -200,7 +210,7 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         identifier_patterns=["ZB*"],
         name_patterns=["z650", "z65"],
         model_patterns=["z650", "z65"],
-        family_patterns=["heat pump"],
+        # No family_patterns — see the module note (Issue #216).
         components_range=5,
         required_components=[0, 1, 2, 3],
         entities=[

--- a/tests/test_issue_216_bridged_heat_pump.py
+++ b/tests/test_issue_216_bridged_heat_pump.py
@@ -1,0 +1,166 @@
+"""Issue #216 — a heat pump bridged by an iQBridge RS must not be read as a chlorinator.
+
+The reporter (@vicsol00-collab) runs an AstralPool Elite Connect LS chlorinator and a
+Zodiac PX50 heat pump on the same Fluidra account. Both are published by the cloud under
+the same pool, but only the chlorinator produced entities.
+
+The diagnostics dump attached to the issue shows why. Both devices are bridged, so both
+carry the ``.nn_`` protocol marker in their cloud id — the PX50's status tree reads
+``{"bridgedInfo": {"protocol": "nn"}, "thingType": "proelyo"}`` and its id is
+``QS23361258.nn_9``, while its family is ``Heat Pumps`` and its type ``heat_pump``. The
+chlorinator catch-all profile listed ``*.nn_*`` among its identifier patterns, so it
+scored the 50-point identifier signal on the heat pump and beat every heat-pump profile.
+The dump proves it: the PX50's ``_identify_cache`` holds
+``DeviceConfig(device_type='chlorinator', identifier_patterns=['*.nn_*'], ...)`` and its
+scanned components are the chlorinator set (0, 1, 2, 3, 4, 8, 11, 20) — no climate.
+
+``.nn_`` is a *bridge protocol* marker, not a device family. These tests pin that.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.fluidra_pool.climate import (
+    FluidraHeatPumpClimate,
+)
+from custom_components.fluidra_pool.climate import (
+    async_setup_entry as climate_setup,
+)
+from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS, DeviceIdentifier
+
+POOL_ID = "pool_4519"
+
+
+def _px50() -> dict:
+    """The Zodiac PX50 exactly as the issue-216 diagnostics report it."""
+    return {
+        "device_id": "QS23361258.nn_9",
+        "name": "PX50",
+        "type": "heat_pump",
+        "family": "Heat Pumps",
+        "model": "PX50",
+        "manufacturer": "Fluidra",
+        "thing_type": "proelyo",
+        "online": True,
+        "components": {},
+        "status": {
+            "info": {"name": "PX50", "family": "Heat Pumps", "core": True},
+            "bridgedInfo": {"protocol": "nn"},
+            "thingType": "proelyo",
+        },
+    }
+
+
+def _elite_connect_ls() -> dict:
+    """The AstralPool Elite Connect LS chlorinator from the same dump."""
+    return {
+        "device_id": "DM24006105.nn_1",
+        "name": "Chlorinator",
+        "type": "chlorinator",
+        "family": "Chlorinators",
+        "model": "Chlorinator",
+        "manufacturer": "Fluidra",
+        "thing_type": "domoticS2",
+        "online": True,
+        "components": {},
+    }
+
+
+def _config_name(config) -> str | None:
+    return next((name for name, value in DEVICE_CONFIGS.items() if value is config), None)
+
+
+class TestBridgedHeatPumpIdentification:
+    """The bridge marker must not decide the device family."""
+
+    def test_px50_is_identified_as_a_heat_pump(self):
+        config = DeviceIdentifier.identify_device(_px50())
+        assert config is not None
+        assert config.device_type == "heat_pump"
+        assert _config_name(config) == "generic_heat_pump"
+
+    def test_px50_declares_a_climate_entity(self):
+        device = _px50()
+        assert DeviceIdentifier.should_create_entity(device, "climate") is True
+
+    def test_px50_scans_the_heat_pump_registers_not_the_chlorinator_ones(self):
+        """The chlorinator profile scanned c164/c172/c177/c185; a heat pump needs c13/c14/c15."""
+        device = _px50()
+        specific = DeviceIdentifier.get_feature(device, "specific_components", [])
+        assert set(specific) == {13, 14, 15}
+        assert DeviceIdentifier.get_feature(device, "hvac_modes") == ["off", "heat"]
+        assert DeviceIdentifier.has_feature(device, "temperature_control") is True
+
+    def test_elite_connect_ls_still_matches_the_chlorinator_catch_all(self):
+        """The device that already worked must keep the exact profile it had."""
+        config = DeviceIdentifier.identify_device(_elite_connect_ls())
+        assert _config_name(config) == "chlorinator"
+        assert DeviceIdentifier.should_create_entity(_elite_connect_ls(), "switch") is True
+
+    def test_bridge_protocol_is_not_a_chlorinator_identifier(self):
+        """``*.nn_*`` means "bridged over protocol nn", so no profile may claim it."""
+        for name, config in DEVICE_CONFIGS.items():
+            assert "*.nn_*" not in config.identifier_patterns, (
+                f"{name} claims every bridged device via the '*.nn_*' protocol marker"
+            )
+
+    @pytest.mark.parametrize(
+        "name",
+        ["z250iq_heat_pump", "z260iq_heat_pump", "z550iq_heat_pump", "z650iq_heat_pump"],
+    )
+    def test_model_specific_heat_pumps_do_not_claim_the_family(self, name):
+        """Same rule the HPGIC profile already documents: a bare "heat pump" family match
+        would steal genuinely-unknown heat pumps from the generic fallback."""
+        assert DEVICE_CONFIGS[name].family_patterns == []
+
+    def test_serial_specific_chlorinators_do_not_claim_the_family(self):
+        """Same rule on the other lineup: only the catch-all may match "Chlorinators"."""
+        claimers = [
+            name
+            for name, config in DEVICE_CONFIGS.items()
+            if "chlorinator" in config.family_patterns and config.identifier_patterns
+        ]
+        assert claimers == []
+
+
+class TestBridgedHeatPumpClimateEntity:
+    """End-to-end: the climate platform must build an entity for the PX50."""
+
+    @staticmethod
+    def _entry(devices):
+        coordinator = MagicMock()
+        pool = {"id": POOL_ID, "name": "Rumoroso", "devices": devices}
+        coordinator.data = {POOL_ID: pool}
+        coordinator.last_update_success = True
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.api = SimpleNamespace(
+            cached_pools=[pool],
+            get_pools=AsyncMock(return_value=[pool]),
+        )
+        return SimpleNamespace(
+            runtime_data=SimpleNamespace(coordinator=coordinator),
+            async_on_unload=lambda _unsub: None,
+        )
+
+    async def _added(self, devices) -> list:
+        added: list = []
+        await climate_setup(
+            MagicMock(),
+            self._entry(devices),
+            MagicMock(side_effect=lambda entities, *a, **k: added.extend(list(entities))),
+        )
+        return added
+
+    async def test_climate_entity_created_for_the_px50(self):
+        added = await self._added([_elite_connect_ls(), _px50()])
+        climates = [e for e in added if isinstance(e, FluidraHeatPumpClimate)]
+        assert len(climates) == 1
+        assert climates[0].unique_id == f"fluidra_pool_{POOL_ID}_QS23361258.nn_9_climate"
+
+    async def test_no_climate_entity_for_the_chlorinator(self):
+        added = await self._added([_elite_connect_ls()])
+        assert added == []


### PR DESCRIPTION
Closes #216.

@vicsol00-collab runs an AstralPool Elite Connect LS chlorinator and a Zodiac PX50 heat pump on one Fluidra account. Only the chlorinator produced entities; the PX50 had no `climate` entity at all.

## What the diagnostics say

Both devices are bridged, so both carry the bridge-protocol marker in their cloud id. The PX50 is published by the API — it is not missing, it is misread:

```json
{
  "device_id": "QS23361258.nn_9",
  "name": "PX50",
  "type": "heat_pump",
  "family": "Heat Pumps",
  "thing_type": "proelyo",
  "status": { "bridgedInfo": { "protocol": "nn" }, "thingType": "proelyo" }
}
```

The chlorinator catch-all listed `"*.nn_*"` among its `identifier_patterns`, so it scored the 50-point identifier signal on the heat pump and beat every heat-pump profile (20 family + 10 type bonus). The dump proves the outcome — the PX50's `_identify_cache` holds `DeviceConfig(device_type='chlorinator', identifier_patterns=['*.nn_*'], ...)`, and its scanned components are the chlorinator set `0, 1, 2, 3, 4, 8, 11, 20`, none of which a heat pump answers.

`.nn_` means "bridged over protocol nn". It is not a device family.

## The fix

- The chlorinator catch-all drops `"*.nn_*"`. Its family match is what identifies a chlorinator; serial-specific profiles still win on their own ids at their own priority.
- Serial-specific chlorinator profiles and model-specific heat-pump profiles drop their `family_patterns`. Every unit of a lineup reports the same family, so a family match carries no model information — it only lets a higher-priority profile outrank the fallback on a unit it was never written for. The HPGIC and tecnoLC2-signature profiles already spelled out this rule individually; it is now applied across both lineups and stated in the module docstrings.

The PX50 resolves to `generic_heat_pump`: a `climate` entity on c13/c14/c15, hvac modes off/heat, temperature control. That profile is `verified=False`, so the existing unverified-profile repair issue fires and asks the owner for a dump — the attached diagnostics cannot give the PX50's real register map, because the chlorinator profile never scanned those registers.

## Tests

`tests/test_issue_216_bridged_heat_pump.py`, built from the reporter's dump: the PX50 identifies as a heat pump, declares `climate`, scans c13/c14/c15, and the climate platform builds one `FluidraHeatPumpClimate` for it; the Elite Connect LS keeps the exact profile it had. Guards pin that no profile claims `*.nn_*` and that no serial-specific profile claims its family.

All 1895 tests pass on this branch (11 new). ruff, bandit and codespell clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification for bridged heat pumps and chlorinators.
  * Prevented bridged non-chlorinators from being incorrectly classified as chlorinators.
  * Ensured supported heat pumps use the correct climate controls, including heating mode and temperature adjustment.
  * Preserved correct detection of existing chlorinator models.
* **Tests**
  * Added coverage verifying accurate device profiles and climate entity creation for bridged heat pumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->