### PR TITLE
fix(schedules): serialise schedule writes per register and hold the edited time (#210)

### DIFF
--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -284,11 +284,30 @@ def _coordinator_has_device(coordinator: FluidraDataUpdateCoordinator, device_id
     return _get_device_data(coordinator, device_id) is not None
 
 
-def _get_schedule_component(coordinator: FluidraDataUpdateCoordinator, device_id: str) -> int:
-    """Return the schedule component for a device, defaulting to pump schedules."""
+def _get_schedule_component(
+    coordinator: FluidraDataUpdateCoordinator,
+    device_id: str,
+    *,
+    component_id: int | None = None,
+    schedule_output: str | None = None,
+) -> int:
+    """Return the schedule component for a device, defaulting to pump schedules.
+
+    ``component_id`` wins when given. ``schedule_output`` resolves a Command
+    Connect cabinet register (``pump`` → c35, ``lights`` → c36, Issue #210).
+    """
+    if component_id is not None:
+        return int(component_id)
+
     device = _get_device_data(coordinator, device_id)
     if device is None:
         return COMPONENT_SCHEDULE
+
+    if schedule_output:
+        from .helpers import resolve_cabinet_schedule_component
+
+        return resolve_cabinet_schedule_component(device, schedule_output)
+
     return resolve_schedule_component(device, COMPONENT_SCHEDULE)
 
 
@@ -517,7 +536,12 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         _ensure_device_pool_writable(coordinator, device_id)
 
         # Convert HA format to Fluidra API format
-        schedule_component = _get_schedule_component(coordinator, device_id)
+        schedule_component = _get_schedule_component(
+            coordinator,
+            device_id,
+            component_id=call.data.get("component_id"),
+            schedule_output=call.data.get("schedule_output"),
+        )
         component_actions = _device_uses_component_actions(coordinator, device_id, schedule_component)
         fluidra_schedules = [
             _service_schedule_to_fluidra(schedule, i, use_component_actions=component_actions)
@@ -560,7 +584,13 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
         try:
             success = await coordinator.api.clear_schedule(
-                device_id, component_id=_get_schedule_component(coordinator, device_id)
+                device_id,
+                component_id=_get_schedule_component(
+                    coordinator,
+                    device_id,
+                    component_id=call.data.get("component_id"),
+                    schedule_output=call.data.get("schedule_output"),
+                ),
             )
         except FluidraError as err:
             _LOGGER.exception("Service %s failed for device %s", SERVICE_CLEAR_SCHEDULE, device_id)

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -104,6 +104,13 @@ SWITCH_CONFIRMATION_DELAY: Final = 2  # seconds - delay after switch toggle befo
 UI_UPDATE_DELAY: Final = 0.1  # seconds - small delay for UI responsiveness
 PUMP_START_DELAY: Final = 1  # seconds - delay after pump start before setting speed
 OPTIMISTIC_ACTION_TIMEOUT: Final = 10  # seconds - timeout for optimistic local state
+# A schedule write is only echoed back once the device has taken it — 5-10 s on
+# the Command Connect cabinet, and the reported value can flap between the old
+# and the new list meanwhile (Issue #210). Dropping the optimistic value after
+# COMMAND_CONFIRMATION_DELAY therefore snapped the field back to the old time a
+# few seconds after every edit, which is what made testers retry and collide.
+# Three poll cycles is the same budget the write verifier gives a control write.
+SCHEDULE_WRITE_HOLD_SECONDS: Final = 3 * DEFAULT_SCAN_INTERVAL  # seconds
 # Consecutive bulk-component-fetch failures before falling back to per-component
 # polling for the rest of the session (Issue #144). A few retries absorb transient
 # network errors; a backend that genuinely lacks the endpoint stops costing an

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -661,6 +661,15 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         schedule_data = reported_value if isinstance(reported_value, list) else []
                         device.setdefault("aux_schedule_data", {})[str(aux_number)] = schedule_data
 
+            # Command Connect cabinet: pump schedule on c35 (r1), lights on c36
+            # (r2). Independent of the pump/aux paths above (Issue #210).
+            for output, cabinet_component in (
+                DeviceIdentifier.get_feature(device, "cabinet_schedule_components", {}) or {}
+            ).items():
+                if component_id == int(cabinet_component):
+                    schedule_data = reported_value if isinstance(reported_value, list) else []
+                    device.setdefault("cabinet_schedule_data", {})[str(output)] = schedule_data
+
             schedule_comp = DeviceIdentifier.get_feature(device, "schedule_component")
             if schedule_comp and component_id == schedule_comp:
                 if isinstance(reported_value, dict) and "programs" in reported_value:
@@ -718,6 +727,26 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             device.setdefault("aux_schedule_data", {})[str(aux_number)] = reported if isinstance(reported, list) else []
             resolved[str(aux_number)] = component_id
         device["aux_schedule_components_resolved"] = resolved
+
+    def _apply_resolved_cabinet_schedules(self, device: dict[str, Any]) -> None:
+        """Point each cabinet output's schedule list at its fixed register.
+
+        Command Connect keeps the filtration schedule on c35 and the lights
+        schedule on c36. Both are lists in the app's CRON shape; an empty list
+        means "no armed window" (Issue #210).
+        """
+        mapping = DeviceIdentifier.get_feature(device, "cabinet_schedule_components", {}) or {}
+        if not mapping:
+            return
+
+        components = device.get("components", {})
+        resolved: dict[str, int] = {}
+        for output, component_id in mapping.items():
+            cid = int(component_id)
+            reported = components.get(str(cid), {}).get("reportedValue")
+            device.setdefault("cabinet_schedule_data", {})[str(output)] = reported if isinstance(reported, list) else []
+            resolved[str(output)] = cid
+        device["cabinet_schedule_components_resolved"] = resolved
 
     def _process_victoria_component(
         self, device: dict[str, Any], component_id: int, component_state: dict[str, Any]
@@ -1193,6 +1222,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if DeviceIdentifier.get_feature(device, "schedule_component_map", None):
                 self._apply_resolved_schedule(device, pool_id, device_id)
             self._apply_resolved_aux_schedules(device)
+            self._apply_resolved_cabinet_schedules(device)
 
             # Recompute auto-mode pump speed AFTER the whole component scan: the
             # speed (component 11) is processed before the schedule (component 20)

--- a/custom_components/fluidra_pool/device_registry/configs/cabinets.py
+++ b/custom_components/fluidra_pool/device_registry/configs/cabinets.py
@@ -12,8 +12,14 @@ CABINET_CONFIGS: dict[str, DeviceConfig] = {
         # Component map verified on hardware by @efgonzalez (Issue #210):
         #   c13 filtration pump on/off, c24 pool lights on/off,
         #   c15 pump auto mode, c26 lights auto mode,
-        #   c35/c36 the two schedulers (r1/r2) — not written by this
-        #   integration yet; c16 packs schedule times as a string.
+        #   c35 pump schedule (r1), c36 lights schedule (r2),
+        #   c16 packs pump schedule times as a string — read-only here.
+        #
+        # Schedule semantics (also verified on his unit): a schedule is an
+        # *armed window*, not a guaranteed stop. Ending the window has been
+        # observed not to stop an output that was started manually; auto-mode
+        # off only disarms the schedule and leaves the output where it was.
+        # Times are local wall-clock despite the bridge reporting GMT0.
         family_patterns=["Cabinets"],
         model_patterns=["Command Connect"],
         components_range=40,
@@ -26,7 +32,10 @@ CABINET_CONFIGS: dict[str, DeviceConfig] = {
             "cabinet_lights": 24,
             "cabinet_pump_auto_mode": 15,
             "cabinet_lights_auto_mode": 26,
-            "specific_components": [13, 15, 24, 26],
+            # Packed pump config string (last digit mirrors c15). Exposed as a
+            # diagnostic sensor only — never written by this integration.
+            "cabinet_packed_config": 16,
+            "specific_components": [13, 15, 16, 24, 26, 35, 36],
             # ⚠ The cabinet silently ignores integer writes: PUT {"desiredValue": 1}
             # returns HTTP 200 and does nothing, while true/false applies within
             # ~5-10 s (Issue #210). Every control entity for this profile must go
@@ -38,6 +47,13 @@ CABINET_CONFIGS: dict[str, DeviceConfig] = {
                 ("cabinet_pump_auto_mode", "cabinet_pump_auto_mode", "mdi:calendar-clock"),
                 ("cabinet_lights_auto_mode", "cabinet_lights_auto_mode", "mdi:calendar-clock"),
             ],
+            # Per-output schedule registers (r1 pump / r2 lights). One slot each
+            # in the captures; format is the app's CRON list with local times,
+            # days 0-6, no ``state`` field on write, clear with ``[]``.
+            "cabinet_schedule_components": {"pump": 35, "lights": 36},
+            "cabinet_schedule_count": 1,
+            "schedule_local_time": True,
+            "schedule_armed_window": True,
         },
         priority=85,
     ),

--- a/custom_components/fluidra_pool/fluidra_api/_base.py
+++ b/custom_components/fluidra_pool/fluidra_api/_base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
     from ..api_resilience import CircuitBreaker, RateLimiter
     from ..write_verification import WriteVerifier
+    from ._schedules import PendingScheduleWrite
 
 
 class FluidraAPIBase:
@@ -46,6 +47,8 @@ class FluidraAPIBase:
         _rate_limiter: RateLimiter
         _token_lock: asyncio.Lock
         write_verifier: WriteVerifier
+        _schedule_write_locks: dict[tuple[str, int], asyncio.Lock]
+        _pending_schedule_writes: dict[tuple[str, int], PendingScheduleWrite]
 
         # --- Cross-mixin methods (defined on sibling mixins) ---
         async def _request(

--- a/custom_components/fluidra_pool/fluidra_api/_schedules.py
+++ b/custom_components/fluidra_pool/fluidra_api/_schedules.py
@@ -2,22 +2,81 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
+from dataclasses import dataclass
 import logging
+import time
 from typing import Any
 from urllib.parse import quote
 
 from ..api_resilience import FluidraAuthError, FluidraError
-from ..const import COMPONENT_DM24049704_SCHEDULE, COMPONENT_SCHEDULE
+from ..const import COMPONENT_DM24049704_SCHEDULE, COMPONENT_SCHEDULE, SCHEDULE_WRITE_HOLD_SECONDS
 from ..helpers import schedule_slots_for_write
 from ..utils import CRON_DAY_TO_NAME, extract_cron_days
+from ..write_verification import normalize_component_value
 from ._base import FluidraAPIBase
 from ._constants import CONNECTED_PARAMS, FLUIDRA_EMEA_BASE
 
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(slots=True)
+class PendingScheduleWrite:
+    """The slot list we last PUT, still waiting for the poll to echo it back.
+
+    A schedule write replaces the register's whole list, so the next write has to
+    start from what we just sent — not from the poll cache, which keeps reporting
+    the pre-write list until the device takes the change (5-10 s on the Command
+    Connect, Issue #210). Re-reading the device instead would be worse, not
+    better: inside that window the read *is* the old list.
+    """
+
+    slots: list[dict[str, Any]]
+    echo: Any
+    expires_at: float
+
+
 class SchedulesMixin(FluidraAPIBase):
     """Schedule encoding (CRON ↔ programs/slots) + ``set_schedule`` / ``clear_schedule``."""
+
+    def schedule_write_lock(self, device_id: str, component_id: int) -> asyncio.Lock:
+        """Return the lock that serialises schedule writes to one register.
+
+        Callers must hold it across *compose and PUT*, not just the PUT: the
+        corruption reported on Issue #210 came from two writes composing from the
+        same pre-write snapshot, each re-sending the other's field unchanged.
+        """
+        key = (str(device_id), int(component_id))
+        lock = self._schedule_write_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._schedule_write_locks[key] = lock
+        return lock
+
+    def pending_schedule_slots(self, device_id: str, component_id: int) -> list[dict[str, Any]] | None:
+        """Return the slot list we last PUT, or ``None`` once it is stale.
+
+        Dropped as soon as the local mirror reports the value back (the write
+        landed and the poll cache is authoritative again) or the hold elapses, so
+        a change made in the Fluidra app is never masked for long.
+        """
+        key = (str(device_id), int(component_id))
+        pending = self._pending_schedule_writes.get(key)
+        if pending is None:
+            return None
+        if time.monotonic() >= pending.expires_at:
+            del self._pending_schedule_writes[key]
+            return None
+        reported = self.reported_component_value(device_id, component_id)
+        if reported is not None and normalize_component_value(reported) == normalize_component_value(pending.echo):
+            del self._pending_schedule_writes[key]
+            return None
+        return copy.deepcopy(pending.slots)
+
+    def discard_pending_schedule(self, device_id: str, component_id: int) -> None:
+        """Forget the composition base for a register (write failed or rejected)."""
+        self._pending_schedule_writes.pop((str(device_id), int(component_id)), None)
 
     def _convert_schedules_to_dm24049704_format(self, schedules: list[dict[str, Any]]) -> dict[str, Any]:
         """Convert CRON-format schedules to DM24049704 programs/slots format.
@@ -130,6 +189,7 @@ class SchedulesMixin(FluidraAPIBase):
         except FluidraError as err:
             _LOGGER.error("set_schedule error: %s", err)
             self.write_verifier.discard(device_id, component_id)
+            self.discard_pending_schedule(device_id, component_id)
             return False
 
         if status != 200:
@@ -137,11 +197,19 @@ class SchedulesMixin(FluidraAPIBase):
             # (the system_log buffer only retains WARNING+, so a DEBUG line was
             # invisible and a failed write gave no diagnostic info — Issue #89).
             self.write_verifier.discard(device_id, component_id)
+            self.discard_pending_schedule(device_id, component_id)
             _LOGGER.warning("set_schedule rejected by Fluidra (HTTP %s): %s", status, raw_text[:500])
             return False
 
         # Arm a later poll comparison — HTTP 200 alone proves nothing.
         self.write_verifier.record(device_id, component_id, desired_value, baseline)
+        # Keep what we sent as the base for the next write on this register: the
+        # poll cache will still report the pre-write list for several seconds.
+        self._pending_schedule_writes[(str(device_id), int(component_id))] = PendingScheduleWrite(
+            slots=copy.deepcopy(schedule_slots_for_write(schedules)),
+            echo=desired_value,
+            expires_at=time.monotonic() + SCHEDULE_WRITE_HOLD_SECONDS,
+        )
         return True
 
     async def clear_schedule(self, device_id: str, component_id: int = COMPONENT_SCHEDULE) -> bool:

--- a/custom_components/fluidra_pool/fluidra_api/_schedules.py
+++ b/custom_components/fluidra_pool/fluidra_api/_schedules.py
@@ -119,20 +119,30 @@ class SchedulesMixin(FluidraAPIBase):
             desired_value = self._convert_schedules_to_dm24049704_format(schedules)
         payload = {"desiredValue": desired_value}
 
+        # Baseline from the local mirror *before* the write: the HTTP response
+        # echoes desiredValue even when the device drops it (Issue #133 / #210).
+        baseline = self.reported_component_value(device_id, component_id)
+
         try:
             status, _, raw_text = await self._request(
                 "PUT", url, headers=headers, json_data=payload, params=dict(CONNECTED_PARAMS)
             )
         except FluidraError as err:
             _LOGGER.error("set_schedule error: %s", err)
+            self.write_verifier.discard(device_id, component_id)
             return False
 
         if status != 200:
             # Surface the rejection reason at WARNING so it reaches HA's system log
             # (the system_log buffer only retains WARNING+, so a DEBUG line was
             # invisible and a failed write gave no diagnostic info — Issue #89).
+            self.write_verifier.discard(device_id, component_id)
             _LOGGER.warning("set_schedule rejected by Fluidra (HTTP %s): %s", status, raw_text[:500])
-        return status == 200
+            return False
+
+        # Arm a later poll comparison — HTTP 200 alone proves nothing.
+        self.write_verifier.record(device_id, component_id, desired_value, baseline)
+        return True
 
     async def clear_schedule(self, device_id: str, component_id: int = COMPONENT_SCHEDULE) -> bool:
         """Clear all schedules for a device."""

--- a/custom_components/fluidra_pool/fluidra_api/client.py
+++ b/custom_components/fluidra_pool/fluidra_api/client.py
@@ -13,7 +13,7 @@ from ._auth import AuthMixin
 from ._commands import CommandsMixin
 from ._components import ComponentsMixin
 from ._devices import DevicesMixin
-from ._schedules import SchedulesMixin
+from ._schedules import PendingScheduleWrite, SchedulesMixin
 from ._session import SessionMixin
 
 if TYPE_CHECKING:
@@ -70,3 +70,12 @@ class FluidraPoolAPI(SessionMixin, AuthMixin, DevicesMixin, ComponentsMixin, Com
         # Judges control writes against the next polls: the cloud returns 200
         # and echoes the requested value even when it discards it (Issue #133).
         self.write_verifier: WriteVerifier = WriteVerifier()
+
+        # Schedule writes rewrite a whole slot list, so two of them racing on the
+        # same register silently undo each other's field. One lock per
+        # (device, component) serialises compose -> PUT, and the list we last
+        # PUT is kept as the composition base until the poll echoes it back —
+        # the poll cache still reports the pre-write list for several seconds
+        # (Issue #210).
+        self._schedule_write_locks: dict[tuple[str, int], asyncio.Lock] = {}
+        self._pending_schedule_writes: dict[tuple[str, int], PendingScheduleWrite] = {}

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -99,6 +99,77 @@ def get_aux_schedule_data(device_data: dict[str, Any], aux_number: Any, schedule
     return None
 
 
+# Command Connect cabinet: all-days CRON field verified by @efgonzalez (Issue
+# #210). Minutes first, local wall-clock — do not convert despite GMT0 on the
+# bridge. Sunday/Monday anchor for day 0 is not confirmed; keep the captured
+# string intact.
+CABINET_SCHEDULE_ALL_DAYS = "0,1,2,3,4,5,6"
+
+
+def get_cabinet_schedule_data(device_data: dict[str, Any], output: Any, schedule_id: Any) -> dict[str, Any] | None:
+    """Return one schedule slot for a Command Connect cabinet output (c35/c36).
+
+    Cabinet schedules live on fixed per-output registers (pump = c35 / r1,
+    lights = c36 / r2), stored under ``device_data["cabinet_schedule_data"]``
+    keyed by output name. Returns ``None`` when that output has no slots.
+    """
+    if not device_data:
+        return None
+
+    by_output = device_data.get("cabinet_schedule_data") or {}
+    schedules = by_output.get(str(output))
+    if not schedules:
+        return None
+
+    for schedule in schedules:
+        if str(schedule.get("id")) == str(schedule_id):
+            result: dict[str, Any] = schedule
+            return result
+
+    return None
+
+
+def resolve_cabinet_schedule_component(device_data: dict[str, Any], output: Any, default: int = 35) -> int:
+    """Return the schedule register for a Command Connect cabinet output."""
+    from .device_registry import DeviceIdentifier
+
+    mapping = DeviceIdentifier.get_feature(device_data, "cabinet_schedule_components", {}) or {}
+    raw = mapping.get(str(output))
+    if raw is None:
+        return default
+    return int(raw)
+
+
+def build_cabinet_schedule_slot(
+    schedule_id: int,
+    start: time,
+    end: time,
+    *,
+    enabled: bool = True,
+    days: str = CABINET_SCHEDULE_ALL_DAYS,
+) -> dict[str, Any]:
+    """Build one cabinet schedule slot in the exact shape the app PUTs.
+
+    Captured on hardware by @efgonzalez (Issue #210)::
+
+        {"id": 1, "groupId": 1, "enabled": true,
+         "startTime": "15 10 * * 0,1,2,3,4,5,6",
+         "endTime": "30 18 * * 0,1,2,3,4,5,6",
+         "startActions": {"operationName": "1"}}
+
+    No ``state`` field — the device reports RUNNING/IDLE itself and rejects or
+    ignores it on write. Times are local; ``days`` defaults to every day.
+    """
+    return {
+        "id": schedule_id,
+        "groupId": schedule_id,
+        "enabled": enabled,
+        "startTime": f"{start.minute} {start.hour} * * {days}",
+        "endTime": f"{end.minute} {end.hour} * * {days}",
+        "startActions": {"operationName": str(schedule_id)},
+    }
+
+
 def resolve_aux_schedule_component(device_data: dict[str, Any], aux_number: Any, default: int = 22) -> int:
     """Return the schedule register an auxiliary output is currently honouring.
 

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -17,6 +17,7 @@ from ..platform_setup import async_setup_dynamic_platform
 from .base import FluidraPoolSensorBase, FluidraPoolSensorEntity
 from .chlorinator import FluidraBoostRemainingSensor, FluidraChlorinatorSensor
 from .device import (
+    FluidraCabinetPackedConfigSensor,
     FluidraCompressorHoursSensor,
     FluidraCompressorModulationSensor,
     FluidraDeviceBatterySensor,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "FluidraBoostRemainingSensor",
+    "FluidraCabinetPackedConfigSensor",
     "FluidraChlorinatorSensor",
     "FluidraCompressorHoursSensor",
     "FluidraCompressorModulationSensor",
@@ -156,6 +158,10 @@ async def async_setup_entry(
 
         if DeviceIdentifier.should_create_entity(device, "sensor_schedule_days"):
             entities.append(FluidraScheduleDaysSensor(coordinator, coordinator.api, pool_id, device_id))
+
+        # Command Connect c16 packed pump config — diagnostic, read-only (Issue #210).
+        if DeviceIdentifier.has_feature(device, "cabinet_packed_config"):
+            entities.append(FluidraCabinetPackedConfigSensor(coordinator, coordinator.api, pool_id, device_id))
 
         # Chlorinator sensors - create based on sensors_config from device registry
         config = DeviceIdentifier.identify_device(device)

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate.const import HVACAction
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfLength,
     UnitOfPower,
     UnitOfTemperature,
@@ -915,6 +916,40 @@ class FluidraScheduleDaysSensor(FluidraPoolSensorEntity):
         # than being silently dropped.
         ordered.extend(sorted(days.difference(self._DAY_ORDER)))
         return ", ".join(ordered)
+
+
+class FluidraCabinetPackedConfigSensor(FluidraPoolSensorEntity):
+    """Read-only packed pump config string on Command Connect c16 (Issue #210).
+
+    The cabinet also encodes filtration schedule times and the auto-mode flag
+    (last digit mirrors c15) in this string. It is diagnostic only — this
+    integration never writes c16; schedules go through c35/c36.
+    """
+
+    _attr_translation_key = "cabinet_packed_config"
+    _attr_icon = "mdi:barcode"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the packed-config sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "cabinet_packed_config")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the packed config string from c16."""
+        component = DeviceIdentifier.get_feature(self.device_data, "cabinet_packed_config", None)
+        if component is None:
+            return None
+        reported = self.device_data.get("components", {}).get(str(component), {}).get("reportedValue")
+        if reported is None:
+            return None
+        return str(reported)
 
 
 class FluidraHeatPumpActivitySensor(FluidraPoolSensorEntity):

--- a/custom_components/fluidra_pool/services.yaml
+++ b/custom_components/fluidra_pool/services.yaml
@@ -24,6 +24,24 @@ set_schedule:
           days: [6,7]
       selector:
         object:
+    # Optional: target a non-default schedule register (e.g. cabinet c35/c36).
+    component_id:
+      example: 35
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 300
+          mode: box
+    # Optional alias for Command Connect: "pump" → c35, "lights" → c36.
+    schedule_output:
+      example: "pump"
+      required: false
+      selector:
+        select:
+          options:
+            - "pump"
+            - "lights"
 
 clear_schedule:
   target:
@@ -33,6 +51,22 @@ clear_schedule:
       required: true
       selector:
         text:
+    component_id:
+      example: 35
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 300
+          mode: box
+    schedule_output:
+      example: "lights"
+      required: false
+      selector:
+        select:
+          options:
+            - "pump"
+            - "lights"
 
 set_preset_schedule:
   target:

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -335,6 +335,9 @@
       },
       "wifi_signal": {
         "name": "WiFi Signal"
+      },
+      "cabinet_packed_config": {
+        "name": "Packed pump config"
       }
     },
     "switch": {
@@ -379,6 +382,9 @@
       },
       "schedule_enable": {
         "name": "Schedule {schedule_id}"
+      },
+      "cabinet_schedule_enable": {
+        "name": "{output} Schedule {schedule_id}"
       }
     },
     "time": {
@@ -399,6 +405,12 @@
       },
       "schedule_start": {
         "name": "Schedule {schedule_id} Start"
+      },
+      "cabinet_schedule_end": {
+        "name": "{output} Schedule {schedule_id} End"
+      },
+      "cabinet_schedule_start": {
+        "name": "{output} Schedule {schedule_id} Start"
       }
     }
   },
@@ -549,6 +561,14 @@
         "device_id": {
           "description": "Device identifier (e.g. LE24500883)",
           "name": "Device ID"
+        },
+        "component_id": {
+          "description": "Optional schedule register (e.g. 35 pump / 36 lights on Command Connect)",
+          "name": "Component ID"
+        },
+        "schedule_output": {
+          "description": "Command Connect output: pump (c35) or lights (c36)",
+          "name": "Schedule output"
         }
       },
       "name": "Clear pump schedule"
@@ -577,6 +597,14 @@
         "schedules": {
           "description": "List of time slots",
           "name": "Schedules"
+        },
+        "component_id": {
+          "description": "Optional schedule register (e.g. 35 pump / 36 lights on Command Connect)",
+          "name": "Component ID"
+        },
+        "schedule_output": {
+          "description": "Command Connect output: pump (c35) or lights (c36)",
+          "name": "Schedule output"
         }
       },
       "name": "Set pump schedule"

--- a/custom_components/fluidra_pool/switch/__init__.py
+++ b/custom_components/fluidra_pool/switch/__init__.py
@@ -110,6 +110,23 @@ async def async_setup_entry(
                         )
                     )
 
+        # Command Connect cabinet schedules: pump = c35, lights = c36 (Issue #210).
+        cabinet_schedule_components = DeviceIdentifier.get_feature(device, "cabinet_schedule_components", {})
+        if cabinet_schedule_components:
+            cabinet_schedule_count = DeviceIdentifier.get_feature(device, "cabinet_schedule_count", 1)
+            for output in sorted(cabinet_schedule_components):
+                for i in range(1, cabinet_schedule_count + 1):
+                    entities.append(
+                        FluidraScheduleEnableSwitch(
+                            coordinator,
+                            coordinator.api,
+                            pool_id,
+                            device_id,
+                            str(i),
+                            cabinet_output=str(output),
+                        )
+                    )
+
         if DeviceIdentifier.has_feature(device, "boost_mode"):
             entities.append(FluidraChlorinatorBoostSwitch(coordinator, coordinator.api, pool_id, device_id))
 

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -14,8 +14,10 @@ from ..const import DOMAIN
 from ..helpers import (
     describe_led_colour,
     get_aux_schedule_data,
+    get_cabinet_schedule_data,
     get_schedule_data,
     resolve_aux_schedule_component,
+    resolve_cabinet_schedule_component,
     resolve_schedule_component,
 )
 from .base import FluidraPoolSwitchEntity
@@ -25,6 +27,8 @@ if TYPE_CHECKING:
     from ..fluidra_api import FluidraPoolAPI
 
 _LOGGER = logging.getLogger(__name__)
+
+_CABINET_OUTPUT_LABELS = {"pump": "Filtration", "lights": "Lights"}
 
 
 def _with_enabled(schedules: list[dict[str, Any]], schedule_id: Any, enabled: bool) -> list[dict[str, Any]]:
@@ -76,13 +80,22 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         device_id: str,
         schedule_id: str,
         aux_number: str | None = None,
+        cabinet_output: str | None = None,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, api, pool_id, device_id)
         self._schedule_id = schedule_id
         self._aux_number = aux_number
+        self._cabinet_output = cabinet_output
 
-        if aux_number is not None:
+        if cabinet_output is not None:
+            self._attr_translation_key = "cabinet_schedule_enable"
+            self._attr_translation_placeholders = {
+                "output": _CABINET_OUTPUT_LABELS.get(cabinet_output, cabinet_output),
+                "schedule_id": schedule_id,
+            }
+            self._attr_unique_id = f"fluidra_{self._device_id}_cabinet_{cabinet_output}_schedule_{schedule_id}_enabled"
+        elif aux_number is not None:
             self._attr_translation_key = "aux_schedule_enable"
             self._attr_translation_placeholders = {"aux_number": aux_number, "schedule_id": schedule_id}
             self._attr_unique_id = f"fluidra_{self._device_id}_aux{aux_number}_schedule_{schedule_id}_enabled"
@@ -107,6 +120,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
     def _get_schedule_data(self) -> dict[str, Any] | None:
         """Get schedule data from coordinator."""
         try:
+            if self._cabinet_output is not None:
+                return get_cabinet_schedule_data(self.device_data, self._cabinet_output, self._schedule_id)
             if self._aux_number is not None:
                 return get_aux_schedule_data(self.device_data, self._aux_number, self._schedule_id)
             return get_schedule_data(self.device_data, self._schedule_id)
@@ -115,7 +130,12 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
             return None
 
     def _get_schedule_list(self) -> list[dict[str, Any]]:
-        """Return the schedule list this switch edits (main or per-aux)."""
+        """Return the schedule list this switch edits (main, per-aux, or cabinet)."""
+        if self._cabinet_output is not None:
+            cabinet_schedules: list[dict[str, Any]] = (self.device_data.get("cabinet_schedule_data") or {}).get(
+                str(self._cabinet_output), []
+            )
+            return cabinet_schedules
         if self._aux_number is not None:
             aux_schedules: list[dict[str, Any]] = (self.device_data.get("aux_schedule_data") or {}).get(
                 str(self._aux_number), []
@@ -126,6 +146,8 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
 
     def _get_schedule_component(self) -> int:
         """Get the schedule component used by this device."""
+        if self._cabinet_output is not None:
+            return resolve_cabinet_schedule_component(self.device_data, self._cabinet_output)
         if self._aux_number is not None:
             # c22/c24 for a plain output, c23/c25 for a colour LED (Issue #174).
             return resolve_aux_schedule_component(self.device_data, self._aux_number)
@@ -267,6 +289,14 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
                     "end_action": schedule.get("endActions", {}),
                 }
             )
+
+        if self._cabinet_output is not None:
+            attrs["cabinet_output"] = self._cabinet_output
+            attrs["schedule_component"] = self._get_schedule_component()
+            # Verified behaviour (Issue #210): schedule = armed window, not a
+            # guaranteed stop when the window ends.
+            attrs["schedule_semantics"] = "armed_window"
+            attrs["schedule_local_time"] = True
 
         if self._aux_number is not None:
             attrs["schedule_component"] = self._get_schedule_component()

--- a/custom_components/fluidra_pool/switch/schedule.py
+++ b/custom_components/fluidra_pool/switch/schedule.py
@@ -10,7 +10,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError
 
 from ..api_resilience import FluidraError
-from ..const import DOMAIN
+from ..const import DOMAIN, SCHEDULE_WRITE_HOLD_SECONDS
 from ..helpers import (
     describe_led_colour,
     get_aux_schedule_data,
@@ -144,6 +144,19 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         schedules: list[dict[str, Any]] = self.device_data.get("schedule_data", [])
         return schedules
 
+    def _write_base_schedules(self, component_id: int) -> list[dict[str, Any]]:
+        """Return the slot list a write must build on for this register.
+
+        Prefers the list we last PUT over the poll cache: within the device's
+        confirmation window the cache still reports the pre-write list, so
+        composing from it re-sends stale times alongside the ``enabled`` flag
+        this switch is toggling (Issue #210).
+        """
+        pending = self._api.pending_schedule_slots(self._device_id, component_id)
+        if pending is not None:
+            return pending
+        return list(self._get_schedule_list())
+
     def _get_schedule_component(self) -> int:
         """Get the schedule component used by this device."""
         if self._cabinet_output is not None:
@@ -164,12 +177,13 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         """Return true if the schedule is enabled using optimistic UI."""
         schedule = self._get_schedule_data()
         if self._pending_state is not None:
-            # Drop the optimistic state as soon as the server has caught up,
-            # or after 15 s as a safety net (the coordinator debounces refresh
-            # by 1.5 s and a full poll can take a few seconds on top).
+            # Drop the optimistic state as soon as the server has caught up, or
+            # after SCHEDULE_WRITE_HOLD_SECONDS as a safety net. The old 15 s net
+            # expired before the next poll on the default 30 s scan interval, so
+            # the toggle flipped back exactly like the time fields did (#210).
             if (
                 schedule and bool(schedule.get("enabled", False)) == self._pending_state
-            ) or self._pending_state_expired(15):
+            ) or self._pending_state_expired(SCHEDULE_WRITE_HOLD_SECONDS):
                 self._clear_pending_state()
             else:
                 return self._pending_state
@@ -184,17 +198,24 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         self._ensure_pool_writable()
         try:
             self._set_pending_state(True)
-            current_schedules = self._get_schedule_list()
-            if not current_schedules:
-                self._clear_pending_state()
-                return
             schedule_component = self._get_schedule_component()
+            # Compose *and* PUT under the register lock, on top of what we last
+            # sent: a schedule write replaces the whole slot list, so a toggle
+            # racing a time edit re-sent the stale times (Issue #210).
+            async with self._api.schedule_write_lock(self._device_id, schedule_component):
+                current_schedules = self._write_base_schedules(schedule_component)
+                if not current_schedules:
+                    self._clear_pending_state()
+                    return
 
-            updated_schedules = _with_enabled(current_schedules, self._schedule_id, True)
+                updated_schedules = _with_enabled(current_schedules, self._schedule_id, True)
 
-            # No padding — Fluidra fills the remaining slots; padding to 8 with
-            # identical placeholder windows is rejected as "OVERLAP in sched" (Issue #105).
-            success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=schedule_component)
+                # No padding — Fluidra fills the remaining slots; padding to 8 with
+                # identical placeholder windows is rejected as "OVERLAP in sched" (Issue #105).
+                success = await self._api.set_schedule(
+                    self._device_id, updated_schedules, component_id=schedule_component
+                )
+
             if success:
                 # Keep optimistic state until is_on observes server confirmation
                 # or the 15 s safety timeout — clearing here flipped the UI back.
@@ -231,16 +252,23 @@ class FluidraScheduleEnableSwitch(FluidraPoolSwitchEntity):
         self._ensure_pool_writable()
         try:
             self._set_pending_state(False)
-            current_schedules = self._get_schedule_list()
-            if not current_schedules:
-                self._clear_pending_state()
-                return
             schedule_component = self._get_schedule_component()
+            # Compose *and* PUT under the register lock, on top of what we last
+            # sent: a schedule write replaces the whole slot list, so a toggle
+            # racing a time edit re-sent the stale times (Issue #210).
+            async with self._api.schedule_write_lock(self._device_id, schedule_component):
+                current_schedules = self._write_base_schedules(schedule_component)
+                if not current_schedules:
+                    self._clear_pending_state()
+                    return
 
-            updated_schedules = _with_enabled(current_schedules, self._schedule_id, False)
+                updated_schedules = _with_enabled(current_schedules, self._schedule_id, False)
 
-            # No padding — see the OVERLAP-in-sched note in async_turn_on (Issue #105).
-            success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=schedule_component)
+                # No padding — see the OVERLAP-in-sched note in async_turn_on (Issue #105).
+                success = await self._api.set_schedule(
+                    self._device_id, updated_schedules, component_id=schedule_component
+                )
+
             if success:
                 await self.coordinator.async_request_refresh()
             else:

--- a/custom_components/fluidra_pool/time/__init__.py
+++ b/custom_components/fluidra_pool/time/__init__.py
@@ -20,6 +20,7 @@ from .base import (
     FluidraScheduleTimeEntity,
     parse_schedule_time,
 )
+from .cabinet_schedule import FluidraCabinetScheduleEndTimeEntity, FluidraCabinetScheduleStartTimeEntity
 from .light import FluidraLightScheduleEndTimeEntity, FluidraLightScheduleStartTimeEntity
 from .schedule import FluidraScheduleEndTimeEntity, FluidraScheduleStartTimeEntity
 
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
 __all__ = [
     "FluidraAuxScheduleEndTimeEntity",
     "FluidraAuxScheduleStartTimeEntity",
+    "FluidraCabinetScheduleEndTimeEntity",
+    "FluidraCabinetScheduleStartTimeEntity",
     "FluidraLightScheduleEndTimeEntity",
     "FluidraLightScheduleStartTimeEntity",
     "FluidraLightScheduleTimeEntity",
@@ -125,6 +128,25 @@ async def async_setup_entry(
                     entities.append(
                         FluidraAuxScheduleEndTimeEntity(
                             coordinator, coordinator.api, pool_id, device_id, aux_number, schedule_id
+                        )
+                    )
+
+        # Command Connect cabinet schedules: pump = c35 (r1), lights = c36 (r2)
+        # (Issue #210). One slot per output in the verified captures.
+        cabinet_schedule_components = DeviceIdentifier.get_feature(device, "cabinet_schedule_components", {})
+        if cabinet_schedule_components:
+            cabinet_schedule_count = DeviceIdentifier.get_feature(device, "cabinet_schedule_count", 1)
+            for output in sorted(cabinet_schedule_components):
+                for i in range(1, cabinet_schedule_count + 1):
+                    schedule_id = str(i)
+                    entities.append(
+                        FluidraCabinetScheduleStartTimeEntity(
+                            coordinator, coordinator.api, pool_id, device_id, output, schedule_id
+                        )
+                    )
+                    entities.append(
+                        FluidraCabinetScheduleEndTimeEntity(
+                            coordinator, coordinator.api, pool_id, device_id, output, schedule_id
                         )
                     )
 

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import time
 import logging
-from typing import TYPE_CHECKING, Any
+from time import monotonic
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import aiohttp
 from homeassistant.components.time import TimeEntity
@@ -12,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..api_resilience import FluidraError
-from ..const import DEVICE_MODEL_FALLBACK, DEVICE_MODEL_MAP, DOMAIN
+from ..const import DEVICE_MODEL_FALLBACK, DEVICE_MODEL_MAP, DOMAIN, SCHEDULE_WRITE_HOLD_SECONDS
 from ..device_registry import DeviceIdentifier
 from ..entity import FluidraPoolControlEntity
 from ..helpers import (
@@ -87,6 +88,12 @@ class _FluidraTimeEntityBase(FluidraPoolControlEntity, TimeEntity):
 
     __slots__ = ("_schedule_id", "_time_type")
 
+    # A slot that does not exist yet has nothing to edit, so these entities go
+    # unavailable with it. Subclasses whose register can legitimately be empty
+    # and still writable (the Command Connect cabinet re-arms a cleared window)
+    # set this to False.
+    _requires_schedule_data: ClassVar[bool] = True
+
     def __init__(
         self,
         coordinator: FluidraDataUpdateCoordinator,
@@ -115,7 +122,9 @@ class _FluidraTimeEntityBase(FluidraPoolControlEntity, TimeEntity):
     @property
     def available(self) -> bool:
         """Return True if the device/coordinator are healthy and the schedule exists."""
-        return super().available and self._get_schedule_data() is not None
+        if not super().available:
+            return False
+        return not self._requires_schedule_data or self._get_schedule_data() is not None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -137,7 +146,7 @@ class _FluidraTimeEntityBase(FluidraPoolControlEntity, TimeEntity):
 class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
     """Base class for Fluidra pump/chlorinator schedule time entities."""
 
-    __slots__ = ("_aux_number", "_optimistic_value")
+    __slots__ = ("_aux_number", "_optimistic_until", "_optimistic_value")
 
     def __init__(
         self,
@@ -152,7 +161,51 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
         """Initialize the time entity."""
         super().__init__(coordinator, api, pool_id, device_id, schedule_id, time_type)
         self._optimistic_value: time | None = None
+        self._optimistic_until: float = 0.0
         self._aux_number = aux_number
+
+    def _set_optimistic(self, value: time) -> None:
+        """Show the time we are writing and hold it until the device confirms."""
+        self._optimistic_value = value
+        self._optimistic_until = monotonic() + SCHEDULE_WRITE_HOLD_SECONDS
+        self.async_write_ha_state()
+
+    def _clear_optimistic(self) -> None:
+        """Drop the optimistic value (the write failed) and show the device again."""
+        self._optimistic_value = None
+        self._optimistic_until = 0.0
+        self.async_write_ha_state()
+
+    def _optimistic_or(self, reported: time | None) -> time | None:
+        """Return the value we wrote until the device echoes it back.
+
+        Dropping it right after the PUT is what made every edit visibly snap back
+        to the old time: the cloud keeps reporting the pre-write value for
+        several seconds, so the refresh fired ``COMMAND_CONFIRMATION_DELAY``
+        later necessarily reads the old one. Users read that as a failed edit and
+        retried, and the retries are what corrupted the slot (Issue #210). The
+        enable switch already worked this way; the time entities did not.
+        """
+        if self._optimistic_value is None:
+            return reported
+        if reported == self._optimistic_value or monotonic() >= self._optimistic_until:
+            self._optimistic_value = None
+            self._optimistic_until = 0.0
+            return reported
+        return self._optimistic_value
+
+    def _write_base_schedules(self, component_id: int) -> list[dict[str, Any]]:
+        """Return the slot list a write must build on for this register.
+
+        Prefers the list we last PUT over the poll cache: within the device's
+        confirmation window the cache still holds the pre-write list, so
+        composing from it re-sends stale values for every field the current edit
+        does not touch (Issue #210).
+        """
+        pending = self._api.pending_schedule_slots(self._device_id, component_id)
+        if pending is not None:
+            return pending
+        return list(self._get_schedule_list())
 
     def _get_schedule_list(self) -> list[dict[str, Any]]:
         """Return the schedule list this entity edits (main or per-aux)."""

--- a/custom_components/fluidra_pool/time/cabinet_schedule.py
+++ b/custom_components/fluidra_pool/time/cabinet_schedule.py
@@ -1,0 +1,318 @@
+"""Command Connect cabinet schedule start & end time entities (c35/c36).
+
+The AstralPool Command Connect keeps two independent schedulers on fixed
+registers — filtration pump on c35 (r1), pool lights on c36 (r2) — with one
+slot each in the captures from @efgonzalez (Issue #210).
+
+A schedule is an *armed window*, not a guaranteed stop: ending the window has
+been observed not to stop an output started manually. Times are local
+wall-clock despite the bridge reporting GMT0. Writes must omit the runtime
+``state`` field; clearing is an empty list ``[]``. HTTP 200 alone is not proof
+the write landed — ``set_schedule`` arms write verification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import time
+import logging
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from ..api_resilience import FluidraError
+from ..const import COMMAND_CONFIRMATION_DELAY, DOMAIN
+from ..entity import FluidraPoolEntity
+from ..helpers import (
+    CABINET_SCHEDULE_ALL_DAYS,
+    build_cabinet_schedule_slot,
+    get_cabinet_schedule_data,
+    resolve_cabinet_schedule_component,
+)
+from .base import FluidraScheduleTimeEntity
+from .schedule import _replace_cron_time
+
+if TYPE_CHECKING:
+    from ..coordinator import FluidraDataUpdateCoordinator
+    from ..fluidra_api import FluidraPoolAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+_OUTPUT_LABELS = {"pump": "Filtration", "lights": "Lights"}
+
+
+def _default_pair(edited: time, time_type: str) -> tuple[time, time]:
+    """Pick a same-day partner when seeding a slot from a single endpoint."""
+    if time_type == "start":
+        end_minutes = (edited.hour * 60 + edited.minute + 60) % (24 * 60)
+        return edited, time(end_minutes // 60, end_minutes % 60)
+    start_minutes = edited.hour * 60 + edited.minute - 60
+    if start_minutes < 0:
+        start_minutes += 24 * 60
+    return time(start_minutes // 60, start_minutes % 60), edited
+
+
+class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
+    """Shared start/end logic for one Command Connect cabinet schedule slot."""
+
+    __slots__ = ("_cabinet_output",)
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        cabinet_output: str,
+        schedule_id: str,
+        time_type: str,
+    ) -> None:
+        """Initialize the cabinet schedule time entity."""
+        # Reuse the aux_number slot on the base class as a channel key so the
+        # shared list/component helpers stay unused; cabinet paths override them.
+        super().__init__(coordinator, api, pool_id, device_id, schedule_id, time_type, aux_number=None)
+        self._cabinet_output = cabinet_output
+        self._attr_translation_placeholders = {
+            "output": _OUTPUT_LABELS.get(cabinet_output, cabinet_output),
+            "schedule_id": schedule_id,
+        }
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    def _get_schedule_data(self) -> dict[str, Any] | None:
+        """Return this output's schedule slot from cabinet_schedule_data."""
+        try:
+            return get_cabinet_schedule_data(self.device_data, self._cabinet_output, self._schedule_id)
+        except (aiohttp.ClientError, TimeoutError, FluidraError, ValueError, TypeError, KeyError, AttributeError):
+            _LOGGER.debug("Failed to get cabinet %s schedule data for %s", self._cabinet_output, self._device_id)
+            return None
+
+    def _get_schedule_list(self) -> list[dict[str, Any]]:
+        """Return the schedule list for this cabinet output."""
+        schedules: list[dict[str, Any]] = (self.device_data.get("cabinet_schedule_data") or {}).get(
+            str(self._cabinet_output), []
+        )
+        return schedules
+
+    def _get_schedule_component(self) -> int:
+        """Return c35 (pump) or c36 (lights) for this output."""
+        return resolve_cabinet_schedule_component(self.device_data, self._cabinet_output)
+
+    @property
+    def available(self) -> bool:
+        """Stay available when the slot is empty so a clear can be rewritten."""
+        return FluidraPoolEntity.available.fget(self)  # type: ignore[misc]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose armed-window semantics and the live register."""
+        schedule = self._get_schedule_data()
+        attrs: dict[str, Any] = {
+            "cabinet_output": self._cabinet_output,
+            "schedule_component": self._get_schedule_component(),
+            # Verified behaviour (Issue #210): the schedule arms a window; it
+            # does not guarantee the output stops when the window ends.
+            "schedule_semantics": "armed_window",
+            "schedule_local_time": True,
+        }
+        if schedule:
+            attrs["schedule_state"] = schedule.get("state")
+            attrs["enabled"] = schedule.get("enabled")
+        return attrs
+
+    async def _async_set_time(self, value: time) -> None:
+        """Rewrite this slot's time (or seed a new slot) and PUT the register."""
+        self._optimistic_value = value
+        self.async_write_ha_state()
+
+        current_schedules = list(self._get_schedule_list())
+        field = "startTime" if self._time_type == "start" else "endTime"
+        current_schedule = self._get_schedule_data()
+
+        if current_schedule and self._time_type == "start":
+            current_end_time = self._parse_cron_time(current_schedule.get("endTime", ""))
+            if current_end_time and value < current_end_time:
+                is_valid, error_msg = self._validate_schedule_overlap(value, current_end_time, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+        elif current_schedule and self._time_type == "end":
+            current_start_time = self._parse_cron_time(current_schedule.get("startTime", ""))
+            if current_start_time and value > current_start_time:
+                is_valid, error_msg = self._validate_schedule_overlap(current_start_time, value, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+
+        if not current_schedules:
+            start, end = _default_pair(value, self._time_type)
+            updated_schedules = [build_cabinet_schedule_slot(int(self._schedule_id), start, end, enabled=True)]
+        else:
+            updated_schedules = []
+            found = False
+            for sched in current_schedules:
+                entry = dict(sched)
+                if str(entry.get("id")) == str(self._schedule_id):
+                    found = True
+                    existing = entry.get(field, "")
+                    if existing:
+                        entry[field] = _replace_cron_time(existing, value)
+                    else:
+                        entry[field] = f"{value.minute} {value.hour} * * {CABINET_SCHEDULE_ALL_DAYS}"
+                entry.setdefault("groupId", entry.get("id"))
+                entry.pop("state", None)
+                entry.pop("endActions", None)
+                if not isinstance(entry.get("startActions"), dict):
+                    entry["startActions"] = {"operationName": str(entry.get("id", self._schedule_id))}
+                updated_schedules.append(entry)
+            if not found:
+                start, end = _default_pair(value, self._time_type)
+                updated_schedules.append(build_cabinet_schedule_slot(int(self._schedule_id), start, end, enabled=True))
+
+        component_id = self._get_schedule_component()
+        success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
+        if not success:
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_rejected",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
+        await self.coordinator.async_request_refresh()
+        self._optimistic_value = None
+        self.async_write_ha_state()
+
+
+class FluidraCabinetScheduleStartTimeEntity(_FluidraCabinetScheduleTimeEntity):
+    """Start time for one Command Connect cabinet schedule slot."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        cabinet_output: str,
+        schedule_id: str,
+    ) -> None:
+        """Initialize the cabinet schedule start time entity."""
+        super().__init__(coordinator, api, pool_id, device_id, cabinet_output, schedule_id, "start")
+        self._attr_translation_key = "cabinet_schedule_start"
+        self._attr_unique_id = f"fluidra_{self._device_id}_cabinet_{cabinet_output}_schedule_{schedule_id}_start_time"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the entity."""
+        return "mdi:clock-start"
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the current start time."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        schedule = self._get_schedule_data()
+        if schedule:
+            return self._parse_cron_time(schedule.get("startTime", ""))
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the start time."""
+        self._ensure_pool_writable()
+        try:
+            await self._async_set_time(value)
+        except HomeAssistantError:
+            raise
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            FluidraError,
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+        ) as err:
+            _LOGGER.error(
+                "Failed to set cabinet %s schedule start time for %s: %s",
+                self._cabinet_output,
+                self._device_id,
+                err,
+            )
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_failed",
+                translation_placeholders={"device_id": self._device_id},
+            ) from err
+
+
+class FluidraCabinetScheduleEndTimeEntity(_FluidraCabinetScheduleTimeEntity):
+    """End time for one Command Connect cabinet schedule slot."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        cabinet_output: str,
+        schedule_id: str,
+    ) -> None:
+        """Initialize the cabinet schedule end time entity."""
+        super().__init__(coordinator, api, pool_id, device_id, cabinet_output, schedule_id, "end")
+        self._attr_translation_key = "cabinet_schedule_end"
+        self._attr_unique_id = f"fluidra_{self._device_id}_cabinet_{cabinet_output}_schedule_{schedule_id}_end_time"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the entity."""
+        return "mdi:clock-end"
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the current end time."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        schedule = self._get_schedule_data()
+        if schedule:
+            return self._parse_cron_time(schedule.get("endTime", ""))
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the end time."""
+        self._ensure_pool_writable()
+        try:
+            await self._async_set_time(value)
+        except HomeAssistantError:
+            raise
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            FluidraError,
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+        ) as err:
+            _LOGGER.error(
+                "Failed to set cabinet %s schedule end time for %s: %s",
+                self._cabinet_output,
+                self._device_id,
+                err,
+            )
+            self._optimistic_value = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_failed",
+                translation_placeholders={"device_id": self._device_id},
+            ) from err

--- a/custom_components/fluidra_pool/time/cabinet_schedule.py
+++ b/custom_components/fluidra_pool/time/cabinet_schedule.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 from datetime import time
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import aiohttp
 from homeassistant.const import EntityCategory
@@ -24,7 +24,6 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..api_resilience import FluidraError
 from ..const import COMMAND_CONFIRMATION_DELAY, DOMAIN
-from ..entity import FluidraPoolEntity
 from ..helpers import (
     CABINET_SCHEDULE_ALL_DAYS,
     build_cabinet_schedule_slot,
@@ -58,6 +57,10 @@ class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
     """Shared start/end logic for one Command Connect cabinet schedule slot."""
 
     __slots__ = ("_cabinet_output",)
+
+    # An empty c35/c36 means "no armed window", not "no such control": the
+    # entity has to stay available so the window can be written back.
+    _requires_schedule_data: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -100,11 +103,6 @@ class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
         return resolve_cabinet_schedule_component(self.device_data, self._cabinet_output)
 
     @property
-    def available(self) -> bool:
-        """Stay available when the slot is empty so a clear can be rewritten."""
-        return FluidraPoolEntity.available.fget(self)  # type: ignore[misc]
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose armed-window semantics and the live register."""
         schedule = self._get_schedule_data()
@@ -123,12 +121,32 @@ class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
 
     async def _async_set_time(self, value: time) -> None:
         """Rewrite this slot's time (or seed a new slot) and PUT the register."""
-        self._optimistic_value = value
+        component_id = self._get_schedule_component()
+        # Compose and PUT under one lock per register: a schedule write replaces
+        # the whole slot list, so two overlapping edits each re-sent the other's
+        # field from their own pre-write snapshot — that is how an end time came
+        # back holding the old start time (Issue #210).
+        async with self._api.schedule_write_lock(self._device_id, component_id):
+            await self._async_compose_and_write(value, component_id)
+
+        await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
+        await self.coordinator.async_request_refresh()
+        # The optimistic value is NOT dropped here: this refresh reads the
+        # pre-write list on a device that takes 5-10 s to confirm. It expires on
+        # its own once the device echoes the new time (see ``_optimistic_or``).
         self.async_write_ha_state()
 
-        current_schedules = list(self._get_schedule_list())
+    async def _async_compose_and_write(self, value: time, component_id: int) -> None:
+        """Build the register's full slot list around this edit and PUT it."""
+        current_schedules = self._write_base_schedules(component_id)
         field = "startTime" if self._time_type == "start" else "endTime"
         current_schedule = self._get_schedule_data()
+
+        if current_schedule is None:
+            current_schedule = next(
+                (slot for slot in current_schedules if str(slot.get("id")) == str(self._schedule_id)),
+                None,
+            )
 
         if current_schedule and self._time_type == "start":
             current_end_time = self._parse_cron_time(current_schedule.get("endTime", ""))
@@ -146,6 +164,10 @@ class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
                     raise ServiceValidationError(
                         error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
                     )
+
+        # Only now show the new time: a rejected overlap must not leave the field
+        # holding a value for the whole confirmation window.
+        self._set_optimistic(value)
 
         if not current_schedules:
             start, end = _default_pair(value, self._time_type)
@@ -172,20 +194,14 @@ class _FluidraCabinetScheduleTimeEntity(FluidraScheduleTimeEntity):
                 start, end = _default_pair(value, self._time_type)
                 updated_schedules.append(build_cabinet_schedule_slot(int(self._schedule_id), start, end, enabled=True))
 
-        component_id = self._get_schedule_component()
         success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
         if not success:
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="schedule_set_rejected",
                 translation_placeholders={"device_id": self._device_id},
             )
-        await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
-        await self.coordinator.async_request_refresh()
-        self._optimistic_value = None
-        self.async_write_ha_state()
 
 
 class FluidraCabinetScheduleStartTimeEntity(_FluidraCabinetScheduleTimeEntity):
@@ -215,12 +231,9 @@ class FluidraCabinetScheduleStartTimeEntity(_FluidraCabinetScheduleTimeEntity):
     @property
     def native_value(self) -> time | None:
         """Return the current start time."""
-        if self._optimistic_value is not None:
-            return self._optimistic_value
         schedule = self._get_schedule_data()
-        if schedule:
-            return self._parse_cron_time(schedule.get("startTime", ""))
-        return None
+        reported = self._parse_cron_time(schedule.get("startTime", "")) if schedule else None
+        return self._optimistic_or(reported)
 
     async def async_set_value(self, value: time) -> None:
         """Set the start time."""
@@ -228,6 +241,7 @@ class FluidraCabinetScheduleStartTimeEntity(_FluidraCabinetScheduleTimeEntity):
         try:
             await self._async_set_time(value)
         except HomeAssistantError:
+            self._clear_optimistic()
             raise
         except (
             aiohttp.ClientError,
@@ -244,8 +258,7 @@ class FluidraCabinetScheduleStartTimeEntity(_FluidraCabinetScheduleTimeEntity):
                 self._device_id,
                 err,
             )
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="schedule_set_failed",
@@ -280,12 +293,9 @@ class FluidraCabinetScheduleEndTimeEntity(_FluidraCabinetScheduleTimeEntity):
     @property
     def native_value(self) -> time | None:
         """Return the current end time."""
-        if self._optimistic_value is not None:
-            return self._optimistic_value
         schedule = self._get_schedule_data()
-        if schedule:
-            return self._parse_cron_time(schedule.get("endTime", ""))
-        return None
+        reported = self._parse_cron_time(schedule.get("endTime", "")) if schedule else None
+        return self._optimistic_or(reported)
 
     async def async_set_value(self, value: time) -> None:
         """Set the end time."""
@@ -293,6 +303,7 @@ class FluidraCabinetScheduleEndTimeEntity(_FluidraCabinetScheduleTimeEntity):
         try:
             await self._async_set_time(value)
         except HomeAssistantError:
+            self._clear_optimistic()
             raise
         except (
             aiohttp.ClientError,
@@ -309,8 +320,7 @@ class FluidraCabinetScheduleEndTimeEntity(_FluidraCabinetScheduleTimeEntity):
                 self._device_id,
                 err,
             )
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="schedule_set_failed",

--- a/custom_components/fluidra_pool/time/schedule.py
+++ b/custom_components/fluidra_pool/time/schedule.py
@@ -76,82 +76,26 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
         """Set the start time using exact mobile app format."""
         self._ensure_pool_writable()
         try:
-            self._optimistic_value = value
-            self.async_write_ha_state()
-
-            current_schedules = self._get_schedule_list()
-            if not current_schedules:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                return
-
-            current_schedule = self._get_schedule_data()
-            if current_schedule:
-                current_end_time = self._parse_cron_time(current_schedule.get("endTime", ""))
-                # Only validate a forward, same-day window. An inverted pair
-                # (start > end) mid-edit is an in-progress state, not a real
-                # overnight range, so skip the overlap check (the user usually
-                # fixes the other endpoint next; the device is the final arbiter).
-                if current_end_time and value < current_end_time:
-                    is_valid, error_msg = self._validate_schedule_overlap(value, current_end_time, self._schedule_id)
-                    if not is_valid:
-                        raise ServiceValidationError(
-                            error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
-                        )
-
-            updated_schedules = []
-            for sched in current_schedules:
-                scheduler = dict(sched)
-                if str(sched.get("id")) == str(self._schedule_id):
-                    scheduler["startTime"] = _replace_cron_time(sched.get("startTime", ""), value)
-
-                component_id = self._get_schedule_component()
-
-                if component_id == 258:
-                    # DM24049704 chlorinator uses a flat groupId=1 + padded CRON.
-                    scheduler = {
-                        "id": sched.get("id"),
-                        "groupId": 1,
-                        "enabled": True,
-                        "startTime": self._format_cron_time_chlorinator(scheduler["startTime"]),
-                        "endTime": self._format_cron_time_chlorinator(scheduler.get("endTime", "")),
-                        "startActions": {"operationName": str(sched.get("startActions", {}).get("operationName", "1"))},
-                    }
-                else:
-                    # Copy the entry verbatim and touch only the time being edited,
-                    # so a schedule whose mode lives in componentActions (eXO iQ)
-                    # keeps it instead of being rebuilt as operationName (Issue #175).
-                    scheduler.setdefault("groupId", sched.get("id"))
-                    scheduler["startTime"] = scheduler.get("startTime", "")
-                    scheduler["endTime"] = scheduler.get("endTime", "")
-                    # Read-only runtime fields the API rejects on write (Issue #89/#174).
-                    scheduler.pop("state", None)
-                    scheduler.pop("endActions", None)
-                updated_schedules.append(scheduler)
-
             component_id = self._get_schedule_component()
+            # Compose *and* PUT under one lock per register: a schedule write
+            # replaces the register's whole slot list, so two overlapping edits
+            # each re-sent the other's field from their own pre-write snapshot
+            # — that is how an end time came back holding an old start time
+            # (Issue #210).
+            async with self._api.schedule_write_lock(self._device_id, component_id):
+                if not await self._async_compose_and_write(value, component_id):
+                    return
 
-            # Send only the configured schedules — no padding. Fluidra fills the
-            # remaining device slots itself; padding to 8 with identical placeholder
-            # windows is rejected as "OVERLAP in sched" (Issue #105), and a packet
-            # capture of the official app confirms it sends only the real entries.
-            success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
-            if not success:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="schedule_set_rejected",
-                    translation_placeholders={"device_id": self._device_id},
-                )
             await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
             await self.coordinator.async_request_refresh()
-            self._optimistic_value = None
+            # The optimistic value is deliberately NOT dropped here: this
+            # refresh still reads the pre-write list on a device that takes
+            # seconds to confirm. ``_optimistic_or`` releases it when the device
+            # echoes the new time, or after SCHEDULE_WRITE_HOLD_SECONDS.
             self.async_write_ha_state()
 
         except HomeAssistantError:
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise
         except (
             aiohttp.ClientError,
@@ -163,13 +107,85 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
             AttributeError,
         ) as err:
             _LOGGER.error("Failed to set schedule start time for %s: %s", self._device_id, err)
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="schedule_set_failed",
                 translation_placeholders={"device_id": self._device_id},
             ) from err
+
+    async def _async_compose_and_write(self, value: time, component_id: int) -> bool:
+        """Rewrite this slot's start time in the full list and PUT the register.
+
+        Returns ``False`` when there is no slot to edit; raises when the write is
+        rejected.
+        """
+        current_schedules = self._write_base_schedules(component_id)
+        if not current_schedules:
+            return False
+
+        current_schedule = self._get_schedule_data() or next(
+            (slot for slot in current_schedules if str(slot.get("id")) == str(self._schedule_id)),
+            None,
+        )
+        if current_schedule:
+            current_end_time = self._parse_cron_time(current_schedule.get("endTime", ""))
+            # Only validate a forward, same-day window. An inverted pair
+            # (start > end) mid-edit is an in-progress state, not a real
+            # overnight range, so skip the overlap check (the user usually
+            # fixes the other endpoint next; the device is the final arbiter).
+            if current_end_time and value < current_end_time:
+                is_valid, error_msg = self._validate_schedule_overlap(value, current_end_time, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+
+        # Only now show the new time: a rejected overlap must not leave the field
+        # holding a value for the whole confirmation window.
+        self._set_optimistic(value)
+
+        updated_schedules = []
+        for sched in current_schedules:
+            scheduler = dict(sched)
+            if str(sched.get("id")) == str(self._schedule_id):
+                scheduler["startTime"] = _replace_cron_time(sched.get("startTime", ""), value)
+
+            if component_id == 258:
+                # DM24049704 chlorinator uses a flat groupId=1 + padded CRON.
+                scheduler = {
+                    "id": sched.get("id"),
+                    "groupId": 1,
+                    "enabled": True,
+                    "startTime": self._format_cron_time_chlorinator(scheduler["startTime"]),
+                    "endTime": self._format_cron_time_chlorinator(scheduler.get("endTime", "")),
+                    "startActions": {"operationName": str(sched.get("startActions", {}).get("operationName", "1"))},
+                }
+            else:
+                # Copy the entry verbatim and touch only the time being edited,
+                # so a schedule whose mode lives in componentActions (eXO iQ)
+                # keeps it instead of being rebuilt as operationName (Issue #175).
+                scheduler.setdefault("groupId", sched.get("id"))
+                scheduler["startTime"] = scheduler.get("startTime", "")
+                scheduler["endTime"] = scheduler.get("endTime", "")
+                # Read-only runtime fields the API rejects on write (Issue #89/#174).
+                scheduler.pop("state", None)
+                scheduler.pop("endActions", None)
+            updated_schedules.append(scheduler)
+
+        # Send only the configured schedules — no padding. Fluidra fills the
+        # remaining device slots itself; padding to 8 with identical placeholder
+        # windows is rejected as "OVERLAP in sched" (Issue #105), and a packet
+        # capture of the official app confirms it sends only the real entries.
+        success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
+        if not success:
+            self._clear_optimistic()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_rejected",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        return True
 
 
 class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
@@ -211,74 +227,26 @@ class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
         """Set the end time using exact mobile app format."""
         self._ensure_pool_writable()
         try:
-            self._optimistic_value = value
-            self.async_write_ha_state()
-
-            current_schedules = self._get_schedule_list()
-            if not current_schedules:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                return
-
-            current_schedule = self._get_schedule_data()
-            if current_schedule:
-                current_start_time = self._parse_cron_time(current_schedule.get("startTime", ""))
-                # Only validate a forward, same-day window (see start-time entity).
-                if current_start_time and value > current_start_time:
-                    is_valid, error_msg = self._validate_schedule_overlap(current_start_time, value, self._schedule_id)
-                    if not is_valid:
-                        raise ServiceValidationError(
-                            error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
-                        )
-
-            updated_schedules = []
-            for sched in current_schedules:
-                scheduler = dict(sched)
-                if str(sched.get("id")) == str(self._schedule_id):
-                    scheduler["endTime"] = _replace_cron_time(sched.get("endTime", ""), value)
-
-                component_id = self._get_schedule_component()
-
-                if component_id == 258:
-                    # DM24049704 chlorinator uses a flat groupId=1 + padded CRON.
-                    scheduler = {
-                        "id": sched.get("id"),
-                        "groupId": 1,
-                        "enabled": True,
-                        "startTime": self._format_cron_time_chlorinator(scheduler.get("startTime", "")),
-                        "endTime": self._format_cron_time_chlorinator(scheduler["endTime"]),
-                        "startActions": {"operationName": str(sched.get("startActions", {}).get("operationName", "1"))},
-                    }
-                else:
-                    # Copy the entry verbatim and touch only the time being edited
-                    # (see the start-time entity; Issue #175).
-                    scheduler.setdefault("groupId", sched.get("id"))
-                    scheduler["startTime"] = scheduler.get("startTime", "")
-                    scheduler["endTime"] = scheduler.get("endTime", "")
-                    scheduler.pop("state", None)
-                    scheduler.pop("endActions", None)
-                updated_schedules.append(scheduler)
-
             component_id = self._get_schedule_component()
+            # Compose *and* PUT under one lock per register: a schedule write
+            # replaces the register's whole slot list, so two overlapping edits
+            # each re-sent the other's field from their own pre-write snapshot
+            # — that is how an end time came back holding an old start time
+            # (Issue #210).
+            async with self._api.schedule_write_lock(self._device_id, component_id):
+                if not await self._async_compose_and_write(value, component_id):
+                    return
 
-            # No padding — see the OVERLAP-in-sched note in the slot editor above (Issue #105).
-            success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
-            if not success:
-                self._optimistic_value = None
-                self.async_write_ha_state()
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="schedule_set_rejected",
-                    translation_placeholders={"device_id": self._device_id},
-                )
             await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
             await self.coordinator.async_request_refresh()
-            self._optimistic_value = None
+            # The optimistic value is deliberately NOT dropped here: this
+            # refresh still reads the pre-write list on a device that takes
+            # seconds to confirm. ``_optimistic_or`` releases it when the device
+            # echoes the new time, or after SCHEDULE_WRITE_HOLD_SECONDS.
             self.async_write_ha_state()
 
         except HomeAssistantError:
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise
         except (
             aiohttp.ClientError,
@@ -290,10 +258,73 @@ class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
             AttributeError,
         ) as err:
             _LOGGER.error("Failed to set schedule end time for %s: %s", self._device_id, err)
-            self._optimistic_value = None
-            self.async_write_ha_state()
+            self._clear_optimistic()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="schedule_set_failed",
                 translation_placeholders={"device_id": self._device_id},
             ) from err
+
+    async def _async_compose_and_write(self, value: time, component_id: int) -> bool:
+        """Rewrite this slot's end time in the full list and PUT the register.
+
+        Returns ``False`` when there is no slot to edit; raises when the write is
+        rejected.
+        """
+        current_schedules = self._write_base_schedules(component_id)
+        if not current_schedules:
+            return False
+
+        current_schedule = self._get_schedule_data() or next(
+            (slot for slot in current_schedules if str(slot.get("id")) == str(self._schedule_id)),
+            None,
+        )
+        if current_schedule:
+            current_start_time = self._parse_cron_time(current_schedule.get("startTime", ""))
+            # Only validate a forward, same-day window (see the start-time entity).
+            if current_start_time and value > current_start_time:
+                is_valid, error_msg = self._validate_schedule_overlap(current_start_time, value, self._schedule_id)
+                if not is_valid:
+                    raise ServiceValidationError(
+                        error_msg, translation_domain=DOMAIN, translation_key="schedule_overlap"
+                    )
+
+        # Only now show the new time (see the start-time entity).
+        self._set_optimistic(value)
+
+        updated_schedules = []
+        for sched in current_schedules:
+            scheduler = dict(sched)
+            if str(sched.get("id")) == str(self._schedule_id):
+                scheduler["endTime"] = _replace_cron_time(sched.get("endTime", ""), value)
+
+            if component_id == 258:
+                # DM24049704 chlorinator uses a flat groupId=1 + padded CRON.
+                scheduler = {
+                    "id": sched.get("id"),
+                    "groupId": 1,
+                    "enabled": True,
+                    "startTime": self._format_cron_time_chlorinator(scheduler.get("startTime", "")),
+                    "endTime": self._format_cron_time_chlorinator(scheduler["endTime"]),
+                    "startActions": {"operationName": str(sched.get("startActions", {}).get("operationName", "1"))},
+                }
+            else:
+                # Copy the entry verbatim and touch only the time being edited
+                # (see the start-time entity; Issue #175).
+                scheduler.setdefault("groupId", sched.get("id"))
+                scheduler["startTime"] = scheduler.get("startTime", "")
+                scheduler["endTime"] = scheduler.get("endTime", "")
+                scheduler.pop("state", None)
+                scheduler.pop("endActions", None)
+            updated_schedules.append(scheduler)
+
+        # No padding — see the OVERLAP-in-sched note in the slot editor above (Issue #105).
+        success = await self._api.set_schedule(self._device_id, updated_schedules, component_id=component_id)
+        if not success:
+            self._clear_optimistic()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_set_rejected",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        return True

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -207,6 +207,9 @@
       "brightness": {
         "name": "Brightness"
       },
+      "cabinet_packed_config": {
+        "name": "Packed pump config"
+      },
       "chlorinator_battery_voltage": {
         "name": "Battery Voltage"
       },
@@ -359,6 +362,9 @@
       "cabinet_pump_auto_mode": {
         "name": "Filtration Auto Mode"
       },
+      "cabinet_schedule_enable": {
+        "name": "{output} Schedule {schedule_id}"
+      },
       "chlorinator": {
         "name": "Chlorinator"
       },
@@ -387,6 +393,12 @@
       },
       "aux_schedule_start": {
         "name": "Aux {aux_number} Schedule {schedule_id} Start"
+      },
+      "cabinet_schedule_end": {
+        "name": "{output} Schedule {schedule_id} End"
+      },
+      "cabinet_schedule_start": {
+        "name": "{output} Schedule {schedule_id} Start"
       },
       "light_schedule_end": {
         "name": "Light Schedule {schedule_id} End"
@@ -546,9 +558,17 @@
     "clear_schedule": {
       "description": "Delete all pump schedules",
       "fields": {
+        "component_id": {
+          "description": "Optional schedule register (e.g. 35 pump / 36 lights on Command Connect)",
+          "name": "Component ID"
+        },
         "device_id": {
           "description": "Device identifier (e.g. LE24500883)",
           "name": "Device ID"
+        },
+        "schedule_output": {
+          "description": "Command Connect output: pump (c35) or lights (c36)",
+          "name": "Schedule output"
         }
       },
       "name": "Clear pump schedule"
@@ -570,9 +590,17 @@
     "set_schedule": {
       "description": "Configure the pump schedule",
       "fields": {
+        "component_id": {
+          "description": "Optional schedule register (e.g. 35 pump / 36 lights on Command Connect)",
+          "name": "Component ID"
+        },
         "device_id": {
           "description": "Device identifier (e.g. LE24500883)",
           "name": "Device ID"
+        },
+        "schedule_output": {
+          "description": "Command Connect output: pump (c35) or lights (c36)",
+          "name": "Schedule output"
         },
         "schedules": {
           "description": "List of time slots",

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -207,6 +207,9 @@
       "brightness": {
         "name": "Brillo"
       },
+      "cabinet_packed_config": {
+        "name": "Config. bomba empaquetada"
+      },
       "chlorinator_battery_voltage": {
         "name": "Tensión de la Batería"
       },
@@ -359,6 +362,9 @@
       "cabinet_pump_auto_mode": {
         "name": "Modo automático de filtración"
       },
+      "cabinet_schedule_enable": {
+        "name": "Programación {output} {schedule_id}"
+      },
       "chlorinator": {
         "name": "Clorador"
       },
@@ -387,6 +393,12 @@
       },
       "aux_schedule_start": {
         "name": "Aux {aux_number} Horario {schedule_id} Inicio"
+      },
+      "cabinet_schedule_end": {
+        "name": "Fin programación {output} {schedule_id}"
+      },
+      "cabinet_schedule_start": {
+        "name": "Inicio programación {output} {schedule_id}"
       },
       "light_schedule_end": {
         "name": "Programación Luz {schedule_id} Fin"
@@ -546,9 +558,17 @@
     "clear_schedule": {
       "description": "Eliminar todos los horarios de la bomba",
       "fields": {
+        "component_id": {
+          "description": "Registro de programación opcional (p. ej. 35 bomba / 36 luces en Command Connect)",
+          "name": "ID de componente"
+        },
         "device_id": {
           "description": "Identificador del dispositivo (p. ej. LE24500883)",
           "name": "ID del dispositivo"
+        },
+        "schedule_output": {
+          "description": "Salida Command Connect: pump (c35) o lights (c36)",
+          "name": "Salida de programación"
         }
       },
       "name": "Borrar el horario de la bomba"
@@ -570,9 +590,17 @@
     "set_schedule": {
       "description": "Configurar el horario de la bomba",
       "fields": {
+        "component_id": {
+          "description": "Registro de programación opcional (p. ej. 35 bomba / 36 luces en Command Connect)",
+          "name": "ID de componente"
+        },
         "device_id": {
           "description": "Identificador del dispositivo (p. ej. LE24500883)",
           "name": "ID del dispositivo"
+        },
+        "schedule_output": {
+          "description": "Salida Command Connect: pump (c35) o lights (c36)",
+          "name": "Salida de programación"
         },
         "schedules": {
           "description": "Lista de franjas horarias",

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -207,6 +207,9 @@
       "brightness": {
         "name": "Luminosité"
       },
+      "cabinet_packed_config": {
+        "name": "Config pompe packée"
+      },
       "chlorinator_battery_voltage": {
         "name": "Tension de la Batterie"
       },
@@ -359,6 +362,9 @@
       "cabinet_pump_auto_mode": {
         "name": "Mode auto filtration"
       },
+      "cabinet_schedule_enable": {
+        "name": "Planification {output} {schedule_id}"
+      },
       "chlorinator": {
         "name": "Chlorinateur"
       },
@@ -387,6 +393,12 @@
       },
       "aux_schedule_start": {
         "name": "Aux {aux_number} Planning {schedule_id} Début"
+      },
+      "cabinet_schedule_end": {
+        "name": "Fin planification {output} {schedule_id}"
+      },
+      "cabinet_schedule_start": {
+        "name": "Début planification {output} {schedule_id}"
       },
       "light_schedule_end": {
         "name": "Planning Éclairage {schedule_id} Fin"
@@ -546,9 +558,17 @@
     "clear_schedule": {
       "description": "Supprimer tous les programmes de la pompe",
       "fields": {
+        "component_id": {
+          "description": "Registre de planification optionnel (ex. 35 pompe / 36 lumières sur Command Connect)",
+          "name": "ID composant"
+        },
         "device_id": {
           "description": "Identifiant de l'appareil (par exemple LE24500883)",
           "name": "Identifiant de l'appareil"
+        },
+        "schedule_output": {
+          "description": "Sortie Command Connect : pump (c35) ou lights (c36)",
+          "name": "Sortie planification"
         }
       },
       "name": "Effacer le programme de la pompe"
@@ -570,9 +590,17 @@
     "set_schedule": {
       "description": "Configurer le programme de la pompe",
       "fields": {
+        "component_id": {
+          "description": "Registre de planification optionnel (ex. 35 pompe / 36 lumières sur Command Connect)",
+          "name": "ID composant"
+        },
         "device_id": {
           "description": "Identifiant de l'appareil (par exemple LE24500883)",
           "name": "Identifiant de l'appareil"
+        },
+        "schedule_output": {
+          "description": "Sortie Command Connect : pump (c35) ou lights (c36)",
+          "name": "Sortie planification"
         },
         "schedules": {
           "description": "Liste des créneaux horaires",

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -207,6 +207,9 @@
       "brightness": {
         "name": "Brilho"
       },
+      "cabinet_packed_config": {
+        "name": "Config. bomba empacotada"
+      },
       "chlorinator_battery_voltage": {
         "name": "Tensão da Bateria"
       },
@@ -359,6 +362,9 @@
       "cabinet_pump_auto_mode": {
         "name": "Modo automático da filtração"
       },
+      "cabinet_schedule_enable": {
+        "name": "Agendamento {output} {schedule_id}"
+      },
       "chlorinator": {
         "name": "Clorador"
       },
@@ -387,6 +393,12 @@
       },
       "aux_schedule_start": {
         "name": "Aux {aux_number} Horário {schedule_id} Início"
+      },
+      "cabinet_schedule_end": {
+        "name": "Fim agendamento {output} {schedule_id}"
+      },
+      "cabinet_schedule_start": {
+        "name": "Início agendamento {output} {schedule_id}"
       },
       "light_schedule_end": {
         "name": "Programação Luz {schedule_id} Fim"
@@ -546,9 +558,17 @@
     "clear_schedule": {
       "description": "Eliminar todos os programas da bomba",
       "fields": {
+        "component_id": {
+          "description": "Registo de agendamento opcional (ex. 35 bomba / 36 luzes no Command Connect)",
+          "name": "ID do componente"
+        },
         "device_id": {
           "description": "Identificador do dispositivo (por ex. LE24500883)",
           "name": "ID do dispositivo"
+        },
+        "schedule_output": {
+          "description": "Saída Command Connect: pump (c35) ou lights (c36)",
+          "name": "Saída de agendamento"
         }
       },
       "name": "Limpar o programa da bomba"
@@ -570,9 +590,17 @@
     "set_schedule": {
       "description": "Configurar o programa da bomba",
       "fields": {
+        "component_id": {
+          "description": "Registo de agendamento opcional (ex. 35 bomba / 36 luzes no Command Connect)",
+          "name": "ID do componente"
+        },
         "device_id": {
           "description": "Identificador do dispositivo (por ex. LE24500883)",
           "name": "ID do dispositivo"
+        },
+        "schedule_output": {
+          "description": "Saída Command Connect: pump (c35) ou lights (c36)",
+          "name": "Saída de agendamento"
         },
         "schedules": {
           "description": "Lista de períodos horários",

--- a/custom_components/fluidra_pool/write_verification.py
+++ b/custom_components/fluidra_pool/write_verification.py
@@ -66,7 +66,21 @@ def normalize_component_value(value: Any) -> Any:
     strings and the cloud reports them back as numbers, and integers come back
     as floats on some registers. Numeric-looking values are therefore compared
     as floats, everything else as-is (strings stripped).
+
+    Schedule lists are normalised through ``schedule_slots_for_write`` so a
+    reported slot that still carries runtime ``state`` / ``endActions`` compares
+    equal to the write body that deliberately omitted them (Issue #210).
     """
+    if isinstance(value, list):
+        # Empty clear (`[]`) and CRON slot lists both go through the same
+        # write-shape normaliser; non-schedule lists fall through unchanged.
+        if not value:
+            return []
+        if all(isinstance(item, dict) for item in value):
+            from .helpers import schedule_slots_for_write
+
+            return schedule_slots_for_write(value)
+        return value
     if isinstance(value, bool):
         return float(value)
     if isinstance(value, (int, float)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ import pytest
 from custom_components.fluidra_pool.fluidra_api import FluidraPoolAPI
 from custom_components.fluidra_pool.write_verification import WriteVerifier
 
+from .schedule_write_stubs import install_schedule_write_stubs
+
 
 @pytest.fixture(autouse=True)
 def enable_custom_integrations(request: pytest.FixtureRequest) -> None:
@@ -25,6 +27,7 @@ def enable_custom_integrations(request: pytest.FixtureRequest) -> None:
 def mock_api() -> AsyncMock:
     """Create a mock FluidraPoolAPI."""
     api = AsyncMock(spec=FluidraPoolAPI)
+    install_schedule_write_stubs(api)
     # Instance attributes are invisible to spec= (the class is not slotted);
     # wire the ones production code reads directly.
     api.access_token = "test-access-token"

--- a/tests/schedule_write_stubs.py
+++ b/tests/schedule_write_stubs.py
@@ -1,0 +1,34 @@
+"""Fake API surface for the schedule write path.
+
+A schedule write serialises compose-and-PUT on a per-register lock and composes
+from the list last PUT rather than the poll cache (Issue #210). Test doubles need
+both, and need them typed: a bare mock hands back a truthy ``MagicMock`` that the
+write path would treat as a slot list, and a ``MagicMock`` cannot be used as an
+``async with`` target.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def install_schedule_write_stubs(api: Any) -> None:
+    """Give ``api`` a working ``schedule_write_lock`` / ``pending_schedule_slots``."""
+    locks: dict[tuple[str, int], asyncio.Lock] = {}
+
+    def _lock(device_id: str, component_id: int) -> asyncio.Lock:
+        return locks.setdefault((str(device_id), int(component_id)), asyncio.Lock())
+
+    api.schedule_write_lock = MagicMock(side_effect=_lock)
+    api.pending_schedule_slots = MagicMock(return_value=None)
+    api.discard_pending_schedule = MagicMock()
+
+
+def schedule_api(**attrs: Any) -> SimpleNamespace:
+    """Return a fake API carrying ``attrs`` plus the schedule-write surface."""
+    api = SimpleNamespace(**attrs)
+    install_schedule_write_stubs(api)
+    return api

--- a/tests/test_aux_schedule.py
+++ b/tests/test_aux_schedule.py
@@ -21,6 +21,8 @@ from custom_components.fluidra_pool.time.aux_schedule import (
     FluidraAuxScheduleStartTimeEntity,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "NS25007212"
 
@@ -84,7 +86,7 @@ def _attach_ha(entity) -> None:
 
 
 def _api(*, success: bool = True) -> SimpleNamespace:
-    return SimpleNamespace(set_schedule=AsyncMock(return_value=success))
+    return schedule_api(set_schedule=AsyncMock(return_value=success))
 
 
 AUX1_SCHEDULE = {
@@ -289,7 +291,7 @@ async def test_aux_schedule_set_value_raises_on_connection_error() -> None:
     from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
 
     device = _aux_device({"1": [dict(AUX1_SCHEDULE)]})
-    api = SimpleNamespace(set_schedule=AsyncMock(side_effect=FluidraConnectionError("net down")))
+    api = schedule_api(set_schedule=AsyncMock(side_effect=FluidraConnectionError("net down")))
     start = FluidraAuxScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
     end = FluidraAuxScheduleEndTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "1", "1")
     _attach_ha(start)

--- a/tests/test_cabinet_schedule.py
+++ b/tests/test_cabinet_schedule.py
@@ -30,6 +30,8 @@ from custom_components.fluidra_pool.write_verification import (
     normalize_component_value,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "QR24xxxx.ndsr_1"
 
@@ -123,7 +125,7 @@ def _attach_ha(entity) -> None:
 
 
 def _api(*, success: bool = True) -> SimpleNamespace:
-    return SimpleNamespace(set_schedule=AsyncMock(return_value=success))
+    return schedule_api(set_schedule=AsyncMock(return_value=success))
 
 
 # --- profile / helpers ----------------------------------------------------

--- a/tests/test_cabinet_schedule.py
+++ b/tests/test_cabinet_schedule.py
@@ -1,0 +1,361 @@
+"""Tests for Command Connect cabinet schedules (c35 pump / c36 lights, Issue #210)."""
+
+from __future__ import annotations
+
+from datetime import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS, DeviceIdentifier
+from custom_components.fluidra_pool.helpers import (
+    CABINET_SCHEDULE_ALL_DAYS,
+    build_cabinet_schedule_slot,
+    get_cabinet_schedule_data,
+    resolve_cabinet_schedule_component,
+    schedule_slots_for_write,
+)
+from custom_components.fluidra_pool.switch.schedule import FluidraScheduleEnableSwitch
+from custom_components.fluidra_pool.time.cabinet_schedule import (
+    FluidraCabinetScheduleEndTimeEntity,
+    FluidraCabinetScheduleStartTimeEntity,
+)
+from custom_components.fluidra_pool.write_verification import (
+    VERDICT_LOST,
+    VERDICT_VERIFIED,
+    WriteVerifier,
+    normalize_component_value,
+)
+
+POOL_ID = "pool-1"
+DEVICE_ID = "QR24xxxx.ndsr_1"
+
+CABINET_SCHEDULE_COMPONENTS = {"pump": 35, "lights": 36}
+
+PUMP_SCHEDULE = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "state": "RUNNING",
+    "startTime": "15 10 * * 0,1,2,3,4,5,6",
+    "endTime": "30 18 * * 0,1,2,3,4,5,6",
+    "startActions": {"operationName": "1"},
+}
+
+LIGHTS_SCHEDULE = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "state": "IDLE",
+    "startTime": "25 18 * * 0,1,2,3,4,5,6",
+    "endTime": "00 22 * * 0,1,2,3,4,5,6",
+    "startActions": {"operationName": "1"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _skip_sleeps() -> Any:
+    """Skip confirmation delays so tests don't wait."""
+    with patch("custom_components.fluidra_pool.time.cabinet_schedule.asyncio.sleep", new=AsyncMock()):
+        yield
+
+
+def _identify_cache() -> dict:
+    return {
+        "_identify_cache": {
+            "key": (DEVICE_ID, "Cabinets", "Command Connect", "cabinet", ""),
+            "config": SimpleNamespace(
+                device_type="cabinet",
+                features={
+                    "cabinet_schedule_components": CABINET_SCHEDULE_COMPONENTS,
+                    "cabinet_schedule_count": 1,
+                    "cabinet_packed_config": 16,
+                    "schedule_local_time": True,
+                    "schedule_armed_window": True,
+                    "boolean_writes": True,
+                },
+                components_range=40,
+                required_components=[13, 24],
+                entities=["switch"],
+            ),
+        },
+    }
+
+
+def _cabinet_device(schedules: dict[str, list[dict]] | None = None) -> dict[str, Any]:
+    device: dict[str, Any] = {
+        "device_id": DEVICE_ID,
+        "name": "Command Connect",
+        "family": "Cabinets",
+        "model": "Command Connect",
+        "type": "cabinet",
+        "online": True,
+        "components": {
+            "13": {"reportedValue": False},
+            "15": {"reportedValue": True},
+            "16": {"reportedValue": "01101518301270101"},
+            "24": {"reportedValue": True},
+            "26": {"reportedValue": False},
+            "35": {"reportedValue": [PUMP_SCHEDULE]},
+            "36": {"reportedValue": [LIGHTS_SCHEDULE]},
+        },
+        **_identify_cache(),
+    }
+    if schedules is not None:
+        device["cabinet_schedule_data"] = schedules
+    return device
+
+
+def _coord(device: dict) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _attach_ha(entity) -> None:
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+
+def _api(*, success: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(set_schedule=AsyncMock(return_value=success))
+
+
+# --- profile / helpers ----------------------------------------------------
+
+
+def test_cabinet_profile_declares_schedule_registers() -> None:
+    features = DEVICE_CONFIGS["command_connect_cabinet"].features
+    assert features["cabinet_schedule_components"] == CABINET_SCHEDULE_COMPONENTS
+    assert features["cabinet_schedule_count"] == 1
+    assert features["cabinet_packed_config"] == 16
+    assert features["schedule_local_time"] is True
+    assert features["schedule_armed_window"] is True
+    for component in (35, 36, 16):
+        assert component in features["specific_components"]
+
+
+def test_build_cabinet_schedule_slot_matches_capture() -> None:
+    """Exact write shape from @efgonzalez — no state, local CRON, days 0-6."""
+    slot = build_cabinet_schedule_slot(1, time(10, 15), time(18, 30))
+    assert slot == {
+        "id": 1,
+        "groupId": 1,
+        "enabled": True,
+        "startTime": "15 10 * * 0,1,2,3,4,5,6",
+        "endTime": "30 18 * * 0,1,2,3,4,5,6",
+        "startActions": {"operationName": "1"},
+    }
+    assert "state" not in slot
+    assert CABINET_SCHEDULE_ALL_DAYS in slot["startTime"]
+
+
+def test_schedule_slots_for_write_strips_state() -> None:
+    normalised = schedule_slots_for_write([PUMP_SCHEDULE])
+    assert "state" not in normalised[0]
+    assert normalised[0]["startTime"] == PUMP_SCHEDULE["startTime"]
+
+
+def test_get_and_resolve_cabinet_schedule() -> None:
+    device = _cabinet_device({"pump": [PUMP_SCHEDULE], "lights": [LIGHTS_SCHEDULE]})
+    assert get_cabinet_schedule_data(device, "pump", 1) == PUMP_SCHEDULE
+    assert get_cabinet_schedule_data(device, "lights", "1") == LIGHTS_SCHEDULE
+    assert get_cabinet_schedule_data(device, "pump", 99) is None
+    assert resolve_cabinet_schedule_component(device, "pump") == 35
+    assert resolve_cabinet_schedule_component(device, "lights") == 36
+
+
+# --- coordinator parsing --------------------------------------------------
+
+
+def test_coordinator_parses_cabinet_schedule_registers() -> None:
+    device = _cabinet_device(None)
+    # Drop the pre-seeded cache schedules path; exercise the decoder.
+    device.pop("cabinet_schedule_data", None)
+
+    from custom_components.fluidra_pool.coordinator.coordinator import (
+        FluidraDataUpdateCoordinator as _Coord,
+    )
+
+    coord = _Coord.__new__(_Coord)
+    coord._track_schedule_count = MagicMock()
+    coord._process_component_state(device, POOL_ID, 35, {"reportedValue": [PUMP_SCHEDULE]})
+    coord._process_component_state(device, POOL_ID, 36, {"reportedValue": [LIGHTS_SCHEDULE]})
+    assert device["cabinet_schedule_data"]["pump"] == [PUMP_SCHEDULE]
+    assert device["cabinet_schedule_data"]["lights"] == [LIGHTS_SCHEDULE]
+
+    coord._apply_resolved_cabinet_schedules(device)
+    assert device["cabinet_schedule_components_resolved"] == {"pump": 35, "lights": 36}
+
+
+# --- time entities --------------------------------------------------------
+
+
+def test_cabinet_schedule_start_native_value() -> None:
+    device = _cabinet_device({"pump": [PUMP_SCHEDULE]})
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "pump", "1")
+    assert entity.native_value == time(10, 15)
+    assert entity.extra_state_attributes["schedule_semantics"] == "armed_window"
+    assert entity.extra_state_attributes["schedule_local_time"] is True
+
+
+def test_cabinet_schedule_end_native_value() -> None:
+    device = _cabinet_device({"lights": [LIGHTS_SCHEDULE]})
+    entity = FluidraCabinetScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "lights", "1")
+    assert entity.native_value == time(22, 0)
+
+
+def test_cabinet_schedule_available_when_empty() -> None:
+    device = _cabinet_device({"pump": []})
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, DEVICE_ID, "pump", "1")
+    assert entity.available is True
+    assert entity.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_cabinet_schedule_start_writes_pump_component_without_state() -> None:
+    device = _cabinet_device({"pump": [PUMP_SCHEDULE]})
+    api = _api()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "pump", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(11, 0))
+
+    api.set_schedule.assert_awaited_once()
+    args, kwargs = api.set_schedule.await_args
+    assert args[0] == DEVICE_ID
+    assert kwargs["component_id"] == 35
+    sent = args[1]
+    assert len(sent) == 1
+    assert "state" not in sent[0]
+    assert sent[0]["startTime"].startswith("0 11")
+    assert "0,1,2,3,4,5,6" in sent[0]["startTime"]
+    assert sent[0]["endTime"] == PUMP_SCHEDULE["endTime"]
+
+
+@pytest.mark.asyncio
+async def test_cabinet_schedule_end_writes_lights_component() -> None:
+    device = _cabinet_device({"lights": [LIGHTS_SCHEDULE]})
+    api = _api()
+    entity = FluidraCabinetScheduleEndTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(23, 0))
+
+    args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 36
+    assert "state" not in args[1][0]
+    assert args[1][0]["endTime"].startswith("0 23")
+
+
+@pytest.mark.asyncio
+async def test_cabinet_schedule_seeds_slot_when_empty() -> None:
+    device = _cabinet_device({"pump": []})
+    api = _api()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "pump", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(10, 15))
+
+    sent = api.set_schedule.await_args.args[1]
+    assert sent == [build_cabinet_schedule_slot(1, time(10, 15), time(11, 15), enabled=True)]
+
+
+@pytest.mark.asyncio
+async def test_cabinet_schedule_set_raises_on_api_failure() -> None:
+    device = _cabinet_device({"pump": [PUMP_SCHEDULE]})
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), _api(success=False), POOL_ID, DEVICE_ID, "pump", "1")
+    _attach_ha(entity)
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_value(time(9, 0))
+
+
+# --- enable switch --------------------------------------------------------
+
+
+def test_cabinet_enable_switch_is_on() -> None:
+    device = _cabinet_device({"pump": [PUMP_SCHEDULE]})
+    switch = FluidraScheduleEnableSwitch(_coord(device), _api(), POOL_ID, DEVICE_ID, "1", cabinet_output="pump")
+    assert switch.is_on is True
+    assert switch.unique_id.endswith("cabinet_pump_schedule_1_enabled")
+    assert switch.extra_state_attributes["schedule_semantics"] == "armed_window"
+
+
+@pytest.mark.asyncio
+async def test_cabinet_enable_switch_turn_off_strips_state() -> None:
+    device = _cabinet_device({"lights": [LIGHTS_SCHEDULE]})
+    api = _api()
+    switch = FluidraScheduleEnableSwitch(_coord(device), api, POOL_ID, DEVICE_ID, "1", cabinet_output="lights")
+    _attach_ha(switch)
+
+    await switch.async_turn_off()
+
+    args, kwargs = api.set_schedule.await_args
+    assert kwargs["component_id"] == 36
+    assert args[1][0]["enabled"] is False
+    assert "state" not in args[1][0]
+
+
+# --- entity setup ---------------------------------------------------------
+
+
+def test_cabinet_schedule_entities_created_for_profile() -> None:
+    from custom_components.fluidra_pool.time import __init__ as time_platform
+    from custom_components.fluidra_pool.time import async_setup_entry as _unused  # noqa: F401
+
+    # Replicate the builder logic used by async_setup_entry.
+    device = {
+        "device_id": DEVICE_ID,
+        "family": "Cabinets",
+        "name": "Command Connect",
+        "type": "cabinet",
+    }
+    config = DeviceIdentifier.identify_device(device)
+    assert config is DEVICE_CONFIGS["command_connect_cabinet"]
+
+    components = DeviceIdentifier.get_feature(device, "cabinet_schedule_components", {})
+    count = DeviceIdentifier.get_feature(device, "cabinet_schedule_count", 1)
+    expected = len(components) * count * 2  # start + end
+    assert expected == 4
+    assert "pump" in components
+    assert "lights" in components
+    # Silence unused import lint for the platform module touch.
+    assert time_platform is not None
+
+
+# --- write verification for schedule lists --------------------------------
+
+
+def test_normalize_strips_state_for_schedule_list_compare() -> None:
+    reported = [PUMP_SCHEDULE]
+    desired = schedule_slots_for_write([PUMP_SCHEDULE])
+    assert normalize_component_value(reported) == normalize_component_value(desired)
+
+
+def test_write_verifier_verifies_schedule_list_round_trip() -> None:
+    verifier = WriteVerifier()
+    desired = schedule_slots_for_write([PUMP_SCHEDULE])
+    verifier.record(DEVICE_ID, 35, desired, baseline=[])
+    pending = next(iter(verifier._pending.values()))
+    # Device echoes the slot back with a runtime state field.
+    assert verifier.resolve(pending, [PUMP_SCHEDULE]) == VERDICT_VERIFIED
+
+
+def test_write_verifier_detects_lost_schedule_clear() -> None:
+    verifier = WriteVerifier()
+    baseline = [PUMP_SCHEDULE]
+    verifier.record(DEVICE_ID, 35, [], baseline=baseline)
+    pending = next(iter(verifier._pending.values()))
+    assert verifier.resolve(pending, baseline) == VERDICT_LOST
+
+
+def test_write_verifier_verifies_empty_clear() -> None:
+    verifier = WriteVerifier()
+    verifier.record(DEVICE_ID, 36, [], baseline=[LIGHTS_SCHEDULE])
+    pending = next(iter(verifier._pending.values()))
+    assert verifier.resolve(pending, []) == VERDICT_VERIFIED

--- a/tests/test_entity_error_paths.py
+++ b/tests/test_entity_error_paths.py
@@ -44,6 +44,8 @@ from custom_components.fluidra_pool.time.schedule import (
     FluidraScheduleStartTimeEntity,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "LE24500883"
 
@@ -70,7 +72,7 @@ def _api(**overrides: Any) -> SimpleNamespace:
         "set_schedule": AsyncMock(return_value=True),
     }
     defaults.update(overrides)
-    return SimpleNamespace(**defaults)
+    return schedule_api(**defaults)
 
 
 def _attach_ha(entity) -> None:
@@ -794,17 +796,20 @@ async def test_schedule_end_returns_false_raises_clears_optimistic() -> None:
     assert entity._optimistic_value is None
 
 
-async def test_schedule_start_success_clears_optimistic_and_refreshes() -> None:
+async def test_schedule_start_success_holds_optimistic_and_refreshes() -> None:
+    # The post-write refresh reads a device that has not confirmed yet, so the
+    # optimistic value must survive it — clearing here snapped the field back to
+    # the old time and made testers retry into a write race (Issue #210).
     entity, coordinator = _start_time()
     await entity.async_set_value(time(7, 0))
-    assert entity._optimistic_value is None
+    assert entity._optimistic_value == time(7, 0)
     coordinator.async_request_refresh.assert_awaited()
 
 
-async def test_schedule_end_success_clears_optimistic_and_refreshes() -> None:
+async def test_schedule_end_success_holds_optimistic_and_refreshes() -> None:
     entity, coordinator = _end_time()
     await entity.async_set_value(time(20, 0))
-    assert entity._optimistic_value is None
+    assert entity._optimistic_value == time(20, 0)
     coordinator.async_request_refresh.assert_awaited()
 
 

--- a/tests/test_new_device_support.py
+++ b/tests/test_new_device_support.py
@@ -163,8 +163,16 @@ class TestCabinetProfile:
     def test_boolean_writes_feature_declared(self) -> None:
         features = DEVICE_CONFIGS["command_connect_cabinet"].features
         assert features["boolean_writes"] is True
-        for component in (13, 15, 24, 26):
+        for component in (13, 15, 16, 24, 26, 35, 36):
             assert component in features["specific_components"]
+
+    def test_schedule_registers_declared(self) -> None:
+        features = DEVICE_CONFIGS["command_connect_cabinet"].features
+        assert features["cabinet_schedule_components"] == {"pump": 35, "lights": 36}
+        assert features["cabinet_schedule_count"] == 1
+        assert features["cabinet_packed_config"] == 16
+        assert features["schedule_armed_window"] is True
+        assert features["schedule_local_time"] is True
 
     def test_four_toggles_declared(self) -> None:
         toggles = DEVICE_CONFIGS["command_connect_cabinet"].features["toggle_switches"]
@@ -325,7 +333,7 @@ async def _run_platform_setup(platform: Any, devices: list[dict[str, Any]]) -> l
     return added
 
 
-async def test_cabinet_setup_creates_four_switches() -> None:
+async def test_cabinet_setup_creates_toggles_and_schedule_enables() -> None:
     from custom_components.fluidra_pool.switch import async_setup_entry as switch_setup
 
     device = _cabinet_device()
@@ -336,7 +344,32 @@ async def test_cabinet_setup_creates_four_switches() -> None:
         "cabinet_lights_auto_mode",
         "cabinet_pump",
         "cabinet_pump_auto_mode",
+        "cabinet_schedule_enable",
+        "cabinet_schedule_enable",
     ]
+
+
+async def test_cabinet_setup_creates_schedule_time_entities() -> None:
+    from custom_components.fluidra_pool.time import async_setup_entry as time_setup
+
+    device = _cabinet_device()
+    entities = await _run_platform_setup(SimpleNamespace(async_setup_entry=time_setup), [device])
+    keys = sorted(e._attr_translation_key for e in entities)
+    assert keys == [
+        "cabinet_schedule_end",
+        "cabinet_schedule_end",
+        "cabinet_schedule_start",
+        "cabinet_schedule_start",
+    ]
+
+
+async def test_cabinet_setup_creates_packed_config_sensor() -> None:
+    from custom_components.fluidra_pool.sensor import async_setup_entry as sensor_setup
+
+    device = _cabinet_device()
+    entities = await _run_platform_setup(SimpleNamespace(async_setup_entry=sensor_setup), [device])
+    keys = [e._attr_translation_key for e in entities]
+    assert "cabinet_packed_config" in keys
 
 
 async def test_robot_setup_creates_battery_and_schedule_days() -> None:

--- a/tests/test_schedule_write_race.py
+++ b/tests/test_schedule_write_race.py
@@ -1,0 +1,311 @@
+"""Regression tests for the schedule write race reported on Issue #210.
+
+@efgonzalez edited a Command Connect lights start time on real hardware, watched
+the field snap back to the old value, retried a few times, and ended up with
+``endTime`` holding the *old* ``startTime`` — an inverted window on the wire.
+
+Two defects produce that, and both are covered here:
+
+* the edited value was dropped ``COMMAND_CONFIRMATION_DELAY`` (3 s) after the
+  PUT, while the cabinet takes 5-10 s to report the change back, so the UI
+  necessarily showed the pre-write value again and invited a retry;
+* every write recomposed the register's whole slot list from the poll cache,
+  which still holds the pre-write list during that window, so the retry re-sent
+  a stale value for the field it was not editing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from datetime import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.fluidra_pool.const import SCHEDULE_WRITE_HOLD_SECONDS
+from custom_components.fluidra_pool.fluidra_api import FluidraPoolAPI
+from custom_components.fluidra_pool.time.cabinet_schedule import (
+    FluidraCabinetScheduleEndTimeEntity,
+    FluidraCabinetScheduleStartTimeEntity,
+)
+
+POOL_ID = "pool-1"
+DEVICE_ID = "QR24xxxx.ndsr_1"
+
+# The lights slot exactly as captured before the failing test (c36, one slot).
+LIGHTS_SLOT: dict[str, Any] = {
+    "id": 1,
+    "groupId": 1,
+    "state": "IDLE",
+    "enabled": True,
+    "startTime": "15 19 * * 0,1,2,3,4,5,6",
+    "endTime": "30 22 * * 0,1,2,3,4,5,6",
+    "startActions": {"operationName": "1"},
+}
+
+
+def _make_api(status: int = 200) -> FluidraPoolAPI:
+    """A real API object with only the request/auth layer mocked."""
+    api = FluidraPoolAPI("a@b.c", "pw")
+    api.access_token = "tok"
+    api.ensure_valid_token = AsyncMock(return_value=True)
+    api._build_auth_headers = MagicMock(return_value={"Authorization": "Bearer tok"})
+    api._request = AsyncMock(return_value=(status, {}, ""))
+    return api
+
+
+def _identify_cache() -> dict[str, Any]:
+    return {
+        "_identify_cache": {
+            "key": (DEVICE_ID, "Cabinets", "Command Connect", "cabinet", ""),
+            "config": SimpleNamespace(
+                device_type="cabinet",
+                features={"cabinet_schedule_components": {"pump": 35, "lights": 36}},
+            ),
+        }
+    }
+
+
+def _device(slots: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "device_id": DEVICE_ID,
+        "name": "Command Connect",
+        "family": "Cabinets",
+        "model": "Command Connect",
+        "type": "cabinet",
+        "online": True,
+        "components": {"36": {"reportedValue": copy.deepcopy(slots)}},
+        "cabinet_schedule_data": {"lights": copy.deepcopy(slots)},
+        **_identify_cache(),
+    }
+
+
+def _coord(device: dict[str, Any]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _attach_ha(entity: Any) -> None:
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _skip_sleep() -> Any:
+    """Skip the post-write confirmation delay."""
+    with patch("custom_components.fluidra_pool.time.cabinet_schedule.asyncio.sleep", new=AsyncMock()):
+        yield
+
+
+# --- API layer: the list we last PUT is the base for the next write --------
+
+
+@pytest.mark.asyncio
+async def test_pending_schedule_slots_holds_the_last_write() -> None:
+    """After a successful PUT, the next write composes on what we sent."""
+    api = _make_api()
+
+    assert api.pending_schedule_slots(DEVICE_ID, 36) is None
+    assert await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36) is True
+
+    pending = api.pending_schedule_slots(DEVICE_ID, 36)
+    assert pending is not None
+    # Stored in write shape: the runtime "state" field never goes back out.
+    assert "state" not in pending[0]
+    assert pending[0]["startTime"] == LIGHTS_SLOT["startTime"]
+
+
+@pytest.mark.asyncio
+async def test_pending_schedule_slots_released_once_the_device_echoes() -> None:
+    """The poll cache becomes authoritative again as soon as it agrees."""
+    api = _make_api()
+    await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36)
+
+    echoed = [{k: v for k, v in LIGHTS_SLOT.items() if k != "state"}]
+    api.get_device_by_id = MagicMock(return_value={"components": {"36": {"reportedValue": echoed}}})
+
+    assert api.pending_schedule_slots(DEVICE_ID, 36) is None
+
+
+@pytest.mark.asyncio
+async def test_pending_schedule_slots_expires_so_the_app_is_never_masked() -> None:
+    """A change made in the Fluidra app wins once the hold elapses."""
+    api = _make_api()
+    await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36)
+
+    pending = api._pending_schedule_writes[(DEVICE_ID, 36)]
+    pending.expires_at -= SCHEDULE_WRITE_HOLD_SECONDS + 1
+
+    assert api.pending_schedule_slots(DEVICE_ID, 36) is None
+
+
+@pytest.mark.asyncio
+async def test_rejected_write_leaves_no_composition_base() -> None:
+    """A refused PUT must not become the base for the next edit."""
+    api = _make_api(status=422)
+    assert await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36) is False
+    assert api.pending_schedule_slots(DEVICE_ID, 36) is None
+
+
+# --- entity layer: two edits in a row must not undo each other ------------
+
+
+class _Suspend:
+    """A real suspension point.
+
+    ``asyncio.sleep`` is patched out for these tests (it is the same module
+    object the production code imports), so a fake that awaited it would never
+    actually yield and the interleaving under test could not happen.
+    """
+
+    def __await__(self) -> Any:
+        yield
+
+
+class _FrozenCloud:
+    """A cloud whose poll cache does not move until the device confirms.
+
+    That is the real behaviour measured on Issue #210 (5-10 s), and it is the
+    condition under which the corruption happened: composing from that cache
+    re-sends the pre-write value for every field the current edit does not touch.
+    """
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[int, list[dict[str, Any]]]] = []
+        self.order: list[str] = []
+        self._locks: dict[tuple[str, int], asyncio.Lock] = {}
+        self._pending: dict[tuple[str, int], list[dict[str, Any]]] = {}
+
+    def schedule_write_lock(self, device_id: str, component_id: int) -> asyncio.Lock:
+        return self._locks.setdefault((str(device_id), int(component_id)), asyncio.Lock())
+
+    def pending_schedule_slots(self, device_id: str, component_id: int) -> list[dict[str, Any]] | None:
+        return copy.deepcopy(self._pending.get((str(device_id), int(component_id))))
+
+    def discard_pending_schedule(self, device_id: str, component_id: int) -> None:
+        self._pending.pop((str(device_id), int(component_id)), None)
+
+    async def set_schedule(self, device_id: str, schedules: list[dict[str, Any]], component_id: int) -> bool:
+        self.order.append(f"put-{len(self.writes)}-in")
+        await _Suspend()  # let a concurrent writer interleave if it can
+        self.writes.append((int(component_id), copy.deepcopy(schedules)))
+        self._pending[(str(device_id), int(component_id))] = copy.deepcopy(schedules)
+        self.order.append(f"put-{len(self.writes) - 1}-out")
+        return True
+
+
+@pytest.mark.asyncio
+async def test_second_edit_does_not_revert_the_first() -> None:
+    """Editing start then end must not send the pre-write start back."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    coord = _coord(device)
+
+    start = FluidraCabinetScheduleStartTimeEntity(coord, api, POOL_ID, DEVICE_ID, "lights", "1")
+    end = FluidraCabinetScheduleEndTimeEntity(coord, api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(start)
+    _attach_ha(end)
+
+    await start.async_set_value(time(19, 30))
+    await end.async_set_value(time(23, 0))
+
+    assert len(api.writes) == 2
+    last_component, last_slots = api.writes[-1]
+    assert last_component == 36
+    # The end edit carries the start time the first write set — not "15 19".
+    assert last_slots[0]["startTime"].startswith("30 19")
+    assert last_slots[0]["endTime"].startswith("0 23")
+
+
+@pytest.mark.asyncio
+async def test_repeated_edits_never_reinstate_the_old_value() -> None:
+    """The revert-retry loop that corrupted the wire, replayed."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(entity)
+
+    for value in (time(19, 30), time(19, 30), time(19, 45)):
+        await entity.async_set_value(value)
+
+    for _, slots in api.writes:
+        # The end time is the only field these edits must never touch.
+        assert slots[0]["endTime"] == LIGHTS_SLOT["endTime"]
+    assert api.writes[-1][1][0]["startTime"].startswith("45 19")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_edits_on_one_scheduler_are_serialised() -> None:
+    """Two writes fired at once must follow each other, not interleave."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    coord = _coord(device)
+
+    start = FluidraCabinetScheduleStartTimeEntity(coord, api, POOL_ID, DEVICE_ID, "lights", "1")
+    end = FluidraCabinetScheduleEndTimeEntity(coord, api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(start)
+    _attach_ha(end)
+
+    await asyncio.gather(
+        start.async_set_value(time(19, 30)),
+        end.async_set_value(time(23, 0)),
+    )
+
+    assert api.order == ["put-0-in", "put-0-out", "put-1-in", "put-1-out"]
+    final = api.writes[-1][1][0]
+    assert final["startTime"].startswith("30 19")
+    assert final["endTime"].startswith("0 23")
+
+
+# --- entity layer: the edit must stay on screen until the device agrees ---
+
+
+@pytest.mark.asyncio
+async def test_edited_time_survives_the_post_write_refresh() -> None:
+    """The refresh 3 s after the PUT reads a device that has not confirmed."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+
+    # The poll cache still holds 19:15 — the field must not snap back to it.
+    assert device["cabinet_schedule_data"]["lights"][0]["startTime"] == "15 19 * * 0,1,2,3,4,5,6"
+    assert entity.native_value == time(19, 30)
+
+
+@pytest.mark.asyncio
+async def test_edited_time_released_when_the_device_reports_it() -> None:
+    """Once the poll agrees, the device is authoritative again."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+    device["cabinet_schedule_data"]["lights"][0]["startTime"] = "30 19 * * 0,1,2,3,4,5,6"
+
+    assert entity.native_value == time(19, 30)
+    assert entity._optimistic_value is None
+
+
+@pytest.mark.asyncio
+async def test_edited_time_released_after_the_hold_expires() -> None:
+    """A write the device never takes must stop lying to the user."""
+    device = _device([LIGHTS_SLOT])
+    api = _FrozenCloud()
+    entity = FluidraCabinetScheduleStartTimeEntity(_coord(device), api, POOL_ID, DEVICE_ID, "lights", "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+    entity._optimistic_until -= SCHEDULE_WRITE_HOLD_SECONDS + 1
+
+    assert entity.native_value == time(19, 15)
+    assert entity._optimistic_value is None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -17,6 +17,8 @@ from custom_components.fluidra_pool.switch import (
     async_setup_entry,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "LE24500883"
 
@@ -42,7 +44,7 @@ def _api(**overrides: Any) -> SimpleNamespace:
         "set_schedule": AsyncMock(return_value=True),
     }
     defaults.update(overrides)
-    return SimpleNamespace(**defaults)
+    return schedule_api(**defaults)
 
 
 def _attach_ha(switch) -> None:

--- a/tests/test_switch_pump_schedule_cov.py
+++ b/tests/test_switch_pump_schedule_cov.py
@@ -38,6 +38,8 @@ from custom_components.fluidra_pool.switch import (
     FluidraScheduleEnableSwitch,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "LE24500883"
 
@@ -62,7 +64,7 @@ def _api(**overrides: Any) -> SimpleNamespace:
         "set_schedule": AsyncMock(return_value=True),
     }
     defaults.update(overrides)
-    return SimpleNamespace(**defaults)
+    return schedule_api(**defaults)
 
 
 def _attach_ha(entity) -> None:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -16,6 +16,8 @@ from custom_components.fluidra_pool.time import (
     parse_schedule_time,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 DEVICE_ID = "TEST-PUMP-001"
 
@@ -115,7 +117,7 @@ def test_schedule_start_native_value_parses_cron_string() -> None:
     """Start time is decoded from the CRON minute/hour fields."""
     entity = FluidraScheduleStartTimeEntity(
         _coord([SCHEDULE]),
-        SimpleNamespace(set_schedule=AsyncMock(return_value=True)),
+        schedule_api(set_schedule=AsyncMock(return_value=True)),
         POOL_ID,
         DEVICE_ID,
         schedule_id="1",
@@ -128,7 +130,7 @@ def test_schedule_end_native_value_parses_cron_string() -> None:
     """End time is decoded from the CRON minute/hour fields."""
     entity = FluidraScheduleEndTimeEntity(
         _coord([SCHEDULE]),
-        SimpleNamespace(set_schedule=AsyncMock(return_value=True)),
+        schedule_api(set_schedule=AsyncMock(return_value=True)),
         POOL_ID,
         DEVICE_ID,
         schedule_id="1",
@@ -141,7 +143,7 @@ def test_schedule_start_native_value_uses_optimistic_value_when_set() -> None:
     """Just after a user edit the optimistic value shadows the stale CRON."""
     entity = FluidraScheduleStartTimeEntity(
         _coord([SCHEDULE]),
-        SimpleNamespace(set_schedule=AsyncMock(return_value=True)),
+        schedule_api(set_schedule=AsyncMock(return_value=True)),
         POOL_ID,
         DEVICE_ID,
         schedule_id="1",
@@ -155,7 +157,7 @@ def test_schedule_start_native_value_none_when_no_match() -> None:
     """Schedule id without a matching entry returns None."""
     entity = FluidraScheduleStartTimeEntity(
         _coord([SCHEDULE]),
-        SimpleNamespace(set_schedule=AsyncMock(return_value=True)),
+        schedule_api(set_schedule=AsyncMock(return_value=True)),
         POOL_ID,
         DEVICE_ID,
         schedule_id="42",
@@ -168,7 +170,7 @@ async def test_schedule_start_async_set_value_no_op_without_schedule_data() -> N
     """When the coordinator hasn't populated schedule_data yet, set_value is a no-op."""
     coord = _coord([])
     coord.data[POOL_ID]["devices"][0].pop("schedule_data")
-    api = SimpleNamespace(set_schedule=AsyncMock(return_value=True))
+    api = schedule_api(set_schedule=AsyncMock(return_value=True))
     entity = FluidraScheduleStartTimeEntity(coord, api, POOL_ID, DEVICE_ID, schedule_id="1")
     _attach_ha(entity)
 

--- a/tests/test_time_schedule.py
+++ b/tests/test_time_schedule.py
@@ -15,6 +15,8 @@ from custom_components.fluidra_pool.time.schedule import (
     FluidraScheduleStartTimeEntity,
 )
 
+from .schedule_write_stubs import schedule_api
+
 POOL_ID = "pool-1"
 PUMP_ID = "TEST-PUMP-001"
 CHLOR_ID = "TEST-CHLOR-DM"
@@ -41,7 +43,7 @@ def _attach_ha(entity) -> None:
 
 
 def _api(*, success: bool = True) -> SimpleNamespace:
-    return SimpleNamespace(set_schedule=AsyncMock(return_value=success))
+    return schedule_api(set_schedule=AsyncMock(return_value=success))
 
 
 def _pump_device(schedules: list[dict] | None) -> dict:
@@ -382,7 +384,7 @@ async def test_start_time_set_value_preserves_cron_sunday_zero_verbatim() -> Non
 
 
 async def test_start_time_set_value_refreshes_coordinator_on_success() -> None:
-    """Successful API call → coordinator refresh, optimistic cleared."""
+    """Successful API call → coordinator refresh, optimistic value held."""
     device = _pump_device([SCHEDULE])
     api = _api()
     coord = _coord(device)
@@ -391,7 +393,8 @@ async def test_start_time_set_value_refreshes_coordinator_on_success() -> None:
 
     await entity.async_set_value(time(7, 0))
 
-    assert entity._optimistic_value is None
+    # Held, not cleared: that refresh still reads the pre-write list (Issue #210).
+    assert entity._optimistic_value == time(7, 0)
     coord.async_request_refresh.assert_awaited_once()
 
 


### PR DESCRIPTION
Fixes the write race @efgonzalez measured on real hardware in #210, on top of the Command Connect schedule support already on this branch.

## What was reported

Editing a lights start time made the field visibly revert to the old value. Retrying a few times in quick succession left the wire with `endTime` holding the old `startTime` — an inverted window. Read-back and deliberately spaced single writes were always clean.

## What it actually was

Two coupled defects, and the first one manufactures the second.

**The revert is not an optimistic coordinator refresh.** `set_schedule` never writes `desiredValue` into the local mirror (unlike `control_device_component`), and the coordinator re-reads c35/c36 from the network each poll. So the value shown after the write is a genuine device read — the device really is still reporting the old list. The bug is that the time entity dropped its optimistic value after a fixed `COMMAND_CONFIRMATION_DELAY` (3 s) on hardware the same issue measured at 5-10 s. That refresh could never see the new value, so the field reverted every single time. The repo already knew this shape: the schedule enable switch carries the comment *"Keep optimistic state until `is_on` observes server confirmation — clearing here flipped the UI back."* The time entities never got that treatment.

**The corruption is compose-from-stale-cache plus no serialisation.** A schedule write replaces the register's whole slot list. Every writer built that list from `cabinet_schedule_data`, which only moves on a poll — so two writes inside the confirmation window both composed from the same pre-write snapshot, and the second re-sent a stale value for the field it was not editing.

## What changed

- The optimistic value is held until the device echoes it back, or `SCHEDULE_WRITE_HOLD_SECONDS` (3 poll cycles) elapses. Applied to the pump/chlorinator time entities too — same code, same defect. The enable switch's own 15 s safety net expired *before* the next poll on the default 30 s scan interval, so it moves to the same budget.
- Writes compose on the list last successfully PUT, kept per `(device, component)` until the poll echoes it and then released, so a change made in the Fluidra app is never masked for long. A rejected or failed PUT never becomes a base.
- Compose *and* PUT run under one `asyncio.Lock` per register, for the time entities and the enable switch.

### One correction to the suggested fix

The report proposed composing from a verified device read immediately before the PUT. That would make things worse, not better: inside the 5-10 s confirmation window the device read *is* the pre-write list, so it would reintroduce exactly the stale-field overwrite. The composition base has to be what we last sent, not what the device currently says.

## Also in here

The cabinet entity kept itself available on an empty slot via `FluidraPoolEntity.available.fget(self)`, which is three errors under mypy strict and left the branch's typing job red. Replaced with a typed `_requires_schedule_data` class flag on the shared time-entity base.

## Verification

- `1915 passed`, coverage 96.09% (gate 90%)
- ruff check + format, pre-commit (`--all-files`), mypy strict, floor-compat import sweep: all clean
- 10 new tests in `tests/test_schedule_write_race.py`. The three that discriminate the fix (`test_second_edit_does_not_revert_the_first`, `test_concurrent_edits_on_one_scheduler_are_serialised`, `test_edited_time_survives_the_post_write_refresh`) were each confirmed to **fail** against the pre-fix behaviour before being kept.

Not verified on hardware — @efgonzalez has offered to re-test once the write path is serialised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schedule controls for Command Connect cabinet pump and lights outputs.
  * Added start/end time entities and enable switches for cabinet schedules.
  * Added optional schedule selection by component ID or output.
  * Added a read-only packed pump configuration diagnostic sensor.

* **Bug Fixes**
  * Improved schedule updates to prevent concurrent edits from overwriting one another.
  * Preserved updated schedule times until device confirmation.
  * Improved handling of schedule write failures and device responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->