### PR TITLE
fix(schedules): release the optimistic time on pumps and keep the base after a refused write

### DIFF
--- a/custom_components/fluidra_pool/fluidra_api/_schedules.py
+++ b/custom_components/fluidra_pool/fluidra_api/_schedules.py
@@ -74,10 +74,6 @@ class SchedulesMixin(FluidraAPIBase):
             return None
         return copy.deepcopy(pending.slots)
 
-    def discard_pending_schedule(self, device_id: str, component_id: int) -> None:
-        """Forget the composition base for a register (write failed or rejected)."""
-        self._pending_schedule_writes.pop((str(device_id), int(component_id)), None)
-
     def _convert_schedules_to_dm24049704_format(self, schedules: list[dict[str, Any]]) -> dict[str, Any]:
         """Convert CRON-format schedules to DM24049704 programs/slots format.
 
@@ -188,16 +184,21 @@ class SchedulesMixin(FluidraAPIBase):
             )
         except FluidraError as err:
             _LOGGER.error("set_schedule error: %s", err)
+            # Only the verifier entry goes: there is no write to confirm. The
+            # composition base left by the *previous* successful write must
+            # survive — dropping it sends the next edit back to the poll cache,
+            # which still reports the pre-write list, and that is exactly the
+            # stale-field overwrite this register serialisation prevents (#210).
             self.write_verifier.discard(device_id, component_id)
-            self.discard_pending_schedule(device_id, component_id)
             return False
 
         if status != 200:
             # Surface the rejection reason at WARNING so it reaches HA's system log
             # (the system_log buffer only retains WARNING+, so a DEBUG line was
             # invisible and a failed write gave no diagnostic info — Issue #89).
+            # A rejected PUT did not change the device, so the base left by the
+            # last successful write is still the right one to compose on.
             self.write_verifier.discard(device_id, component_id)
-            self.discard_pending_schedule(device_id, component_id)
             _LOGGER.warning("set_schedule rejected by Fluidra (HTTP %s): %s", status, raw_text[:500])
             return False
 

--- a/custom_components/fluidra_pool/time/schedule.py
+++ b/custom_components/fluidra_pool/time/schedule.py
@@ -64,13 +64,9 @@ class FluidraScheduleStartTimeEntity(FluidraScheduleTimeEntity):
     @property
     def native_value(self) -> time | None:
         """Return the current start time."""
-        if self._optimistic_value is not None:
-            return self._optimistic_value
         schedule = self._get_schedule_data()
-        if schedule:
-            start_time_str = schedule.get("startTime", "")
-            return self._parse_cron_time(start_time_str)
-        return None
+        reported = self._parse_cron_time(schedule.get("startTime", "")) if schedule else None
+        return self._optimistic_or(reported)
 
     async def async_set_value(self, value: time) -> None:
         """Set the start time using exact mobile app format."""
@@ -215,13 +211,9 @@ class FluidraScheduleEndTimeEntity(FluidraScheduleTimeEntity):
     @property
     def native_value(self) -> time | None:
         """Return the current end time."""
-        if self._optimistic_value is not None:
-            return self._optimistic_value
         schedule = self._get_schedule_data()
-        if schedule:
-            end_time_str = schedule.get("endTime", "")
-            return self._parse_cron_time(end_time_str)
-        return None
+        reported = self._parse_cron_time(schedule.get("endTime", "")) if schedule else None
+        return self._optimistic_or(reported)
 
     async def async_set_value(self, value: time) -> None:
         """Set the end time using exact mobile app format."""

--- a/tests/schedule_write_stubs.py
+++ b/tests/schedule_write_stubs.py
@@ -24,7 +24,6 @@ def install_schedule_write_stubs(api: Any) -> None:
 
     api.schedule_write_lock = MagicMock(side_effect=_lock)
     api.pending_schedule_slots = MagicMock(return_value=None)
-    api.discard_pending_schedule = MagicMock()
 
 
 def schedule_api(**attrs: Any) -> SimpleNamespace:

--- a/tests/test_schedule_write_race.py
+++ b/tests/test_schedule_write_race.py
@@ -25,11 +25,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.fluidra_pool.api_resilience import FluidraError
 from custom_components.fluidra_pool.const import SCHEDULE_WRITE_HOLD_SECONDS
 from custom_components.fluidra_pool.fluidra_api import FluidraPoolAPI
 from custom_components.fluidra_pool.time.cabinet_schedule import (
     FluidraCabinetScheduleEndTimeEntity,
     FluidraCabinetScheduleStartTimeEntity,
+)
+from custom_components.fluidra_pool.time.schedule import (
+    FluidraScheduleEndTimeEntity,
+    FluidraScheduleStartTimeEntity,
 )
 
 POOL_ID = "pool-1"
@@ -98,8 +103,11 @@ def _attach_ha(entity: Any) -> None:
 
 @pytest.fixture(autouse=True)
 def _skip_sleep() -> Any:
-    """Skip the post-write confirmation delay."""
-    with patch("custom_components.fluidra_pool.time.cabinet_schedule.asyncio.sleep", new=AsyncMock()):
+    """Skip the post-write confirmation delay on both schedule time platforms."""
+    with (
+        patch("custom_components.fluidra_pool.time.cabinet_schedule.asyncio.sleep", new=AsyncMock()),
+        patch("custom_components.fluidra_pool.time.schedule.asyncio.sleep", new=AsyncMock()),
+    ):
         yield
 
 
@@ -153,6 +161,42 @@ async def test_rejected_write_leaves_no_composition_base() -> None:
     assert api.pending_schedule_slots(DEVICE_ID, 36) is None
 
 
+@pytest.mark.asyncio
+async def test_rejected_write_keeps_the_base_left_by_the_last_good_one() -> None:
+    """A refused PUT changes nothing on the device, so the base still stands.
+
+    Dropping it here sent the next edit back to the poll cache, which inside the
+    confirmation window still reports the pre-write list — the very stale-field
+    overwrite that inverted @efgonzalez's window (Issue #210).
+    """
+    api = _make_api()
+    written = copy.deepcopy(LIGHTS_SLOT)
+    written["startTime"] = "30 19 * * 0,1,2,3,4,5,6"
+    assert await api.set_schedule(DEVICE_ID, [written], component_id=36) is True
+
+    api._request = AsyncMock(return_value=(422, {}, "OVERLAP in sched"))
+    refused = copy.deepcopy(written)
+    refused["endTime"] = "0 19 * * 0,1,2,3,4,5,6"  # end before start
+    assert await api.set_schedule(DEVICE_ID, [refused], component_id=36) is False
+
+    pending = api.pending_schedule_slots(DEVICE_ID, 36)
+    assert pending is not None
+    assert pending[0]["startTime"] == "30 19 * * 0,1,2,3,4,5,6"
+    assert pending[0]["endTime"] == LIGHTS_SLOT["endTime"]
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_keeps_the_base_left_by_the_last_good_one() -> None:
+    """Same for a PUT that never got an answer: the last good list still stands."""
+    api = _make_api()
+    assert await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36) is True
+
+    api._request = AsyncMock(side_effect=FluidraError("connection reset"))
+    assert await api.set_schedule(DEVICE_ID, [LIGHTS_SLOT], component_id=36) is False
+
+    assert api.pending_schedule_slots(DEVICE_ID, 36) is not None
+
+
 # --- entity layer: two edits in a row must not undo each other ------------
 
 
@@ -187,9 +231,6 @@ class _FrozenCloud:
 
     def pending_schedule_slots(self, device_id: str, component_id: int) -> list[dict[str, Any]] | None:
         return copy.deepcopy(self._pending.get((str(device_id), int(component_id))))
-
-    def discard_pending_schedule(self, device_id: str, component_id: int) -> None:
-        self._pending.pop((str(device_id), int(component_id)), None)
 
     async def set_schedule(self, device_id: str, schedules: list[dict[str, Any]], component_id: int) -> bool:
         self.order.append(f"put-{len(self.writes)}-in")
@@ -308,4 +349,101 @@ async def test_edited_time_released_after_the_hold_expires() -> None:
     entity._optimistic_until -= SCHEDULE_WRITE_HOLD_SECONDS + 1
 
     assert entity.native_value == time(19, 15)
+    assert entity._optimistic_value is None
+
+
+# --- the pump/chlorinator registers hold and release the same way ---------
+
+PUMP_DEVICE_ID = "VS-1"
+
+# One pump slot in the shape the poll publishes it (c20, CRON days 1-7).
+PUMP_SLOT: dict[str, Any] = {
+    "id": 1,
+    "groupId": 1,
+    "enabled": True,
+    "startTime": "15 19 * * 1,2,3,4,5,6,7",
+    "endTime": "30 22 * * 1,2,3,4,5,6,7",
+    "startActions": {"operationName": "3"},
+}
+
+
+def _pump_device(slots: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "device_id": PUMP_DEVICE_ID,
+        "name": "Pump",
+        "family": "Pumps",
+        "model": "VS",
+        "type": "pump",
+        "online": True,
+        "components": {"20": {"reportedValue": copy.deepcopy(slots)}},
+        "schedule_data": copy.deepcopy(slots),
+    }
+
+
+def _pump_coord(device: dict[str, Any]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_pump_edited_time_survives_the_post_write_refresh() -> None:
+    """The pump entity keeps the written time while the cloud lags behind."""
+    device = _pump_device([PUMP_SLOT])
+    entity = FluidraScheduleStartTimeEntity(_pump_coord(device), _FrozenCloud(), POOL_ID, PUMP_DEVICE_ID, "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+
+    assert device["schedule_data"][0]["startTime"] == "15 19 * * 1,2,3,4,5,6,7"
+    assert entity.native_value == time(19, 30)
+
+
+@pytest.mark.asyncio
+async def test_pump_edited_time_released_when_the_device_reports_it() -> None:
+    """Once the poll agrees, the device is authoritative again.
+
+    ``native_value`` returned ``_optimistic_value`` directly and never reached
+    ``_optimistic_or``, so neither release condition ever ran on this platform.
+    """
+    device = _pump_device([PUMP_SLOT])
+    entity = FluidraScheduleStartTimeEntity(_pump_coord(device), _FrozenCloud(), POOL_ID, PUMP_DEVICE_ID, "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+    device["schedule_data"][0]["startTime"] = "30 19 * * 1,2,3,4,5,6,7"
+
+    assert entity.native_value == time(19, 30)
+    assert entity._optimistic_value is None
+
+
+@pytest.mark.asyncio
+async def test_pump_edited_time_released_after_the_hold_expires() -> None:
+    """A write the device never took must stop masking the Fluidra app."""
+    device = _pump_device([PUMP_SLOT])
+    entity = FluidraScheduleStartTimeEntity(_pump_coord(device), _FrozenCloud(), POOL_ID, PUMP_DEVICE_ID, "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(19, 30))
+    entity._optimistic_until -= SCHEDULE_WRITE_HOLD_SECONDS + 1
+    device["schedule_data"][0]["startTime"] = "0 20 * * 1,2,3,4,5,6,7"
+
+    assert entity.native_value == time(20, 0)
+    assert entity._optimistic_value is None
+
+
+@pytest.mark.asyncio
+async def test_pump_end_time_released_after_the_hold_expires() -> None:
+    """Same for the end-time entity, which carried the same copy of the bug."""
+    device = _pump_device([PUMP_SLOT])
+    entity = FluidraScheduleEndTimeEntity(_pump_coord(device), _FrozenCloud(), POOL_ID, PUMP_DEVICE_ID, "1")
+    _attach_ha(entity)
+
+    await entity.async_set_value(time(23, 0))
+    entity._optimistic_until -= SCHEDULE_WRITE_HOLD_SECONDS + 1
+    device["schedule_data"][0]["endTime"] = "45 22 * * 1,2,3,4,5,6,7"
+
+    assert entity.native_value == time(22, 45)
     assert entity._optimistic_value is None

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -149,7 +149,9 @@ def test_schedule_start_native_value_uses_optimistic_value_when_set() -> None:
         schedule_id="1",
     )
     _attach_ha(entity)
-    entity._optimistic_value = time(7, 0)
+    # Arm it the way a write does: the hold has to be running, otherwise the
+    # value is released on sight (``_optimistic_or``).
+    entity._set_optimistic(time(7, 0))
     assert entity.native_value == time(7, 0)
 
 

--- a/tests/test_time_schedule.py
+++ b/tests/test_time_schedule.py
@@ -114,7 +114,7 @@ def test_start_time_native_value_returns_optimistic_when_set() -> None:
     device = _pump_device([SCHEDULE])
     entity = FluidraScheduleStartTimeEntity(_coord(device), _api(), POOL_ID, PUMP_ID, schedule_id="1")
     _attach_ha(entity)
-    entity._optimistic_value = time(7, 15)
+    entity._set_optimistic(time(7, 15))
     assert entity.native_value == time(7, 15)
 
 
@@ -123,7 +123,7 @@ def test_end_time_native_value_returns_optimistic_when_set() -> None:
     device = _pump_device([SCHEDULE])
     entity = FluidraScheduleEndTimeEntity(_coord(device), _api(), POOL_ID, PUMP_ID, schedule_id="1")
     _attach_ha(entity)
-    entity._optimistic_value = time(11, 30)
+    entity._set_optimistic(time(11, 30))
     assert entity.native_value == time(11, 30)
 
 


### PR DESCRIPTION
Follow-up to #218: two of CodeRabbit's five review comments on that PR turned out to be real, and both sit inside the write-race fix itself. #218 was merged before they were triaged, so they land here.

## The optimistic value was never released on pumps and chlorinators

`FluidraScheduleStartTimeEntity.native_value` and its end-time twin returned `self._optimistic_value` directly. They never reached `_optimistic_or`, so neither release condition applied to them: not the device echo, not `SCHEDULE_WRITE_HOLD_SECONDS`. `async_set_value` deliberately keeps the value after the post-write refresh, and `_clear_optimistic` only runs on a failed write — so after a *successful* pump or chlorinator schedule edit the entity showed the written time for the rest of the Home Assistant session, masking anything the owner later changed in the Fluidra app.

#218 claimed the hold applied to these entities too. It did not, and the reason it went unseen is that every entity-level test for the hold used the cabinet classes. Both properties now go through `_optimistic_or`, exactly as `FluidraCabinetScheduleStartTimeEntity` does.

## A refused write destroyed the composition base

`set_schedule` called `discard_pending_schedule` on both failure paths. A refused PUT changes nothing on the device, so the list left by the last *successful* write is still the right base for the next edit. Dropping it sends that edit back to the poll cache, which inside the device's 5-10 s confirmation window still reports the pre-write list — which is precisely the stale-field overwrite that inverted @efgonzalez's window in #210.

Only the write-verifier entry is discarded now (there is no write to confirm). `discard_pending_schedule` had no other caller and goes with them.

## What was measured

Six new tests in `tests/test_schedule_write_race.py`. Five of them were confirmed to fail against the pre-fix code:

```
FAILED test_rejected_write_keeps_the_base_left_by_the_last_good_one
FAILED test_transport_failure_keeps_the_base_left_by_the_last_good_one
FAILED test_pump_edited_time_released_when_the_device_reports_it
FAILED test_pump_edited_time_released_after_the_hold_expires
FAILED test_pump_end_time_released_after_the_hold_expires
5 failed, 11 passed
```

Three existing tests set `_optimistic_value` directly, leaving `_optimistic_until` at `0.0`; they now arm the hold through `_set_optimistic`, which is what the write path does.

Gate: `1933 passed`, coverage 96.13% (gate 90%), ruff check + format clean, mypy strict clean on 65 files, pre-commit `--all-files` clean.

Not verified on hardware.

## CodeRabbit remarks deliberately not applied here

- **Service schemas reject `component_id` / `schedule_output`** (`__init__.py`) — real: `vol.Schema` defaults to `PREVENT_EXTRA`, so both keys are refused before the handler runs and the cabinet routing added in #218 is unreachable through the service. Also flagged: `_service_schedule_to_fluidra` emits days `1..7` and `mode` as `operationName`, while c35/c36 want `0..6` and the slot id. That is the cabinet *service* surface, not the write race, and fixing it needs a cabinet serialiser plus payload tests — worth its own issue.
- **Cabinet enable switch unavailable on an empty register** (`switch/schedule.py`) — real asymmetry with `_FluidraCabinetScheduleTimeEntity._requires_schedule_data = False`, but it is a cabinet-availability question, not the race.
- **Pump-only wording for `set_schedule` / `clear_schedule`** (`strings.json`, `translations/pt.json`) — contingent on the point above: broadening the copy would advertise a `schedule_output` the service still refuses.
- **Duplicated `_write_base_schedules` and cabinet label map** — a refactor; leaves behaviour untouched.
- **Test stub should record successful payloads** (`tests/schedule_write_stubs.py`) — the stated consequence does not exist: exactly one test using that stub performs two writes, and it is an aux error-path test that never consults the pending base. The dedicated race tests use `_FrozenCloud`, which does model the base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed schedule editing after a rejected or failed update, preserving the last successfully saved schedule as the basis for subsequent changes.
  - Improved optimistic handling for pump, chlorinator, and cabinet schedule times.
  - Ensured displayed start and end times consistently reflect the latest available values.

- **Tests**
  - Added regression coverage for schedule update failures and optimistic value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->