### PR TITLE
feat: realtime push channel, new registers and family-aware device identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,13 @@ scan_*_components.py
 *_IMPROVEMENTS.md
 *_COMPLETE.md
 *_report.md
+
+# Local reverse-engineering artefacts: the vendor APK and its extracted strings
+# are third-party binaries, hundreds of MB, and have no place in the repo. The
+# findings drawn from them live in API-DISCOVERY.md.
+com.fluidra.iaqualinkplus_*.apks
+apk-analysis/
+
+# Local agent tooling scratch directories.
+.agent_context/
+.commandcode/

--- a/API-DISCOVERY.md
+++ b/API-DISCOVERY.md
@@ -1,0 +1,574 @@
+# API reverse-engineering — `iaqualink-plus` APK v2.23.1
+
+> Source : `com.fluidra.iaqualinkplus_2.23.1.apks` (Flutter, AOT dans `libapp.so`,
+> 33,4 Mo). Pas de code Java/Kotlin lisible — toute l'analyse vient des chaînes
+> littérales extraites de `libapp.so`. Les modèles DTO Dart (`fluidra_iot_generic_api_client`,
+> `generic_api`) sont visibles via leurs `package:` ; les valeurs min/max/units/factor
+> des registres viennent des blocs JSON `readId`/`writeId` du `configFile` de l'UI.
+
+## 1. Stack et architecture (vue client)
+
+| Couche | Détail |
+|---|---|
+| Framework mobile | Flutter (AOT), 0 code Java/Kotlin utile |
+| HTTP | `Dio` (intercepteurs `BearerAuthInterceptor`, `ApiKeyAuthInterceptor`, `OAuthInterceptor`) |
+| AuthN | AWS Cognito `eu-west-1` (InitiateAuth, RespondToAuthChallenge, etc.) + `Auth0` OAuth pour l'app mobile |
+| Sérialisation | `freezed` + `json_serializable` (modèles Dart) |
+| SDKs tiers | AppsFlyer, Firebase, Google Play Services, Helpshift (`fluidraemea.helpshift.com`) |
+| WebSocket | `wss://ws.fluidra-emea.com` (prod) / `wss://dev.ws.fluidra-emea.com` etc. |
+| Stockage local | SharedPreferences, Drift, Isar (DeviceLocalDatabaseClient) |
+
+## 2. Endpoints HTTP
+
+### 2.1 Base et auth (constants)
+
+```
+prod   : https://api.fluidra-emea.com/generic
+stage  : https://stage.api.fluidra-emea.com/generic
+dev    : https://dev.api.emea-iot.aws.fluidra.com/generic
+test   : https://test.api.emea-iot.aws.fluidra.com/generic
+```
+
+Cognito user pool : `fluidra-emea-fluidra-pool-prod` / `-staging` / `-dev` / `-test`
+(région `eu-west-1`, le même que l'intégration actuelle).
+
+### 2.2 Endpoints découverts (Tier 1)
+
+| Méthode | Path | Source | Auth | Note |
+|---|---|---|---|---|
+| GET | `/generic/devices` | `_devices.py` | Bearer | déjà utilisé |
+| GET | `/generic/devices/{id}` | APK | Bearer | détail d'un appareil |
+| GET | `/generic/devices/{id}/components` | `_components.py:57` | Bearer | liste des `desiredValue`/`reportedValue` |
+| GET | `/generic/devices/{id}/components?deviceType=connected&details=true` | `_components.py:44` | Bearer | variante avec détails |
+| GET | `/generic/devices/{id}/components/{cid}` | `_components.py:144` | Bearer | composant unique |
+| PUT | `/generic/devices/{id}/components/{cid}` | `_components.py` + APK | Bearer | `desiredValue` + `connected=true&tz=...` |
+| GET | `/generic/devices/{id}/uiconfig` | APK | Bearer | **NOUVEAU** — schéma UI avec `readId`/`writeId` |
+| GET | `/generic/pools/{poolId}` | `_devices.py:329` | Bearer | déjà utilisé (status) |
+| GET | `/generic/pools/{poolId}/status` | `_devices.py:363` | Bearer | agrégat |
+| GET | `/generic/pools/{poolId}/schedulers` | `_schedules.py:234` | Bearer | déjà utilisé (Issue #210/218/219) |
+| PUT/POST | `/generic/pools/{poolId}/schedulers/{sid}` | APK | Bearer | scheduler CRUD |
+| POST/GET | `/generic/pools/{poolId}/automations` | APK | Bearer | **NOUVEAU** — non exposé par l'intégration |
+| GET | `/generic/pools/{poolId}/recommendations` | APK | Bearer | **NOUVEAU** — recommandations (vides / filtrage) |
+| GET | `/generic/pools/{poolId}/settings` | APK | Bearer | **NOUVEAU** — settings pool |
+| GET | `/generic/pools/current/devices` | APK | Bearer | devices du pool courant |
+| POST | `/generic/pools/link` | APK | Bearer | invitation / partage |
+| GET | `/v1/pools/{poolId}/devices` | APK | Bearer | variante v1 (devices) |
+| GET | `/v1/pools/{poolId}/devices/{id}/main` | APK | Bearer | page « main » d'un appareil |
+| GET | `/v1/pools/{poolId}/devices/{id}/pages/{+pageId}` | APK | Bearer | page UI dynamique |
+| GET | `/v1/pools/{poolId}/devices/{id}/pages/wifi-setup` | APK | Bearer | wizard Wi-Fi BLE |
+| GET | `/v1/pools/{poolId}/algorithms/{algoId}/jobs/{jobId}/main` | APK | Bearer | assistant (e.g. recommandations) |
+| GET | `/v1/pools/{poolId}/automations` | APK | Bearer | alias v1 de l'endpoint v0 |
+| GET | `/v1/pools/{poolId}/recommendations` | APK | Bearer | **NOUVEAU** (v1) |
+| GET | `/v1/user/settings` | APK | Bearer | settings utilisateur |
+| GET | `/v1/help` | APK | Bearer | contenus d'aide |
+| GET | `/v1/account/preferences/notifications` | APK | Bearer | notifications opt-in |
+| GET | `/v1/account/preferences/assistance` | APK | Bearer | préférences d'assistant |
+| GET | `/v1/popup/pools/{poolId}/devices/{id}/pages/{+pageId}` | APK | Bearer | page en mode popup |
+| POST | `/generic/devices/{id}/components/{cid}/command` | APK (ws + http) | Bearer | **NOUVEAU** — `action: "command", commandId: "..."` |
+| GET | `/configFiles` | APK | Bearer | **NOUVEAU** — liste de fichiers de config |
+| GET | `/configFiles/thingTypes/` | APK | Bearer | **NOUVEAU** — types d'objets (thingTypes) |
+| GET | `/configFiles/identification/{configFileId}` | APK | Bearer | **NOUVEAU** — identification (AWS, BLE) |
+| GET | `/telemetry` | APK | Bearer | **NOUVEAU** — télémétrie agrégée (devices, pool, user, water quality) |
+
+### 2.3 Endpoints auth (Cognito + Auth0)
+
+| Méthode | Path | Note |
+|---|---|---|
+| `AWSCognitoIdentityProviderService.InitiateAuth` | Cognito eu-west-1 | login par mot de passe (déjà utilisé) |
+| `AWSCognitoIdentityProviderService.RespondToAuthChallenge` | Cognito | MFA / SMS |
+| `AWSCognitoIdentityProviderService.GetUser` | Cognito | profil |
+| `AWSCognitoIdentityProviderService.SetUserMFAPreference` | Cognito | activation MFA |
+| `AWSCognitoIdentityProviderService.ConfirmSignUp` / `ResendConfirmationCode` | Cognito | signup |
+| `Auth0` OAuth password grant | `fluidra-emea-fluidra-pro-auth0-*` | **distinct de Cognito** — pour l'app mobile |
+
+## 3. WebSocket temps réel
+
+```
+URL prod : wss://ws.fluidra-emea.com
+URL stage: wss://stage.ws.fluidra-emea.com
+URL dev  : wss://dev.ws.fluidra-emea.com
+```
+
+Message d'abonnement :
+```json
+{"action": "subsDevice", "deviceType": "connected", "deviceId": "<id>"}
+```
+
+Réponse aux commandes push (depuis le cloud) :
+```json
+{"action": "command", "commandId": "<uuid>"}
+```
+
+Désabonnement : `unsubsDevice` (et `disableSchedulerWebsockets` pour couper le
+canal schedulers, `disableWebsockets` pour tout couper).
+
+L'intégration actuelle n'utilise **pas** ces websockets — un poll REST reste
+la seule source d'état. C'est probablement l'optimisation la plus rentable
+pour ne plus attendre que le cloud publie un changement après une écriture.
+
+## 4. Registres (composants) découverts
+
+L'UI Flutter charge un `configFile` (JSON) avec un bloc par registre.
+Chaque bloc a la forme :
+
+```json
+"readId":  <int>,
+"writeId": <int>,            (facultatif)
+"type": "number" | "boolean" | "string",
+"factor": <float>,           (multiplicateur à l'affichage)
+"decimals": <int>,
+"min": <float>, "max": <float>, "steps": <float>,
+"units": "°C" | "mV" | "mg/l" | "g/L" | "%" | "h" | ""
+```
+
+Pour chaque id on a croisé label, fonction (gauge / slider / selector / tile / label), bornes, et les conditions d'affichage (`hide`, `hideValue`).
+
+### 4.1 Sondes / qualité d'eau (déjà partiellement mappés dans l'intégration)
+
+| `readId` | `writeId` | Libellé UI | Unité | Plage mesure | Plage consigne | Rôle / rem |
+|---|---|---|---|---|---|---|
+| 8 | 8 | pH | — | 0–14 | 6.5–8.5 (steps 0.1) | consigne pH (facteur écriture = 100) |
+| 11 | 11 | ORP | mV | 0–1000 | 300–850 (steps 10) | consigne redox |
+| 12 | 12 | Free Chlorine | mg/l | 0–5 (readId 178) | 0.3–3.5 (steps 0.1) | chlore libre ; read=178, setpoint=12 |
+| 16 | 16 | Pool Temperature (HPC) | °C | 6–50 | 6–50 (steps 1) | consigne PAC — facteur 0.1 (gauge) **ou** facteur 100 (writeId 16 sur pompe pH) |
+| 20 | 20 | ORP | mV | 0–1000 | 300–850 | consigne ORP alternative (2e slider ORP, min 500/950 visu) |
+| 76 | — | (mask pH) | — | — | — | `hide` OR-condition : `c76==0` *ou* `c80==1` → masque le slider pH |
+| 77 | — | (mask ORP) | — | — | — | `hide` : `c77==0` → masque ORP |
+| 80 | — | (mask pH) | — | — | — | voir c76 |
+| 135 | 137 | Filtration mode + Speed | — | state 0/1/2 | state→write 1/2/3 | **pompe à vitesse** (writeId 137, value 1/2/3) — masque si `c135==0 \|\| (c20==2)` |
+| 137 | 137 | Speed | — | state 0/1/2 (3 vitesses) | — | Pompe à 3 vitesses (Victron/Victoria) |
+| 154 | 10 | Chlorination (D2R) | % | 0–100 | 0–100 (steps 10) | % chlorination D2R (read=154, setpoint read=228, write=4) |
+| 164 | 4 | Chlorination (D2R) | % | 0–100 | 0–100 (steps 10) | idem 154, autre bloc UI |
+| 165 | — | pH (label) | — | 0–14 | — | 2e sonde pH (multi-pool) |
+| 170 | 20 | ORP (label) | mV | 0–1000 | — | 2e sonde ORP |
+| 172 | 8 | pH (slider) | — | 0–14 | 6.5–8.5 (steps 0.1) | slider pH principal (read=172, setpoint 8) |
+| 174 | — | Salinity (label) | g/L | 0–?? | — | 1re sonde salinité (read=174) — facteur 0.01 |
+| 178 | 12 | Free Chlorine (slider) | mg/l | 0–5 | 0.3–3.5 | 2e sonde chlore libre (read=178, write=12) |
+| 183 | — | Pool Temperature (label) | °C | 0–50 | — | 2e sonde température (read=183) — facteur 0.1 |
+| 185 | — | Salinity (label) | g/L | 0–?? | — | 2e sonde salinité (read=185) — facteur 0.01 |
+| 200 | — | Cover mode (label) | — | 0/1 | — | icône `devices.cover`, état « mode hivernage » |
+| 214 | — | (mask pH/ORP/Cl) | — | 0/1 | — | flag équipement de traitement présent (sinon masque les sliders) |
+| 228 | 10 | Chlorination (setpoint) | % | 0–100 | 0–100 | consigne chlorination (write=10) |
+| 244 | 2 | Filtration state | — | 0/1/2 | — | `hide` (OR avec c135==0) — état du bloc filtration |
+| 245 | 245 | Boost (selector) | — | true/false | 0/1 | mode boost chlorination (24h) |
+| 246 | — | Cover mode / Boost | — | 0/1 | — | `hide` slider pH/ORP : si `c246==0` → visible |
+| 247 | — | (mask pH) | — | 0 | — | `hide` (OR avec c248==0) — voir pH |
+| 248 | — | (mask ORP) | — | 0 | — | `hide` (OR avec c249==0) — voir ORP |
+| 249 | — | (mask Free Cl) | — | 0 | — | `hide` (OR avec c250==0) — voir chlore libre |
+| 250 | — | (mask Pool T°) | — | 0 | — | `hide` UV lamp block |
+| 251 | — | (mask Salinity) | — | 0 | — | `hide` Salinity block |
+| 252 | — | (mask UV) | — | 0 | — | `hide` UV block |
+| 253 | — | UV lamp running hours | h | 0 | — | heures de fonctionnement UV (entier) |
+| 254 | — | (mask pH/ORP) | — | 0 | — | `hide` (OR avec c214==1) — bloque la consigne |
+| 263 | — | Chlorination (D2R setpoint read) | % | 0–100 | — | 2e consigne chlorination D2R (read=263, write=4) |
+| 264 | — | (mask pH/ORP) | — | 0/1 | — | `hide` (OR avec c254==0) — bloque la valeur |
+| 269 | — | HPC state (gauge) | — | 0/1/2 | — | états PAC : `0`=Heating, `1`=No Flow, `2`=No Flow (popup) |
+| 275 | — | Filtration present | bool | true/false | — | `hide` (AND `c275==false`) — la tuile Filtration |
+| 103 | 103 | Boost mode | — | true/false | 0/1 | idem 245, code couleur + label |
+| 111 | — | Boost minutes remaining | — | 0 | — | `attributeId: "minutes"` du label « Will set prod to max for 24h » |
+| 118 | — | Boost hours remaining | — | 0 | — | `attributeId: "hours"` du même label |
+| 137 | 137 | Speed | — | state 0/1/2 | write 1/2/3 | (déjà connu : Pompe 3 vitesses) |
+| 4 | 4 | Chlorination write | % | — | 0–100 | 2e bloc D2R |
+| 48 | — | HPC cover/icon | — | 0/1 | — | icône « cover mode » PAC |
+| 0,1,2,3,5,6,7,9,10,13,14,15,17,18,21,… | — | non observés dans ce dump | — | — | — | Registres non décodés ici |
+
+### 4.2 Ce qui était manquant et qu'on a maintenant
+
+- **Facteur d'écriture** : `c8` (pH write) utilise un **facteur 100** dans l'APK (la valeur envoyée est 700 pour pH 7,00), l'intégration HA a un commentaire identique. Cohérent.
+- **Sonde pH 2e mesure (`c165`)** : confirmé comme un second registre pH (label = « pH », `factor 0.01`). Le code l'ignore ; il pourrait être utile pour les doubles bassins.
+- **Salinité (`c174`, `c185`)** : déjà utilisé (`c185` est l'unité `c16` du `probes.py`). `c174` est une **seconde** salinité, ignorée.
+- **UV (`c252`, `c253`)** : le bloc UI affiche un compteur « UV lamp running hours » en heures, `factor 1`, `decimals 0`. L'intégration HA n'a aucune entité UV. Candidat à ajouter (système UV GenSalt / similaire).
+- **Boost chlorination (`c103`, `c245`, `c111`, `c118`)** : status + min/h restantes. L'intégration a probablement un « boost » mais pas de minuterie visible. `c111` = minutes, `c118` = heures (jauge 24 h).
+- **`hide` / `hideValue` logique** : on sait maintenant que la présence du bloc pH/ORP/Cl dépend de `c214==0` ET `c246==0` ET (`c76==0 \|\| c80==1`). La simple lecture d'un registre peut donc masquer un autre — important pour ne pas masquer par erreur en production.
+- **Pompe 3 vitesses (`c137`)** : la table d'états UI montre `0→3`, `1→1`, `2→2`. Le « 0 » est probablement « off ». L'intégration lit la vitesse via `COMPONENT_PUMP_SPEED=11` mais ignore `c135`/`c244` qui portent l'état « mode filtration on/off ». Un nouveau `binary_sensor` est possible.
+
+## 5. Modèles (`fluidra_iot_generic_api_client` + `generic_api`)
+
+DTOs Dart présents dans `libapp.so` (visibles via `package:fluidra_iot_generic_api_client/src/models/...`) :
+
+```
+actions_op, alarm, alarm_default, alarm_i,
+auto_date_and_time, aws_identification, ble, ble_nodon,
+ble_pre_discovery_screen, ble_protocols, ble_provisioning_info,
+bridge, bridged_info, bridge_manual_children_adding,
+button_ui_component, calendar, capabilities, capability,
+clock, command_and_control, command_and_control_properties,
+command_and_control_ui_component, component_or_number,
+config, config_file, config_file_configuration,
+config_file_identification, config_file_information, config_file_response,
+configuration_info, configuration_settings,
+connection_technology, connectivity, data, device, device_component,
+device_family, device_item, device_name, device_query, device_request,
+device_update, divider_ui_component, document, dynamic_image, dynamic_value,
+federated_identification, form_list_ui_properties,
+gauge_container_ui_component, gauge_mode_ui_properties,
+iaq_full_screen, icon_ui_component, info_ui_component, internal_label,
+job_ui_configuration, job_ui_response,
+label_ui_component, link_info, list_layout_ui_component,
+manual, manual_date_and_time, manual_identification, migration, mobile,
+nn_identification, on_tap_ui_component, ota, ota_update_status,
+paginated_list, pool, pool_data, pool_owner, pool_sharing_code,
+provisioning, schedulers, selector_ui_component, serial_number,
+service_type, shadow, slave_linking,
+slider_setpoint_ui_component, slider_ui_component,
+step, tabs_screen_item, timezone, ui_component_i, ui_config, ui_response,
+user, user_name, user_pool, user_preferences
++   telemetry/{telemetry, telemetry_device, telemetry_measure,
+                telemetry_pool, telemetry_records, telemetry_user}
++   pool_data/pool_status, pool_temperature, pool_water_quality,
+                pool_weather/{weather, daily_weather}
++   generic_api/src/model/{subscription_plan, user_integrations, voice_assistants}
++   ~80 modèles `generic_api/src/model/...` (REST OpenAPI auto-généré)
+```
+
+Le `PoolAccessLevel` est un des modèles importants :
+
+```
+accessLevel: string
+  valeurs probables : "owner" | "viewer" | "shared" | "blocked"   (à confirmer)
+```
+
+L'intégration actuelle n'utilise **que** `pool.owner` (cf. commentaire
+`info.py` sur les droits viewer — Issue #133). Le reste de la matrice
+d'accès est invisible côté client.
+
+## 6. Couverture fonctionnelle côté app
+
+| Capacité | Visible dans l'APK | Couvert par l'intégration |
+|---|---|---|
+| Lecture des composants (poll REST) | oui | oui |
+| PUT composant | oui | oui (c9, c10, c11, c13, c15, c17, c20, c45, c258…) |
+| Schedules (`/schedulers`) | oui | oui (Issue #210/218/219) |
+| **WebSocket subsDevice** | oui | **non** |
+| **Automations (`/pools/{id}/automations`)** | oui | non |
+| **Recommendations (`/pools/{id}/recommendations`)** | oui | non |
+| **Telemetry (water quality trends)** | oui | non |
+| **UV lamp running hours (`c253`)** | oui | non |
+| **Boost chlorination minuterie (`c111/c118`)** | oui | partiel |
+| **Pompe 3 vitesses via `c135/c137/c244`** | oui | partiel (c11 vitesse lue, pas l'état) |
+| **Piston backwash (`d2r_piston_backwash_label`)** | oui | non |
+| **CellGuard operation (`cellGuardTecnologyIsEnabledComponentId`)** | oui | non |
+| **Ota update status (`otaUpdateStatus`)** | oui | non (capability detection only) |
+| **Pool sharing code (`/pools/{id}/link`)** | oui | non |
+| **Pool climate (`/v1/.../devices/.../main`)** | oui | non |
+| **Alexa/Google voice integration** | oui (`user_integrations_alexa`, `device_properties_voice_assistants`) | non |
+| **Subscription plan / paywall** | oui | non |
+| **Connected-device access code (`accessCodeComponentId`)** | oui | non (c10) |
+| **Offline access code (`offlineDeviceAccessCodeComponentId`)** | oui | non (c11) |
+
+## 7. Pistes concrètes pour l'intégration
+
+1. **WebSocket** : passer à `wss://ws.fluidra-emea.com` avec
+   `{"action":"subsDevice","deviceType":"connected","deviceId":<id>}`
+   après login. Réduit la latence sur les changements émis par le cloud
+   (notamment après un PUT — la cible d'Issue #210).
+2. **`/pools/{id}/automations`** : si l'APK expose ce qu'elle appelle
+   « automations » (≠ schedulers, plus haut niveau : déclenchement
+   conditionnel par mode/heure/état), c'est probablement le « wizards »
+   qu'on voit dans l'UI, distinct du scheduler. Première chose à GET
+   pour voir la forme.
+3. **`/telemetry`** : agrégats water quality / pump speed / device state
+   sur 24 h/7 j. Permettrait des sensors `state_class: measurement` (rolling).
+4. **`/generic/devices/{id}/uiconfig`** : le bloc JSON `configFile` est la
+   source canonique des `readId`/`writeId`/factor/units. Le charger
+   en option permet de **ne plus coder en dur** les c11/c13/c15/c20 :
+   les nouvelles sondes s'ajoutent toutes seules. Coût d'implémentation
+   ≈ 100 lignes.
+5. **Capteurs UV** : `c252` (présence UV) + `c253` (heures) → un
+   `binary_sensor` + un `sensor` « hours ».
+6. **Boost chlorination** : `c245` (state) + `c111` (min) + `c118` (h)
+   → un `binary_sensor` « boost » + un `sensor` « boost_remaining »
+   formaté « X h Y ».
+7. **Pompe à 3 vitesses** : `c135` (état filtration) + `c137` (vitesse)
+   + `c244` (mode). Expose le `select` au lieu d'un nombre brut.
+8. **Piston backwash / CellGuard** : visiblement des actions ponctuelles
+   (`PistonBackwashOperation`, `CellGuardOperation`) avec leur propre
+   `componentId`. À confirmer côté `set_command` (Endpoint §2.2).
+9. **Pool sharing code** : `POST /generic/pools/link` permet
+   d'inviter ; `PoolSharingCode` est l'objet retour. Voir ce qu'il
+   faudrait pour supporter le partage de HA ↔ autres utilisateurs.
+10. **OTA** : `device_properties_ota_update_status` est dans le payload
+    components. Le parser pourrait remonter un `update` HA quand le
+    statut change. Domaine d'utilité discutable mais gratuit à extraire.
+
+## 8. Limites de cette passe
+
+- **Dart AOT** : on n'a accès qu'aux chaînes littérales ; les structures
+  internes (`freezed` copyWith, `Map<int, dynamic>` non sérialisés) sont
+  perdues. La forme exacte des payloads PUT n'est pas confirmée par
+  le code (seulement par ce que l'APK reçoit déjà).
+- **Pas de confirmation `accessLevel`** : le modèle `PoolAccessLevel`
+  existe mais ses valeurs enum ne sont pas dans le dump. À mesurer sur
+  un compte non-owner (cf. Issue #133).
+- **Pas de trace des autres backends** (Fluida Connect, AstralPool NA,
+  APAC) — confirmé par l'absence de chaînes les référençant dans
+  `libapp.so`. La recherche croisée avec le dump de DenisLacroix (#201)
+  reste à faire.
+- **Tests dynamiques** : aucun des nouveaux endpoints n'a été
+  vérifié sur matériel. Le format JSON `uiconfig` est
+  hypothétiquement bon mais le parsing DTO reste à écrire.
+- **WebSocket auth** : handshake exact non vu (header d'auth supposé
+  Bearer après login, à confirmer par capture).
+
+
+---
+
+## 9. Mesures sur le cloud réel (2026-08-26)
+
+Tout ce qui précède vient des chaînes de `libapp.so`. Cette section vient
+d'appels **réellement effectués** sur un compte propriétaire (une pompe E30iQ,
+`thingType: eppvs`), en lecture seule, via le client de l'intégration. Elle
+corrige plusieurs suppositions des sections 2 et 7.
+
+### 9.1 Ce qui répond, ce qui refuse
+
+| Endpoint | Code | Ce que ça dit |
+|---|---|---|
+| `GET /generic/devices/{id}` | **200** | payload riche : `info.configuration.capabilities`, `thingType`, `sku`, `vr`, `alarms` |
+| `GET /generic/configFiles` | **200** | index de **124** configFiles (`{id, vr, cf}`) |
+| `GET /generic/configFiles/identification/{thingType}` | **200** | les mêmes 124 records, complets — **392 Ko** |
+| `GET /generic/configFiles/thingTypes/` | **200** | **67** types (`AC3`, `BC3`, `eppvs`, `tecnoLC2`, `domS2`, …) |
+| `GET /generic/devices/{id}/uiconfig` | **400** | `Missing required request parameters: [deviceType, appId]` |
+| `GET /generic/telemetry` | **403** | *signature AWS attendue* — voir 9.3 |
+| `GET /generic/pools/{id}/automations` | **403** | idem |
+| `GET /generic/pools/{id}/recommendations` | **403** | idem |
+| `GET /generic/pools/{id}/settings` | **403** | idem |
+| `GET /v1/pools/{id}/automations` | **403** | `Forbidden` (sec) |
+| `GET /v1/user/settings` | **403** | `Forbidden` (sec) |
+
+### 9.2 `/uiconfig` : deux paramètres non devinables
+
+`appId` et `appVr` sont validés côté serveur. `appId=iaqualink_plus` franchit la
+validation (le 400 devient 500) ; huit formats d'`appVr` ont été refusés
+(`2.23.1`, `2.23`, `223`, `2`, `v2.23.1`, `2.23.1.0`, `2230100`, + `lang`).
+Aucune valeur littérale de ces deux paramètres n'existe dans `libapp.so` —
+seulement les messages qui les nomment. **Un `curl` ne suffit pas : il faut une
+capture MITM de l'app.**
+
+### 9.3 Les 403 ne sont pas des refus de droits
+
+Le corps est explicite :
+
+```
+Invalid key=value pair (missing equal-sign) in Authorization header
+(hashed with SHA-256 and encoded with Base64): '…'
+```
+
+C'est le message d'**AWS SigV4**. Ces routes attendent une requête signée IAM,
+pas le Bearer Cognito qui sert partout ailleurs. Ce n'est donc pas une question
+de niveau d'accès du compte : `/telemetry`, `/automations`, `/recommendations`
+et `/settings` sont derrière un **autre schéma d'authentification**. Les passes
+4, 6 et 7 du plan 013 sont bloquées par là, pas par les droits.
+
+### 9.4 `capabilities` : le cloud déclare le registre des plannings
+
+`GET /generic/devices/{id}` renvoie, pour l'E30iQ mesurée :
+
+```json
+"capabilities": {
+  "schedulers": [{"id": "pump", "type": "minimal", "enabled": true,
+                  "componentRead": 20, "componentWrite": 20}],
+  "ota": {"technologies": ["cloud"], "type": "default", "enabled": true},
+  "dateAndTime": {"technologies": ["ble"], "manual": {"timezone": {"enabled": true}}},
+  "postLinkingSteps": ["poolDetails"], "provisioning": {"ble": {…}}, "ble": {}
+}
+```
+
+C'est **la réponse d'autorité à l'Issue #174** : quel registre porte les
+plannings d'un appareil donné, que les profils résolvent aujourd'hui à la main
+depuis les drapeaux de type de pompe (c82/c83). L'intégration l'expose désormais
+dans ses diagnostics, à côté du registre que le profil a résolu, avec un booléen
+`matches_profile` — une seule requête par appareil, au téléchargement des
+diagnostics, jamais sur le chemin de poll.
+
+### 9.5 `configFiles` : l'identification officielle, sans les registres
+
+Un record `CF#tecnoLC2` (9 Ko) contient :
+
+- `alternativeCommercialNames`: `["Clear Connect", "Ei2 iQ", "GenSalt OE iQ", "Tecno LC2 KA"]`
+  — exactement la gamme que le dépôt identifie à la main par numéro de série ;
+- `nn.manId` (2 valeurs), `nn.prCode` (**82** codes produit), `nn.swVr` (133 versions)
+  — la table d'identification officielle des appareils bridgés « nn » ;
+- `configuration.op.jsonata` — une expression **JSONata** qui décode
+  `payload.identification.modbus.holding.rD` en groupes de capacités :
+  `electrolysis`, `ph`, `cl-orp`, `cl-ppm`, … C'est la détection officielle de
+  « quelles sondes cette unité possède », que les profils devinent aujourd'hui.
+
+En revanche **aucun `readId`/`writeId`/`factor`/`units`** : zéro occurrence dans
+les 392 Ko. Les blocs UI de registres ne sont pas là — ils restent derrière
+`/uiconfig` et son `appId`.
+
+### 9.6 Pistes ouvertes par cette mesure
+
+1. **Identification par `prCode`/`manId`** plutôt que par motif de numéro de
+   série, si le payload d'un appareil bridgé les expose (à vérifier : le compte
+   mesuré n'a pas d'appareil bridgé).
+2. **Capacités par JSONata** : le cloud sait dire quelles sondes existent ; la
+   piste vaut pour les profils « non vérifiés » de l'Issue #73 et consorts.
+3. **`configFileVersion`** est présent par appareil (`0.0.8` sur l'E30iQ) — de
+   quoi savoir quand un profil codé en dur a pris du retard.
+
+
+---
+
+## 10. WebSocket : mesuré de bout en bout (2026-08-26)
+
+La section 3 décrivait le canal d'après les chaînes de l'APK. Il a été
+**ouvert, abonné et vérifié** sur le compte de l'opérateur, avec son accord
+explicite pour commander sa pompe.
+
+### 10.1 Handshake
+
+L'authentification ne passe **pas** par un en-tête :
+
+| Tentative | Résultat |
+|---|---|
+| `Authorization: Bearer <access_token>` | handshake **401** |
+| `Authorization: <access_token>` (brut) | handshake **401** |
+| **`wss://ws.fluidra-emea.com?token=<access_token>`** | **connecté** |
+
+C'est le jeton d'accès Cognito, celui que l'intégration détient déjà, passé en
+**paramètre de requête**. Le §3 du présent document ne le disait pas et le plan
+013 supposait un Bearer — c'est corrigé.
+
+### 10.2 Actions acceptées
+
+```json
+{"action": "subsDevice", "deviceType": "connected", "deviceId": "<id>"}
+→ {"statusCode":200,"action":"subsDevice","body":"{…,\"message\":\"OK\"}"}
+
+{"action": "subsPool", "poolId": "<uuid>"}
+→ {"statusCode":200,"action":"subsPool","body":"{…,\"message\":\"OK\"}"}
+```
+
+`subsPool` n'était pas documenté — il est accepté. Une action inconnue
+(`subsScheduler`) reçoit `{"message": "Forbidden", "connectionId": …}` sans
+fermer la connexion.
+
+### 10.3 Le canal pousse bien les changements — 2,5 s
+
+Écriture de `c11` (vitesse) via le chemin PUT habituel, en écoutant :
+
+```
+[  0.0s] subsDevice → 200 OK
+[  2.5s] {"statusCode":200,"action":"componentChange",
+          "body":"{\"deviceId\":\"…\",\"deviceType\":\"connected\",
+                   \"componentId\":11,\"reportedValue\":1,\"ts\":1787767038}"}
+[ 28.2s] componentChange … componentId:11, reportedValue:0     (la restauration)
+[ 39.5s] componentChange … componentId:11, reportedValue:1     (voir 10.4)
+```
+
+**`componentChange` porte tout ce qu'il faut** : `deviceId`, `componentId`,
+`reportedValue`, `ts`. **2,5 secondes** après l'écriture, contre un intervalle
+de poll complet aujourd'hui. C'est la cible de l'Issue #210, et elle est
+atteignable : le canal existe, s'authentifie avec un jeton déjà en main, et
+livre exactement le triplet que le coordinateur applique.
+
+### 10.4 La troisième frame, c'est l'amorçage de la pompe
+
+La frame à 39,5 s renvoie `1` **après** la restauration à `0` de 28,2 s, puis la
+valeur se stabilise à `0` (vérifié sur 60 s). Explication donnée par
+l'opérateur, qui connaît son matériel : **en mode manuel, l'E30iQ démarre à
+100 % pendant environ une minute, puis redescend au niveau demandé.** La
+remontée observée est cette phase d'amorçage, pas un croisement d'écritures ni
+un rejeu de consigne par le cloud.
+
+Ce qu'il faut en retenir pour l'intégration : après un démarrage manuel, la
+valeur *rapportée* peut diverger de la consigne pendant ~1 min sans que rien
+n'aille mal. La vérification d'écriture y résiste déjà —
+`WRITE_VERIFY_MIN_GRACE_SECONDS` vaut **180 s**, et la grâce effective est
+`max(180 s, 3 × intervalle de poll)` — donc l'amorçage ne peut pas être compté
+comme une écriture perdue. À ne pas raccourcir sans refaire ce calcul.
+
+### 10.5 Robustesse : mesuré (connexions en écoute pure, aucune commande émise)
+
+| Question | Mesure |
+|---|---|
+| Jeton invalide dans l'URL | handshake **403** |
+| Jeton vide, ou paramètre absent | handshake **401** |
+| Le jeton est-il validé à l'ouverture ? | **oui** — pas de connexion anonyme |
+| Ping WebSocket standard | **PONG reçu** |
+| Connexion silencieuse (aucun trafic) | **fermée à +600 s pile**, `close_code=1006` |
+| Connexion avec ping toutes les 60 s | **vivante à +23 min**, sans incident |
+| Le canal survit-il à l'expiration du jeton ? | **oui** — à +420 s, jeton mort depuis 2,5 min, `subsDevice` répond `200 OK` |
+| `unsubsDevice` | `200 OK` |
+| `unsubsPool` | **`500` « Unsubscription Error »**, avec rollback annoncé |
+| `disableSchedulerWebsockets` / `disableWebsockets` | `Forbidden` — verbes non reconnus sur cette route |
+
+Trois conséquences directes pour un futur client :
+
+1. **Un keepalive de moins de 10 minutes est obligatoire.** Les 600 s pile et
+   le `1006` sont la signature du délai d'inactivité d'AWS API Gateway
+   WebSocket. La fermeture est *abrupte* — pas de frame de close propre — donc
+   le client doit traiter `1006` comme un événement normal et se reconnecter
+   avec un backoff, pas comme une erreur.
+2. **Inutile de rouvrir la connexion à chaque rafraîchissement de jeton.** Le
+   jeton n'est vérifié qu'au handshake ; une fois la connexion établie, elle
+   reste utilisable, abonnements compris. Cela simplifie beaucoup le cycle de
+   vie : ouvrir une fois, garder vivant, rouvrir seulement sur fermeture.
+   (API Gateway impose par ailleurs une durée maximale de connexion de 2 h —
+   non atteinte lors de cette mesure, à traiter comme une reconnexion de plus.)
+3. **Ne pas compter sur `unsubsPool`.** Il rend 500. Pour se désabonner de
+   tout, fermer la connexion.
+
+Les réponses arrivent de façon **asynchrone** : celle d'`unsubsDevice` n'est
+apparue qu'après l'envoi suivant. Un client qui attend une réponse synchrone
+après chaque envoi se bloquerait — il faut une boucle de lecture indépendante
+et une corrélation par le champ `action`.
+
+### 10.6 Ce qui reste inconnu
+
+- ce que `subsPool` pousse réellement (l'abonnement est accepté, aucune frame
+  ne l'a exercé) ;
+- le comportement au-delà de 2 h ;
+- `appVr` pour `/uiconfig` : le versionCode de l'User-Agent
+  (`1741857021`) a été essayé avec quatre `appId` différents, toujours
+  `400 Invalid appVr parameter`. La piste est fermée.
+
+
+---
+
+## 11. Table `thingType` → gamme (extraite des 124 configFiles)
+
+`GET /generic/devices` — l'appel que l'intégration fait déjà — renvoie pour
+chaque appareil un `thingType` : **l'identifiant de famille officiel de
+Fluidra**, disponible dès la découverte, avant tout scan de registre. Croisé
+avec les configFiles (§9.5), il donne la correspondance suivante. Les lignes
+marquées ✅ sont désormais déclarées en `thing_type_patterns` sur le profil
+correspondant.
+
+| `thingType` | Famille cloud | Gamme commerciale | Profil du dépôt |
+|---|---|---|---|
+| `eppvs` | Filtration Pumps | E30iQ, Inari VS, Verdon VS | ✅ `e30iq_pump` |
+| `mppvs` | Filtration Pumps | Victoria Smart Connect VS | ✅ `victoria_smart_connect_pump` |
+| `exr` | Chlorinators | eXO iQ, GenSalt OT iQ, Hydroxinator | ✅ `ns25_exo_chlorinator` |
+| `zs500` | Heat Pumps | Z550iQ, Z550iQ+ (Z550iQR32) | ✅ `z550iq_heat_pump` |
+| `SRC` | Cabinets | Command Connect | ✅ `command_connect_cabinet` |
+| `tecnoLC2` / `lc2` | Chlorinators / Bridges | Energy Connect, Clear Connect, Ei2 iQ, GenSalt OE iQ | déroutage dédié existant (inchangé) |
+| `domoticS2` / `dm2` | Chlorinators / Bridges | Elite Connect, Control Connect, Neolysis | catch-all `chlorinator` |
+| `amt` | Heat Pumps | Z250iQ, Z260iQ, PX25, PX26, Eco Elyo | **non déclaré** — zone gelée, ces profils se départagent au composant 7 |
+| `nhpp` | Heat Pumps | Z450, Z650iQ, Verti/Silent/Eco Elyo R290 | **non déclaré** — famille trop large pour un seul profil |
+| `hpc` | Heat Pumps | Z350iQ | aucun profil |
+| `proelyo` | Heat Pumps | PX50, HPO, Pro Elyo Touch | aucun profil |
+| `evoline` | Heat Pumps | PM40, Evoline | aucun profil |
+| `z950iq` | Heat Pumps | z950iQ Powerforce Inverter | aucun profil |
+| `tecno2` | Chlorinators | eXPERT, Smart Next (± pH/Rx) | aucun profil |
+| `tecnoS3` / `ts3` | Chlorinators | Smart Connect LS, eXPERT iQ LS | aucun profil |
+| `dosingpump` | Chlorinators | DoseNext Pro, eDose Pro iQ, Smart Dosing | aucun profil |
+| `LWM` | Light Controllers | Lumiplus Connect | `generic_light` |
+| `N30L`, `cycr`, `vrr`, `EBOX`, `cbr`, `T51L` | Robot Cleaners | Freedom, Cyclonext, Alpha… | aucun profil |
+| `svrac` | Valves | Multiport valve | aucun profil |
+| `isp`, `gpio` | GPIOs | Smart Plug, GPIO | aucun profil |
+| `BC3`, `AC3` | Data collectors | Blue Connect, Aqua Connect | aucun profil |
+| `teststrip` | Test Strips | Test strip | virtuel, connu pour ne pas répondre aux polls |
+
+Deux familles sont volontairement laissées de côté. `amt` mélange Z250iQ et
+Z260iQ, que l'intégration sépare par la signature du composant 7 : y accrocher
+un profil brouillerait exactement ce que cette logique distingue. `nhpp` couvre
+le Z450 et les Elyo R290 en plus du Z650iQ ; router tout le monde vers le profil
+Z650iQ donnerait des lectures fausses avec l'apparence d'un profil vérifié.
+
+La colonne « aucun profil » est la liste de ce que l'intégration ne sait pas
+encore lire — robots, vannes, prises, doseurs, et six familles de pompes à
+chaleur. C'est aussi la feuille de route la plus factuelle dont dispose le
+projet.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ Your contributions help me keep improving this project and adding new equipment.
   a circuit breaker for sustained outages, and a rate limiter.
 - **Localized UI** — English, French, Spanish and Portuguese translations; failed commands
   surface a clear, translated error instead of silently doing nothing.
-- **Diagnostics** — downloadable diagnostics (with credentials redacted) for bug reports.
+- **Realtime updates (opt-in)** — the Fluidra cloud can push changes as they happen
+  instead of being polled for them: a state change reaches Home Assistant in about
+  2 seconds. Polling keeps running underneath, so the channel only ever shortens the
+  wait. Off by default; enable it under **Configure**.
+- **Family-aware recognition** — devices are matched on Fluidra's own family identifier
+  as well as on their serial, so a model nobody has reported yet still lands on the right
+  register map instead of a generic fallback.
+- **Diagnostics** — downloadable diagnostics (with credentials redacted) for bug reports,
+  including what the cloud itself declares about each device's schedule register.
 
 ### 🧩 Entity platforms
 
@@ -52,7 +60,8 @@ Your contributions help me keep improving this project and adding new equipment.
 | `light`  | LumiPlus Connect RGBW (on/off, brightness, colour) |
 | `time`   | Schedule start/end time editing |
 | `button` | Victoria VS pump Stop (halt without disarming the schedule) |
-| `sensor` | pH, ORP, free chlorine, salinity, temperatures, pump speed/mode, power & head & flow (VS pumps), firmware, signal, status |
+| `sensor` | pH, ORP, free chlorine, salinity, temperatures, pump speed/mode, power & head & flow (VS pumps), UV lamp hours, boost countdown, firmware, signal, status |
+| `binary_sensor` | Cell production, alarms, speed-preset inputs, UV lamp presence, filtration running |
 
 ---
 
@@ -138,7 +147,9 @@ Your equipment isn't listed or is only partially recognised? Help us add it:
    ```
 2. **Open an [issue](https://github.com/foXaCe/Fluidra-pool/issues)** with:
    - Your equipment model and serial prefix
-   - The device-discovery debug logs
+   - The device-discovery debug logs — these now include the device's `thing_type`
+     (Fluidra's own family id, e.g. `eppvs`, `tecnoLC2`) and every register no profile
+     maps yet, which is usually enough to identify what is missing
    - The features/values shown in the official Fluidra Pool app
 3. **Test and share** your results — most new models are added this way.
 
@@ -188,6 +199,10 @@ The integration is configured entirely from the UI (config flow):
 ### Options
 - **Update interval** — polling interval in seconds, configurable from **30 to 1800**
   (default **30 s**). Change it via the integration's **Configure** button.
+- **Realtime updates (experimental)** — subscribe to the Fluidra cloud's push channel so
+  state changes arrive in about 2 seconds instead of waiting for the next poll. Off by
+  default. Polling continues either way, so turning it off simply restores the previous
+  behaviour.
 
 ---
 

--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -204,6 +204,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
     # Set up platforms after coordinator has data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Realtime channel, when the user opted in (plan 013, Pass 5). Started after
+    # the platforms so a change pushed within the first seconds lands on
+    # entities that exist. It never gates setup: the poll is the source of
+    # truth and runs the same whether the channel comes up or not.
+    # Closing it is async and belongs to async_unload_entry, which can await it
+    # — an async_on_unload callback would have to spawn a task and leave it
+    # lingering past teardown.
+    await coordinator.async_start_realtime()
+
     # 🥇 Gold: Recharger l'intégration quand les options changent
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
@@ -238,6 +247,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry)
         runtime = getattr(entry, "runtime_data", None)
         coordinator = getattr(runtime, "coordinator", None)
         if coordinator is not None:
+            await coordinator.async_stop_realtime()
             await coordinator.api.close()
     return unload_ok
 

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -334,6 +334,119 @@ class FluidraHeatPumpAlarmBinarySensor(FluidraPoolEntity, BinarySensorEntity):
         return bool(value) if value is not None else None
 
 
+class FluidraUvPresentBinarySensor(FluidraPoolEntity, BinarySensorEntity):
+    """Whether the chlorinator reports a UV lamp block at all.
+
+    The app uses this register as a display mask: 0 hides the whole UV block,
+    non-zero shows it. Exposed as a diagnostic sensor so a UV unit that stops
+    being reported (lamp module unplugged, firmware downgrade) is visible
+    rather than silently turning the hours counter unavailable.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PRESENCE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        component_id: int,
+    ) -> None:
+        """Initialize the UV presence binary sensor."""
+        super().__init__(coordinator, pool_id, device_id)
+        self._api = api
+        self._component_id = component_id
+        self._attr_unique_id = f"{DOMAIN}_{pool_id}_{device_id}_uv_present"
+        self._attr_translation_key = "uv_present"
+
+    @property
+    def available(self) -> bool:
+        """Return True once the device has reported component data."""
+        return self.coordinator.last_update_success and bool(self.device_data.get("components"))
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the UV block is reported present."""
+        components = self.device_data.get("components", {})
+        raw = components.get(str(self._component_id), {}).get("reportedValue")
+        if raw is None:
+            return None
+        try:
+            return float(raw) > 0
+        except (ValueError, TypeError):
+            return None
+
+
+class FluidraFiltrationStateBinarySensor(FluidraPoolEntity, BinarySensorEntity):
+    """Whether the filtration block driven by this controller is running.
+
+    Distinct from the pump's own on/off: on a schedule-driven installation the
+    controller reports the live state of the filtration block on its own
+    register, which is what an automation actually needs ("is water flowing"),
+    while the on/off switch only says whether the pump was commanded on.
+
+    The register id is profile-declared (``filtration_state``) with an optional
+    fallback, because the same numbers carry unrelated meanings on other
+    families — c135 is the active quick-function slot on a Victoria VS pump.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        component_id: int,
+        fallback_component_id: int | None = None,
+    ) -> None:
+        """Initialize the filtration state binary sensor."""
+        super().__init__(coordinator, pool_id, device_id)
+        self._api = api
+        self._component_id = component_id
+        self._fallback_component_id = fallback_component_id
+        self._attr_unique_id = f"{DOMAIN}_{pool_id}_{device_id}_filtration_state"
+        self._attr_translation_key = "filtration_state"
+
+    @property
+    def available(self) -> bool:
+        """Return True once the device has reported component data."""
+        return self.coordinator.last_update_success and bool(self.device_data.get("components"))
+
+    def _read(self, component_id: int | None) -> float | None:
+        """Return one register's value as a float, or None when unusable."""
+        if component_id is None:
+            return None
+        components = self.device_data.get("components", {})
+        raw = components.get(str(component_id), {}).get("reportedValue")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while the filtration block is running.
+
+        The primary register wins whenever it answers; the fallback covers the
+        firmware versions that only carry the second one. Both are 0 = stopped,
+        non-zero = running (the app treats 1 and 2 alike for the block state).
+        """
+        value = self._read(self._component_id)
+        if value is None:
+            value = self._read(self._fallback_component_id)
+        if value is None:
+            return None
+        return value > 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: FluidraPoolConfigEntry,
@@ -393,6 +506,36 @@ async def async_setup_entry(
                     alarm_key,
                 )
                 for alarm_key in alarm_keys
+            )
+
+        # UV lamp block, on the chlorinator families that carry one. Both
+        # registers are profile-declared: the presence flag is the app's own
+        # display mask, the counter is the lamp's running hours.
+        uv_lamp = DeviceIdentifier.get_feature(device, "uv_lamp")
+        if isinstance(uv_lamp, dict) and uv_lamp.get("present") is not None:
+            entities.append(
+                FluidraUvPresentBinarySensor(
+                    coordinator,
+                    coordinator.api,
+                    pool_id,
+                    device_id,
+                    uv_lamp["present"],
+                )
+            )
+
+        # Live state of the filtration block, where the controller reports it
+        # on its own register rather than through the pump's on/off.
+        filtration_state = DeviceIdentifier.get_feature(device, "filtration_state")
+        if isinstance(filtration_state, dict) and filtration_state.get("state") is not None:
+            entities.append(
+                FluidraFiltrationStateBinarySensor(
+                    coordinator,
+                    coordinator.api,
+                    pool_id,
+                    device_id,
+                    filtration_state["state"],
+                    filtration_state.get("fallback"),
+                )
             )
 
         # Victoria VS speed-preset dry-contact inputs (Issue #144).

--- a/custom_components/fluidra_pool/config_flow.py
+++ b/custom_components/fluidra_pool/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -31,7 +32,13 @@ from .api_resilience import (
     FluidraError,
     FluidraMFARequired,
 )
-from .const import CONF_REFRESH_TOKEN, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    CONF_ENABLE_REALTIME,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_ENABLE_REALTIME,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from .fluidra_api import FluidraPoolAPI
 from .utils import mask_email
 
@@ -439,6 +446,7 @@ class FluidraPoolOptionsFlowHandler(OptionsFlow):
 
         # Get current values or defaults
         current_scan_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        current_realtime = self.config_entry.options.get(CONF_ENABLE_REALTIME, DEFAULT_ENABLE_REALTIME)
 
         return self.async_show_form(
             step_id="init",
@@ -459,6 +467,13 @@ class FluidraPoolOptionsFlowHandler(OptionsFlow):
                         ),
                         vol.Coerce(int),
                     ),
+                    # Realtime channel: the cloud pushes changes instead of
+                    # being polled for them. Off by default — the poll keeps
+                    # running either way, this only shortens the wait.
+                    vol.Optional(
+                        CONF_ENABLE_REALTIME,
+                        default=current_realtime,
+                    ): BooleanSelector(),
                 }
             ),
         )

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -96,6 +96,12 @@ ATTR_BRIGHTNESS: Final = "brightness"
 
 # Default values
 DEFAULT_SCAN_INTERVAL: Final = 30  # seconds
+
+# Realtime channel (plan 013, Pass 5). Opt-in: the REST poll stays the source of
+# truth and keeps running either way, so this only ever shortens the wait for a
+# value the next poll would have brought anyway.
+CONF_ENABLE_REALTIME: Final = "enable_realtime"
+DEFAULT_ENABLE_REALTIME: Final = False
 DEFAULT_TIMEOUT: Final = 30  # seconds — aligned with HTTP request timeout
 
 # Timing constants for optimistic state management

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -21,7 +21,9 @@ from ..api_resilience import FluidraConnectionError, FluidraError
 from ..const import (
     BULK_FETCH_FAILURE_LIMIT,
     COMPONENT_HEAT_PUMP_SETPOINT,
+    CONF_ENABLE_REALTIME,
     CONNECTION_ISSUE_THRESHOLD,
+    DEFAULT_ENABLE_REALTIME,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_TYPE_CHLORINATOR,
     DEVICE_TYPE_HEAT_PUMP,
@@ -84,6 +86,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Devices whose unmapped registers have already been dumped at DEBUG — see
         # _log_unmapped_components; log once per session, not on every poll.
         self._unmapped_logged: set[str] = set()
+
+        # Realtime channel (opt-in, plan 013 Pass 5). None until started; the
+        # poll runs identically whether it is up or not.
+        self._realtime: Any = None
+        self.realtime_changes = 0
 
         # Honour the user-configured polling interval.
         scan_interval = DEFAULT_SCAN_INTERVAL
@@ -196,7 +203,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Calculate current speed based on active schedules in auto mode."""
         return calculate_auto_speed_from_schedules(device)
 
-    async def _fetch_components(self, device_id: str, components_to_scan: list[int]) -> dict[int, dict[str, Any]]:
+    async def _fetch_components(
+        self, device_id: str, components_to_scan: list[int], thing_type: str = ""
+    ) -> dict[int, dict[str, Any]]:
         """Fetch the requested components, preferring the single bulk request.
 
         The bulk endpoint returns every component in one call (Issue #144), which
@@ -222,7 +231,7 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # carries every register, and processing unrequested ones would feed
                 # the per-family decoders components they don't expect.
                 wanted = set(components_to_scan)
-                self._log_unmapped_components(device_id, bulk, wanted)
+                self._log_unmapped_components(device_id, bulk, wanted, thing_type)
                 return {cid: state for cid, state in bulk.items() if cid in wanted}
 
             failures = self._bulk_fetch_failures.get(device_id, 0) + 1
@@ -237,7 +246,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return await self._fetch_components_parallel(device_id, components_to_scan)
 
-    def _log_unmapped_components(self, device_id: str, bulk: dict[int, dict[str, Any]], wanted: set[int]) -> None:
+    def _log_unmapped_components(
+        self, device_id: str, bulk: dict[int, dict[str, Any]], wanted: set[int], thing_type: str = ""
+    ) -> None:
         """Log, once per device, the registers the bulk response carries but no profile maps.
 
         Adding support for a missing feature (a boost mode, an aux output, a
@@ -248,6 +259,10 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for repeated diagnostics exports that only ever contain the registers we
         already know about (Issues #174/#175, where every requested register was
         unrelated to the missing boost/aux/schedule features).
+
+        The device's ``thingType`` goes in the same line: it is Fluidra's own
+        family identifier, and it is what tells a maintainer which register map
+        an unreported model should be reading (README "Adding New Equipment").
         """
         if not _LOGGER.isEnabledFor(logging.DEBUG) or device_id in self._unmapped_logged:
             return
@@ -255,9 +270,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         unmapped = {cid: bulk[cid].get("reportedValue") for cid in sorted(bulk) if cid not in wanted}
         if unmapped:
             _LOGGER.debug(
-                "Device %s reports %d component(s) no profile maps — toggle a missing "
-                "feature in the Fluidra app and compare to find its register: %s",
+                "Device %s (thing_type=%s) reports %d component(s) no profile maps — "
+                "toggle a missing feature in the Fluidra app and compare to find its "
+                "register: %s",
                 device_id,
+                thing_type or "unknown",
                 len(unmapped),
                 unmapped,
             )
@@ -290,6 +307,88 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if state and isinstance(state, dict):
                 component_states[cid] = state
         return component_states
+
+    @property
+    def realtime_enabled(self) -> bool:
+        """Return True when the user opted into the realtime channel."""
+        entry = self.config_entry
+        if entry is None or not entry.options:
+            return DEFAULT_ENABLE_REALTIME
+        return bool(entry.options.get(CONF_ENABLE_REALTIME, DEFAULT_ENABLE_REALTIME))
+
+    @property
+    def realtime_connected(self) -> bool:
+        """Return True while the realtime channel is actually connected."""
+        return bool(getattr(self._realtime, "connected", False))
+
+    def _known_device_ids(self) -> list[str]:
+        """Return every device id currently in the coordinator's data."""
+        device_ids: list[str] = []
+        for pool in (self.data or {}).values():
+            if not isinstance(pool, dict):
+                continue
+            for device in pool.get("devices", []):
+                device_id = device.get("device_id")
+                if device_id and str(device_id) not in device_ids:
+                    device_ids.append(str(device_id))
+        return device_ids
+
+    async def async_start_realtime(self) -> None:
+        """Open the realtime channel, if the user asked for it.
+
+        Failure here is never fatal: the integration polls exactly as before,
+        and the channel retries on its own.
+        """
+        if not self.realtime_enabled or self._realtime is not None:
+            return
+
+        from ..fluidra_api._websocket import FluidraWebsocketClient
+
+        session = await self.api._get_session()
+        device_ids = self._known_device_ids()
+        self._realtime = FluidraWebsocketClient(
+            session,
+            lambda: self.api.access_token,
+            self._handle_realtime_change,
+        )
+        await self._realtime.start(device_ids)
+        _LOGGER.debug("Realtime channel requested for %d device(s)", len(device_ids))
+
+    async def async_stop_realtime(self) -> None:
+        """Close the realtime channel, if one is running."""
+        if self._realtime is None:
+            return
+        await self._realtime.stop()
+        self._realtime = None
+
+    async def _handle_realtime_change(self, change: Any) -> None:
+        """Apply one pushed component change and tell the entities right away.
+
+        The push carries the same triplet a poll would have read, so it goes
+        through the very same decoder — no second code path that could drift
+        from the polled one. A change for a device we do not know is ignored:
+        discovery stays the poll's job.
+        """
+        data = self.data
+        if not data:
+            return
+
+        for pool_id, pool in data.items():
+            if not isinstance(pool, dict):
+                continue
+            for device in pool.get("devices", []):
+                if str(device.get("device_id")) != change.device_id:
+                    continue
+                device.setdefault("components", {})
+                state: dict[str, Any] = {"reportedValue": change.reported_value}
+                if change.timestamp is not None:
+                    state["ts"] = change.timestamp
+                self._process_component_state(device, str(pool_id), change.component_id, state)
+                self.realtime_changes += 1
+                # Push to the entities without a network round-trip: this is
+                # the whole point of the channel (Issue #210).
+                self.async_set_updated_data(data)
+                return
 
     def _process_component_state(
         self, device: dict[str, Any], pool_id: str, component_id: int, component_state: dict[str, Any]
@@ -1176,7 +1275,9 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 component_range = DeviceIdentifier.get_components_range(device)
                 components_to_scan = list(range(component_range))
-            component_states = await self._fetch_components(device_id, components_to_scan)
+            component_states = await self._fetch_components(
+                device_id, components_to_scan, str(device.get("thing_type", ""))
+            )
 
             if components_to_scan and not component_states:
                 strikes = self._empty_component_fetch_counts.get(device_id, 0) + 1

--- a/custom_components/fluidra_pool/device_registry/configs/cabinets.py
+++ b/custom_components/fluidra_pool/device_registry/configs/cabinets.py
@@ -22,6 +22,8 @@ CABINET_CONFIGS: dict[str, DeviceConfig] = {
         # Times are local wall-clock despite the bridge reporting GMT0.
         family_patterns=["Cabinets"],
         model_patterns=["Command Connect"],
+        # Cloud family id, until now recognised by its model string alone.
+        thing_type_patterns=["SRC"],
         components_range=40,
         required_components=[13, 24],
         entities=["switch"],

--- a/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
+++ b/custom_components/fluidra_pool/device_registry/configs/chlorinators.py
@@ -1013,6 +1013,9 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
     "ns25_exo_chlorinator": DeviceConfig(
         device_type="chlorinator",
         identifier_patterns=["NS*"],
+        # Cloud family id for the eXO line — it also covers GenSalt OT iQ and
+        # Hydroxinator, whose serials do not start with NS.
+        thing_type_patterns=["exr"],
         # No family_patterns — see the module note (Issue #216).
         components_range=25,
         required_components=[0, 1, 2, 3],
@@ -1143,3 +1146,58 @@ CHLORINATOR_CONFIGS: dict[str, DeviceConfig] = {
 # Signature-only profile: strip every pattern so it can never win pattern/priority
 # scoring; identifier.py hands it out solely via the tecnoLC2 component signature.
 CHLORINATOR_CONFIGS["tecnolc2_signature"].family_patterns = []
+
+
+# --- Registers read from the app's own UI config (plan 013, Pass 1) -----------
+#
+# The Fluidra app builds its tecnoLC2 screens from a `configFile` JSON that
+# declares more registers than the integration ever scanned. Three blocks of it
+# are read-only and decodable, so they are declared here for the whole lineup:
+#
+#   c252/c253 — UV lamp: c252 is the app's own display mask for the UV block
+#               (0 hides it), c253 the lamp's running hours (factor 1).
+#   c111/c118 — the two halves of the boost countdown the app joins into its
+#               "Will set prod to max for 24h" label (minutes and hours).
+#   c135/c244 — live state of the filtration block, 0 = stopped. The app hides
+#               the block when c135 reads 0 and falls back to c244.
+#
+# None of them is verified on hardware yet: the operator's own pool carries no
+# chlorinator (only an E30iQ pump), and the registers are absent from every
+# diagnostics dump collected so far. Declaring them costs nothing on the wire —
+# the bulk component fetch returns the whole register set anyway and only the
+# scan list decides what is kept — and the entities are built to stay quiet when
+# the register never answers: the UV counter reports unavailable, the UV mask and
+# the filtration state report unknown rather than a made-up zero.
+#
+# The lineup is identified by its water-temperature register: c172 is the
+# tecnoLC2 signature (the catch-all, the DM units and the eXO all read the
+# temperature elsewhere), the same signal identifier.py uses to rescue an
+# unknown-serial unit.
+UV_LAMP_REGISTERS: dict[str, int] = {"present": 252, "running_hours": 253}
+BOOST_COUNTDOWN_REGISTERS: dict[str, int] = {"hours": 118, "minutes": 111}
+FILTRATION_STATE_REGISTERS: dict[str, int] = {"state": 135, "fallback": 244}
+
+
+def _declare_tecnolc2_ui_registers() -> None:
+    """Add the UI-config registers above to every tecnoLC2 chlorinator profile."""
+    for config in CHLORINATOR_CONFIGS.values():
+        features = config.features
+        if features.get("sensors", {}).get("temperature") != 172:
+            continue
+
+        features["uv_lamp"] = dict(UV_LAMP_REGISTERS)
+        features["filtration_state"] = dict(FILTRATION_STATE_REGISTERS)
+        scan_ids = [*UV_LAMP_REGISTERS.values(), *FILTRATION_STATE_REGISTERS.values()]
+
+        # The countdown only means something on a unit that has a boost at all.
+        if features.get("boost_mode") is not None:
+            features["boost_remaining_hours"] = dict(BOOST_COUNTDOWN_REGISTERS)
+            scan_ids += list(BOOST_COUNTDOWN_REGISTERS.values())
+
+        # specific_components is the exhaustive scan set: a register missing from
+        # it is never read, whatever the entity asks for.
+        specific = features.setdefault("specific_components", [])
+        specific.extend(component for component in scan_ids if component not in specific)
+
+
+_declare_tecnolc2_ui_registers()

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -136,6 +136,9 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
     "z550iq_heat_pump": DeviceConfig(
         device_type="heat_pump",
         identifier_patterns=["LD*"],
+        # Cloud family id covering Z550iQ and Z550iQ+ (Z550iQR32), which this
+        # profile already handles together.
+        thing_type_patterns=["zs500"],
         name_patterns=["z550", "z55"],
         # No family_patterns — see the module note (Issue #216).
         components_range=5,

--- a/custom_components/fluidra_pool/device_registry/configs/probes.py
+++ b/custom_components/fluidra_pool/device_registry/configs/probes.py
@@ -21,6 +21,17 @@ PROBE_CONFIGS: dict[str, DeviceConfig] = {
         #  - comp 14 = ORP (mV, direct, e.g. 764)
         identifier_patterns=["WA*"],
         family_patterns=["data collectors"],
+        # Fluidra's own family id for the whole Blue Connect line, so a unit whose
+        # serial is not WA* and whose name does not say "gold" lands on this
+        # mapping — right readings on temperature/pH/ORP — instead of the
+        # chlorinator catch-all, which reads those registers as something else
+        # entirely (Issue #186).
+        #
+        # It is declared here, on the minimal profile, and deliberately not on
+        # the Gold: "BC3" does not tell the two apart, so putting it on both
+        # would tie them on score and hand every unnamed unit to the richer
+        # profile. The Gold is reached by its own "QX…" serial or by its name.
+        thing_type_patterns=["BC3"],
         components_range=25,
         required_components=[0, 1, 2, 3],
         # Sensor-only: no switch (probe doesn't actuate), no select (no mode),
@@ -64,6 +75,13 @@ PROBE_CONFIGS: dict[str, DeviceConfig] = {
         # so the two are told apart by the product name, which is stable across
         # units (the Silver is "…Silver").
         name_patterns=["blue connect gold"],
+        # The Gold's own cloud serial. It carries no thing_type_patterns on
+        # purpose: "BC3" covers Silver and Gold alike, so declaring it here would
+        # tie the two on score and hand every unnamed Blue Connect to this richer
+        # profile — leaving a Silver with permanently unavailable conductivity,
+        # salinity and battery entities. The family id belongs on the minimal
+        # profile; this one is reached by its serial or its name (Issue #186).
+        identifier_patterns=["QX*"],
         family_patterns=["data collectors"],
         components_range=25,
         required_components=[0, 1, 2, 3],

--- a/custom_components/fluidra_pool/device_registry/configs/pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/pumps.py
@@ -8,6 +8,10 @@ PUMP_CONFIGS: dict[str, DeviceConfig] = {
     "e30iq_pump": DeviceConfig(
         device_type="pump",
         identifier_patterns=["E30*", "LE*", "PUMP*"],
+        # Fluidra's own family id for this pump line, measured on hardware
+        # (thingType "eppvs", model E30iQ). The cloud lists Inari VS and
+        # Verdon VS under it too, and their serials need not start with E30/LE.
+        thing_type_patterns=["eppvs"],
         components_range=5,
         required_components=[0, 1, 2, 3],
         entities=[
@@ -47,6 +51,8 @@ PUMP_CONFIGS: dict[str, DeviceConfig] = {
         # remaining work — direct speed via /schedulers, activity/telemetry polish —
         # is additive, not a correctness gap).
         model_patterns=["Victoria Smart Connect"],
+        # Until now this family was recognised by its model string alone.
+        thing_type_patterns=["mppvs"],
         components_range=25,
         required_components=[0, 1, 2, 3],
         # No plain on/off "switch": the Victoria is schedule-driven, so control is

--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -69,6 +69,7 @@ def _identify_device_uncached(
     model: str,
     device_type_hint: str,
     comp7_value: str,
+    thing_type: str = "",
 ) -> DeviceConfig | None:
     """Resolve a :class:`DeviceConfig` from hashable primitives so lru_cache can memoise."""
     sorted_configs = sorted(DEVICE_CONFIGS.items(), key=lambda x: x[1].priority, reverse=True)
@@ -85,6 +86,12 @@ def _identify_device_uncached(
 
         if _match(device_id, tuple(config.identifier_patterns)):
             signal += 50
+        # Fluidra's own family identifier. Deliberately worth less than a serial
+        # match (a profile written for one unit stays more specific) and more
+        # than name/family/model, which are generic strings shared across the
+        # whole line-up ("Chlorinator", "Chlorinators").
+        if _match(thing_type, tuple(config.thing_type_patterns)):
+            signal += 40
         if _match(device_name, tuple(config.name_patterns)):
             signal += 30
         if _match(family, tuple(config.family_patterns)):
@@ -237,6 +244,7 @@ class DeviceIdentifier:
             model=str(cache_key[2]),
             device_type_hint=str(cache_key[3]).lower(),
             comp7_value=comp7_value,
+            thing_type=thing_type,
         )
         device["_identify_cache"] = {"key": cache_key, "config": result}
         return _tecnolc2_signature_override(result, components, thing_type)

--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -86,12 +86,14 @@ def _identify_device_uncached(
 
         if _match(device_id, tuple(config.identifier_patterns)):
             signal += 50
-        # Fluidra's own family identifier. Deliberately worth less than a serial
-        # match (a profile written for one unit stays more specific) and more
-        # than name/family/model, which are generic strings shared across the
-        # whole line-up ("Chlorinator", "Chlorinators").
+        # Fluidra's own family identifier, slotted between the product name and
+        # the generic strings. It names a *family*, so it must lose to a serial
+        # (a profile written for one unit) and to an explicit product name
+        # ("Blue Connect Gold" is more specific than the "BC3" family both Blue
+        # Connect models report), while still beating "Chlorinator"/"Chlorinators"
+        # and other labels the whole line-up shares.
         if _match(thing_type, tuple(config.thing_type_patterns)):
-            signal += 40
+            signal += 25
         if _match(device_name, tuple(config.name_patterns)):
             signal += 30
         if _match(family, tuple(config.family_patterns)):
@@ -223,6 +225,13 @@ class DeviceIdentifier:
         comp7_value = ""
         if "7" in components and isinstance(components["7"], dict):
             comp7_value = str(components["7"].get("reportedValue", ""))
+        if not thing_type:
+            # Some families publish the family id on component 7 instead of (or as
+            # well as) the device entry — a Blue Connect reports "BC3" there
+            # (Issue #186). Heat pumps put a product code there instead
+            # ("BXWAA"/"BXWAD"), which matches no declared family pattern, so
+            # reading it here cannot mislabel them.
+            thing_type = comp7_value
 
         cache_key = (
             device.get("device_id", ""),

--- a/custom_components/fluidra_pool/device_registry/types.py
+++ b/custom_components/fluidra_pool/device_registry/types.py
@@ -15,6 +15,12 @@ class DeviceConfig:
     name_patterns: list[str] = field(default_factory=list)  # Substrings matched against the device name.
     family_patterns: list[str] = field(default_factory=list)  # Substrings matched against the family field.
     model_patterns: list[str] = field(default_factory=list)  # Substrings matched against the model field.
+    # Fluidra's own family identifier, served on every device of the account from
+    # the very first fetch (``thingType``: "eppvs", "tecnoLC2", "domS2", ...). It
+    # names the *family*, not the unit, so it scores below a serial match but well
+    # above the catch-alls: a model nobody has reported yet still lands on the
+    # right family instead of on a profile that misreads its registers.
+    thing_type_patterns: list[str] = field(default_factory=list)
 
     # Polling scope.
     components_range: int = 25  # Number of components to scan.

--- a/custom_components/fluidra_pool/diagnostics.py
+++ b/custom_components/fluidra_pool/diagnostics.py
@@ -9,7 +9,10 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
+from .api_resilience import FluidraAuthError
 from .const import FluidraPoolConfigEntry
+from .helpers import resolve_schedule_component
+from .utils import mask_device_id
 
 TO_REDACT = {
     CONF_EMAIL,
@@ -120,8 +123,55 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Fluidra
         # ids are already masked by the verifier and the values are setpoints
         # and modes, so there is nothing identifying left to redact.
         "lost_writes": list(getattr(coordinator, "lost_writes", [])),
+        # What the cloud itself says about each device's schedule register,
+        # next to what the profile resolved. Fetched here and nowhere else:
+        # on the poll path it would cost one request per device and buy
+        # nothing, but in a bug report it settles "my schedule writes land on
+        # the wrong slot" outright (Issue #174).
+        "cloud_schedulers": await _collect_scheduler_capabilities(coordinator, coordinator_data),
         "pools": _redact_pools_data(coordinator_data),
     }
+
+
+async def _collect_scheduler_capabilities(coordinator: Any, pools_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Compare the cloud-declared schedule register with the resolved one, per device.
+
+    Never fails the diagnostics download: an endpoint that refuses, an account
+    whose token expired mid-download, or a device the cloud says nothing about
+    all come back as an empty or partial list.
+    """
+    api = getattr(coordinator, "api", None)
+    if api is None or not hasattr(api, "get_device_capabilities"):
+        return []
+
+    collected: list[dict[str, Any]] = []
+    for pool in pools_data.values():
+        if not isinstance(pool, dict):
+            continue
+        for device in pool.get("devices", []):
+            device_id = device.get("device_id")
+            if not device_id:
+                continue
+            try:
+                capabilities = await api.get_device_capabilities(device_id)
+            except (FluidraAuthError, OSError, TimeoutError):
+                continue
+
+            resolved = resolve_schedule_component(device)
+            for capability in capabilities:
+                collected.append(
+                    {
+                        "device_id": mask_device_id(device_id),
+                        "scheduler_id": capability.scheduler_id,
+                        "type": capability.scheduler_type,
+                        "enabled": capability.enabled,
+                        "cloud_component_read": capability.component_read,
+                        "cloud_component_write": capability.component_write,
+                        "profile_resolved_component": resolved,
+                        "matches_profile": capability.component_write == resolved,
+                    }
+                )
+    return collected
 
 
 def _redact_pools_data(pools_data: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/fluidra_pool/fluidra_api/__init__.py
+++ b/custom_components/fluidra_pool/fluidra_api/__init__.py
@@ -6,6 +6,20 @@ optimised for Home Assistant usage with real AWS Cognito authentication.
 
 from __future__ import annotations
 
+from ._uiconfig import (
+    SchedulerCapability,
+    UiRegister,
+    build_dynamic_scan_set,
+    parse_scheduler_capabilities,
+    parse_uiconfig,
+)
 from .client import FluidraPoolAPI
 
-__all__ = ["FluidraPoolAPI"]
+__all__ = [
+    "FluidraPoolAPI",
+    "SchedulerCapability",
+    "UiRegister",
+    "build_dynamic_scan_set",
+    "parse_scheduler_capabilities",
+    "parse_uiconfig",
+]

--- a/custom_components/fluidra_pool/fluidra_api/_uiconfig.py
+++ b/custom_components/fluidra_pool/fluidra_api/_uiconfig.py
@@ -1,0 +1,302 @@
+"""Reader and parser for the cloud's own UI configuration (``/uiconfig``).
+
+The Fluidra app does not hard-code a register map: it asks the cloud for a
+``configFile`` describing every register of the device it is about to display —
+which id to read, which to write, the factor to apply, how many decimals, the
+bounds, the unit, and when to hide the block. That is the same information this
+integration keeps by hand in ``device_registry/configs/``.
+
+Reading it at runtime is what plan 013 Pass 3 is for. The endpoint is real and
+answers, but it takes two query parameters the APK never spells out — ``appId``
+and ``appVr`` — and rejects every value tried so far (``appId=iaqualink_plus``
+gets past validation, ``appVr`` does not; see the plan for the full trace).
+Until a capture of the official app supplies them, :meth:`get_device_uiconfig`
+returns ``None`` on every call and nothing in the integration depends on it.
+
+The parser below is useful regardless: the *shape of a register block* is known
+from the APK's own literals, only the envelope around it is not, so it accepts
+the plausible envelopes the way the bulk-components parser does.
+
+A second, *working* source lives here too: ``GET /generic/devices/{id}`` answers
+without any extra parameter and carries
+``info.configuration.capabilities``, where the cloud states which register holds
+this device's schedules — the very thing the profiles resolve by hand from the
+pump-type flags (Issue #174). It is read for diagnostics only, so a mismatch
+between what the cloud declares and what the profile resolved becomes visible
+without changing any behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+from urllib.parse import quote
+
+from ..api_resilience import FluidraAuthError, FluidraError
+from ..utils import mask_device_id
+from ._base import FluidraAPIBase
+from ._constants import CONNECTED_PARAMS, FLUIDRA_EMEA_BASE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class UiRegister:
+    """One register block of a device's UI configuration."""
+
+    read_id: int
+    write_id: int | None = None
+    value_type: str | None = None
+    factor: float = 1.0
+    decimals: int = 0
+    minimum: float | None = None
+    maximum: float | None = None
+    steps: float | None = None
+    units: str | None = None
+
+    def decode(self, raw: Any) -> float | None:
+        """Turn a reported value into what the app would display.
+
+        The factor is a display multiplier — a temperature reported as 213 with
+        factor 0.1 is 21.3 °C — and ``decimals`` says how far to round. Returns
+        None for anything that is not a number, like every other decoder here.
+        """
+        try:
+            value = float(raw) * self.factor
+        except (TypeError, ValueError):
+            return None
+        return round(value, self.decimals)
+
+    def encode(self, value: float) -> float | int | None:
+        """Turn a value the user picked into what the device expects.
+
+        The inverse of :meth:`decode`. Whole results come back as ``int``: the
+        write path sends ``desiredValue`` as-is, and a register whose factor
+        makes it integral must not go out as ``700.0``.
+        """
+        if not self.factor:
+            return None
+        raw = value / self.factor
+        rounded = round(raw)
+        return rounded if abs(raw - rounded) < 1e-9 else raw
+
+
+class UiConfigMixin(FluidraAPIBase):
+    """Fetch and parse the cloud-served UI configuration of a device."""
+
+    async def get_device_uiconfig(self, device_id: str) -> dict[int, UiRegister] | None:
+        """Return the device's register map as served by the cloud.
+
+        ``None`` whenever the endpoint refuses the request or answers something
+        unrecognisable — the caller keeps its hand-written profile, which is the
+        behaviour today and the reason this is safe to call at all.
+        """
+        if not self.access_token:
+            raise FluidraAuthError("Not authenticated")
+
+        headers = self._build_auth_headers()
+        url = f"{FLUIDRA_EMEA_BASE}/generic/devices/{quote(str(device_id), safe='')}/uiconfig"
+
+        try:
+            status, data, _ = await self._request("GET", url, headers=headers, params=dict(CONNECTED_PARAMS))
+        except FluidraError as err:
+            _LOGGER.debug("UI config fetch failed for %s: %s", mask_device_id(device_id), err)
+            return None
+
+        if status != 200:
+            # Expected until the appId/appVr pair is known: the endpoint answers
+            # 400 (missing parameters) rather than 404. Debug, not a warning —
+            # nothing depends on it, so this is not a degraded state.
+            _LOGGER.debug(
+                "UI config fetch for %s returned HTTP %s",
+                mask_device_id(device_id),
+                status,
+            )
+            return None
+
+        return parse_uiconfig(data)
+
+    async def get_device_capabilities(self, device_id: str) -> list[SchedulerCapability]:
+        """Return the scheduler registers the cloud declares for this device.
+
+        Unlike :meth:`get_device_uiconfig`, this endpoint answers today. It is
+        deliberately *not* on the poll path: one request per device would buy
+        nothing in normal operation, since the profiles already resolve the
+        register. It is read when diagnostics are downloaded, where knowing
+        which register the cloud itself points at settles a whole class of
+        "my schedule writes land on the wrong slot" reports (Issue #174).
+
+        An empty list means "the cloud said nothing", never "no schedules".
+        """
+        if not self.access_token:
+            raise FluidraAuthError("Not authenticated")
+
+        url = f"{FLUIDRA_EMEA_BASE}/generic/devices/{quote(str(device_id), safe='')}"
+        try:
+            status, data, _ = await self._request(
+                "GET", url, headers=self._build_auth_headers(), params=dict(CONNECTED_PARAMS)
+            )
+        except FluidraError as err:
+            _LOGGER.debug("Capability fetch failed for %s: %s", mask_device_id(device_id), err)
+            return []
+
+        if status != 200:
+            _LOGGER.debug(
+                "Capability fetch for %s returned HTTP %s",
+                mask_device_id(device_id),
+                status,
+            )
+            return []
+
+        return parse_scheduler_capabilities(data)
+
+
+def _coerce_register(entry: Any) -> UiRegister | None:
+    """Build a UiRegister from one raw block, or None when it carries no read id."""
+    if not isinstance(entry, dict):
+        return None
+    try:
+        read_id = int(entry["readId"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    def number(key: str, default: float | None = None) -> float | None:
+        raw = entry.get(key)
+        if raw is None:
+            return default
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return default
+
+    write_raw = entry.get("writeId")
+    try:
+        write_id = int(write_raw) if write_raw is not None else None
+    except (TypeError, ValueError):
+        write_id = None
+
+    decimals = number("decimals", 0)
+    return UiRegister(
+        read_id=read_id,
+        write_id=write_id,
+        value_type=entry.get("type") if isinstance(entry.get("type"), str) else None,
+        factor=number("factor", 1.0) or 1.0,
+        decimals=int(decimals) if decimals is not None else 0,
+        minimum=number("min"),
+        maximum=number("max"),
+        steps=number("steps"),
+        units=entry.get("units") if isinstance(entry.get("units"), str) else None,
+    )
+
+
+def parse_uiconfig(data: Any) -> dict[int, UiRegister] | None:
+    """Normalise a ``/uiconfig`` payload into ``{read_id: UiRegister}``.
+
+    The envelope is unconfirmed, so accept what it can plausibly be — a bare
+    list of blocks, a ``configFile``/``components``/``registers`` wrapper around
+    one, or a mapping keyed by register id — and return ``None`` for anything
+    else rather than an empty map, which a caller would read as "this device has
+    no registers".
+    """
+    entries: Any = data
+    if isinstance(data, dict):
+        for key in ("configFile", "components", "registers", "uiConfig"):
+            nested = data.get(key)
+            if isinstance(nested, (list, dict)):
+                return parse_uiconfig(nested)
+
+        registers: dict[int, UiRegister] = {}
+        for key, value in data.items():
+            register = _coerce_register(value)
+            if register is not None:
+                registers[register.read_id] = register
+                continue
+            # A mapping keyed by register id, whose blocks omit their own readId.
+            if isinstance(value, dict):
+                try:
+                    keyed = int(key)
+                except (TypeError, ValueError):
+                    continue
+                register = _coerce_register({"readId": keyed, **value})
+                if register is not None:
+                    registers[keyed] = register
+        return registers or None
+
+    if not isinstance(entries, list):
+        return None
+
+    registers = {}
+    for entry in entries:
+        register = _coerce_register(entry)
+        if register is not None:
+            registers[register.read_id] = register
+    return registers or None
+
+
+def build_dynamic_scan_set(profile_specific: list[int], uiconfig: dict[int, UiRegister] | None) -> list[int]:
+    """Union the profile's scan set with the registers the cloud declares.
+
+    The profile always wins on ordering and is never dropped: its list is the
+    result of decoding real hardware, while the cloud's is a superset that
+    includes registers nothing knows how to read yet.
+    """
+    scan_set = list(profile_specific)
+    if not uiconfig:
+        return scan_set
+    scan_set.extend(read_id for read_id in sorted(uiconfig) if read_id not in scan_set)
+    return scan_set
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerCapability:
+    """One scheduler block the cloud declares for a device."""
+
+    scheduler_id: str | None
+    component_read: int | None
+    component_write: int | None
+    scheduler_type: str | None
+    enabled: bool
+
+
+def parse_scheduler_capabilities(payload: Any) -> list[SchedulerCapability]:
+    """Pull the scheduler blocks out of a ``GET /devices/{id}`` payload.
+
+    Returns an empty list for anything unexpected: this is diagnostic
+    information, and a device that declares nothing is a normal answer.
+    """
+    if not isinstance(payload, dict):
+        return []
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return []
+    configuration = info.get("configuration")
+    if not isinstance(configuration, dict):
+        return []
+    capabilities = configuration.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return []
+    blocks = capabilities.get("schedulers")
+    if not isinstance(blocks, list):
+        return []
+
+    def component(block: dict[str, Any], key: str) -> int | None:
+        try:
+            return int(block[key])
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    parsed: list[SchedulerCapability] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        parsed.append(
+            SchedulerCapability(
+                scheduler_id=block.get("id") if isinstance(block.get("id"), str) else None,
+                component_read=component(block, "componentRead"),
+                component_write=component(block, "componentWrite"),
+                scheduler_type=block.get("type") if isinstance(block.get("type"), str) else None,
+                enabled=bool(block.get("enabled", False)),
+            )
+        )
+    return parsed

--- a/custom_components/fluidra_pool/fluidra_api/_websocket.py
+++ b/custom_components/fluidra_pool/fluidra_api/_websocket.py
@@ -1,0 +1,256 @@
+"""Realtime channel: the cloud pushes component changes instead of being polled.
+
+Measured end to end on 2026-08-26 (see ``API-DISCOVERY.md`` §10), and every
+design decision here follows from one of those measurements:
+
+* the handshake authenticates with the Cognito access token as a **query
+  parameter** — an ``Authorization`` header gets a 401;
+* a silent connection is closed at **600 s exactly** with ``close_code=1006``,
+  the AWS API Gateway idle timeout, so a keepalive well under that is not
+  optional and an abrupt 1006 is a normal event, not an error;
+* the token is checked **only at handshake time** — a live connection keeps
+  working long after it expires, so there is no reason to reconnect when the
+  token is refreshed;
+* replies come back **asynchronously**, out of step with what was sent, so
+  there is a single reader loop and nothing ever waits for a reply;
+* ``unsubsPool`` answers 500, so closing the socket is how you stop everything.
+
+The channel is an accelerator, never a source of truth: the REST poll keeps
+running unchanged, and a push only shortens the wait for a value the next poll
+would have brought anyway. That is what makes it safe to fail silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import json
+import logging
+from typing import Any
+
+import aiohttp
+
+from ..utils import mask_device_id
+from ._constants import FLUIDRA_USER_AGENT
+
+_LOGGER = logging.getLogger(__name__)
+
+WS_URL = "wss://ws.fluidra-emea.com"
+
+# Well under the 600 s idle timeout measured on the gateway, and frequent
+# enough that a dead connection is noticed within a poll cycle rather than at
+# the next state change.
+PING_INTERVAL = 240.0
+
+# A closed socket is routine here (idle timeout, gateway recycling, network
+# blips), so reconnection starts fast and backs off to something that will not
+# hammer the cloud if it is down for an hour.
+INITIAL_RECONNECT_DELAY = 5.0
+MAX_RECONNECT_DELAY = 300.0
+RECONNECT_MULTIPLIER = 2.0
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentChange:
+    """One ``componentChange`` frame, as the cloud pushes it."""
+
+    device_id: str
+    component_id: int
+    reported_value: Any
+    timestamp: int | None = None
+
+
+def parse_frame(raw: Any) -> ComponentChange | None:
+    """Turn one received frame into a ComponentChange, or None.
+
+    None covers everything that is not a usable state change: subscription
+    acknowledgements, the ``Forbidden`` reply to an unknown action, malformed
+    payloads. The body is itself a JSON *string* inside the envelope, which is
+    why it is decoded twice.
+    """
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            raw = raw.decode()
+        except UnicodeDecodeError:
+            return None
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(raw, dict) or raw.get("action") != "componentChange":
+        return None
+
+    body = raw.get("body")
+    if isinstance(body, str):
+        try:
+            body = json.loads(body)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(body, dict):
+        return None
+
+    device_id = body.get("deviceId")
+    if not isinstance(device_id, str) or not device_id:
+        return None
+    try:
+        component_id = int(body["componentId"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if "reportedValue" not in body:
+        return None
+
+    timestamp = body.get("ts")
+    try:
+        timestamp = int(timestamp) if timestamp is not None else None
+    except (TypeError, ValueError):
+        timestamp = None
+
+    return ComponentChange(
+        device_id=device_id,
+        component_id=component_id,
+        reported_value=body["reportedValue"],
+        timestamp=timestamp,
+    )
+
+
+class FluidraWebsocketClient:
+    """Keep one subscribed connection alive and hand changes to a callback.
+
+    Owns nothing but its own task: the session and the token come from the API
+    client, the devices to subscribe to are given at start, and what to do with
+    a change is the caller's business.
+    """
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        token_provider: Callable[[], str | None],
+        on_change: Callable[[ComponentChange], Awaitable[None] | None],
+        url: str = WS_URL,
+    ) -> None:
+        """Initialize the client. Nothing connects until :meth:`start`."""
+        self._session = session
+        self._token_provider = token_provider
+        self._on_change = on_change
+        self._url = url
+        self._device_ids: list[str] = []
+        self._task: asyncio.Task[None] | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._stopping = False
+        self.connected = False
+        self.changes_received = 0
+        self.reconnections = 0
+
+    async def start(self, device_ids: list[str]) -> None:
+        """Begin connecting, and keep the connection up until :meth:`stop`."""
+        self._device_ids = list(device_ids)
+        self._stopping = False
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Close the connection and stop reconnecting."""
+        self._stopping = True
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # shutdown must not raise
+                pass
+            self._task = None
+        self.connected = False
+
+    async def update_devices(self, device_ids: list[str]) -> None:
+        """Subscribe to devices discovered after the connection was opened."""
+        new = [device_id for device_id in device_ids if device_id not in self._device_ids]
+        self._device_ids.extend(new)
+        if not new or self._ws is None or self._ws.closed:
+            return
+        for device_id in new:
+            await self._subscribe(self._ws, device_id)
+
+    async def _subscribe(self, ws: aiohttp.ClientWebSocketResponse, device_id: str) -> None:
+        """Send one subscription. The acknowledgement, if any, arrives later."""
+        await ws.send_json({"action": "subsDevice", "deviceType": "connected", "deviceId": device_id})
+
+    async def _run(self) -> None:
+        """Connect, read, and reconnect with backoff until stopped."""
+        delay = INITIAL_RECONNECT_DELAY
+        while not self._stopping:
+            try:
+                await self._connect_once()
+                # A clean return means the socket closed: reconnect promptly,
+                # since the commonest cause is the 600 s idle timeout.
+                delay = INITIAL_RECONNECT_DELAY
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # the channel must never break the integration
+                _LOGGER.debug("Realtime channel error (%s), retrying in %.0fs", type(err).__name__, delay)
+                delay = min(delay * RECONNECT_MULTIPLIER, MAX_RECONNECT_DELAY)
+
+            if self._stopping:
+                break
+            self.connected = False
+            self.reconnections += 1
+            await asyncio.sleep(delay)
+
+    async def _connect_once(self) -> None:
+        """Open one connection and read it until it closes."""
+        token = self._token_provider()
+        if not token:
+            raise RuntimeError("no access token available")
+
+        headers = {"User-Agent": FLUIDRA_USER_AGENT}
+        async with self._session.ws_connect(
+            f"{self._url}?token={token}", headers=headers, autoping=False, heartbeat=None
+        ) as ws:
+            self._ws = ws
+            self.connected = True
+            _LOGGER.debug("Realtime channel connected, subscribing to %d device(s)", len(self._device_ids))
+            for device_id in self._device_ids:
+                await self._subscribe(ws, device_id)
+
+            pinger = asyncio.create_task(self._ping_loop(ws))
+            try:
+                async for message in ws:
+                    if message.type is not aiohttp.WSMsgType.TEXT:
+                        continue
+                    await self._handle(message.data)
+            finally:
+                pinger.cancel()
+                self._ws = None
+                self.connected = False
+
+    async def _ping_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Keep the connection under the gateway's idle timeout."""
+        try:
+            while not ws.closed:
+                await asyncio.sleep(PING_INTERVAL)
+                if ws.closed:
+                    return
+                await ws.ping(b"ha")
+        except (asyncio.CancelledError, ConnectionResetError, aiohttp.ClientError):
+            return
+
+    async def _handle(self, data: Any) -> None:
+        """Dispatch one frame, never letting a callback failure kill the reader."""
+        change = parse_frame(data)
+        if change is None:
+            return
+        self.changes_received += 1
+        _LOGGER.debug(
+            "Realtime change: device %s component %s = %s",
+            mask_device_id(change.device_id),
+            change.component_id,
+            change.reported_value,
+        )
+        try:
+            result = self._on_change(change)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:  # a bad callback must not close the channel
+            _LOGGER.exception("Realtime change handler failed")

--- a/custom_components/fluidra_pool/fluidra_api/client.py
+++ b/custom_components/fluidra_pool/fluidra_api/client.py
@@ -15,6 +15,7 @@ from ._components import ComponentsMixin
 from ._devices import DevicesMixin
 from ._schedules import PendingScheduleWrite, SchedulesMixin
 from ._session import SessionMixin
+from ._uiconfig import UiConfigMixin
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -22,7 +23,15 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
-class FluidraPoolAPI(SessionMixin, AuthMixin, DevicesMixin, ComponentsMixin, CommandsMixin, SchedulesMixin):
+class FluidraPoolAPI(
+    SessionMixin,
+    AuthMixin,
+    DevicesMixin,
+    ComponentsMixin,
+    CommandsMixin,
+    SchedulesMixin,
+    UiConfigMixin,
+):
     """Wrapper for Fluidra Pool API for Home Assistant.
 
     Deliberately not slotted: there is a single instance per config entry (no

--- a/custom_components/fluidra_pool/icons.json
+++ b/custom_components/fluidra_pool/icons.json
@@ -6,6 +6,18 @@
         "state": {
           "on": "mdi:flash"
         }
+      },
+      "filtration_state": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump"
+        }
+      },
+      "uv_present": {
+        "default": "mdi:lightbulb-off-outline",
+        "state": {
+          "on": "mdi:lightbulb-on-outline"
+        }
       }
     },
     "climate": {

--- a/custom_components/fluidra_pool/select/__init__.py
+++ b/custom_components/fluidra_pool/select/__init__.py
@@ -17,7 +17,11 @@ from ..platform_setup import async_setup_dynamic_platform
 from .aux import FluidraAuxOutputSelect
 from .chlorinator import FluidraChlorinatorModeSelect
 from .light import FluidraLightEffectSelect
-from .pump import FluidraPumpSpeedSelect, FluidraVictoriaQuickFunctionSelect
+from .pump import (
+    FluidraPumpSpeedSelect,
+    FluidraThreeSpeedPumpSelect,
+    FluidraVictoriaQuickFunctionSelect,
+)
 from .schedule import FluidraChlorinatorScheduleSpeedSelect, FluidraScheduleModeSelect
 
 if TYPE_CHECKING:
@@ -31,6 +35,7 @@ __all__ = [
     "FluidraLightEffectSelect",
     "FluidraPumpSpeedSelect",
     "FluidraScheduleModeSelect",
+    "FluidraThreeSpeedPumpSelect",
     "FluidraVictoriaQuickFunctionSelect",
     "async_setup_entry",
 ]
@@ -71,10 +76,28 @@ async def async_setup_entry(
         if DeviceIdentifier.has_feature(device, "skip_schedules"):
             return entities
 
+        # Three-speed filtration pump driven through a controller register, as
+        # opposed to the E30iQ's own c9/c11 pair below. The two are mutually
+        # exclusive: a profile declaring pump_3speed drives the pump only here.
+        three_speed = DeviceIdentifier.get_feature(device, "pump_3speed")
+        if isinstance(three_speed, dict) and three_speed.get("component") is not None:
+            entities.append(
+                FluidraThreeSpeedPumpSelect(
+                    coordinator,
+                    coordinator.api,
+                    pool_id,
+                    device_id,
+                    three_speed["component"],
+                    three_speed.get("write_map"),
+                    three_speed.get("read_map"),
+                )
+            )
+
         if (
             device_type == DEVICE_TYPE_PUMP
             and DeviceIdentifier.should_create_entity(device, "select")
             and device.get("variable_speed")
+            and not isinstance(three_speed, dict)
         ):
             entities.append(FluidraPumpSpeedSelect(coordinator, coordinator.api, pool_id, device_id))
 

--- a/custom_components/fluidra_pool/select/pump.py
+++ b/custom_components/fluidra_pool/select/pump.py
@@ -185,6 +185,101 @@ class FluidraPumpSpeedSelect(FluidraPoolControlEntity, SelectEntity):
         return attrs
 
 
+# Fallback mapping for the three-speed control register, used when a profile
+# declares the feature without spelling its own tables out. Both directions are
+# profile-overridable on purpose: the app's own UI config reads the state as
+# 0/1/2 and writes 1/2/3, but which physical speed each number stands for is the
+# one thing the APK dump does not settle (plan 013, Pass 2), so a family that
+# turns out to number them differently is a profile edit, not a code change.
+THREE_SPEED_DEFAULT_WRITE: dict[str, int] = {"low": 1, "medium": 2, "high": 3}
+THREE_SPEED_DEFAULT_READ: dict[int, str] = {0: "low", 1: "medium", 2: "high"}
+
+
+class FluidraThreeSpeedPumpSelect(FluidraPoolControlEntity, SelectEntity):
+    """Speed of a three-speed filtration pump driven by a controller register.
+
+    Distinct from :class:`FluidraPumpSpeedSelect`, which drives an E30iQ over
+    its own c9/c11 pair and derives its state from the coordinator's decoded
+    ``speed_level_reported``/``speed_percent``. Here the controller exposes a
+    single register carrying the speed as a small integer, and writing that
+    same register changes it — nothing else in the device data reflects it.
+
+    Both the read table and the write table come from the profile
+    (``pump_3speed``), so a family that numbers its speeds differently needs no
+    code change.
+    """
+
+    __slots__ = ("_component", "_optimistic_option", "_read_map", "_write_map")
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        component: int,
+        write_map: dict[str, int] | None = None,
+        read_map: dict[int, str] | None = None,
+    ) -> None:
+        """Initialize the three-speed select."""
+        super().__init__(coordinator, api, pool_id, device_id)
+        self._component = component
+        self._write_map = dict(write_map or THREE_SPEED_DEFAULT_WRITE)
+        self._read_map = dict(read_map or THREE_SPEED_DEFAULT_READ)
+        self._optimistic_option: str | None = None
+
+        self._attr_unique_id = f"{DOMAIN}_{pool_id}_{device_id}_pump_3speed"
+        self._attr_translation_key = "pump_3speed"
+        self._attr_options = list(self._write_map)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the speed the controller reports, or None while it is unknown."""
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+
+        components = self.device_data.get("components", {})
+        raw = components.get(str(self._component), {}).get("reportedValue")
+        if raw is None:
+            return None
+        try:
+            reported = int(float(raw))
+        except (ValueError, TypeError):
+            _LOGGER.debug("Unparsable three-speed value %s on component %s", raw, self._component)
+            return None
+
+        option = self._read_map.get(reported)
+        if option is None:
+            # A value outside the declared table means the profile's mapping is
+            # wrong for this unit — say nothing rather than name a wrong speed.
+            _LOGGER.debug("Three-speed register %s reports unmapped value %s", self._component, reported)
+        return option
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the requested speed to the controller's register."""
+        self._ensure_pool_writable()
+        value = self._write_map.get(option)
+        if value is None:
+            return
+
+        try:
+            self._optimistic_option = option
+            self.async_write_ha_state()
+
+            success = await self._api.control_device_component(self._device_id, self._component, value)
+            if success:
+                await asyncio.sleep(COMMAND_CONFIRMATION_DELAY)
+                await self.coordinator.async_request_refresh()
+        except (aiohttp.ClientError, TimeoutError, FluidraError) as err:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="pump_speed_set_failed") from err
+        finally:
+            self._optimistic_option = None
+            self.async_write_ha_state()
+
+        if not success:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="pump_speed_set_failed")
+
+
 class FluidraVictoriaQuickFunctionSelect(FluidraPoolControlEntity, SelectEntity):
     """Run one of the Victoria's configured quick functions (Issue #144).
 

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -15,7 +15,12 @@ from ..const import (
 from ..device_registry import DeviceIdentifier
 from ..platform_setup import async_setup_dynamic_platform
 from .base import FluidraPoolSensorBase, FluidraPoolSensorEntity
-from .chlorinator import FluidraBoostRemainingSensor, FluidraChlorinatorSensor
+from .chlorinator import (
+    FluidraBoostRemainingHoursSensor,
+    FluidraBoostRemainingSensor,
+    FluidraChlorinatorSensor,
+    FluidraUvRunningHoursSensor,
+)
 from .device import (
     FluidraCabinetPackedConfigSensor,
     FluidraCompressorHoursSensor,
@@ -47,6 +52,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 __all__ = [
+    "FluidraBoostRemainingHoursSensor",
     "FluidraBoostRemainingSensor",
     "FluidraCabinetPackedConfigSensor",
     "FluidraChlorinatorSensor",
@@ -71,6 +77,7 @@ __all__ = [
     "FluidraRunningHoursSensor",
     "FluidraScheduleDaysSensor",
     "FluidraTemperatureSensor",
+    "FluidraUvRunningHoursSensor",
     "FluidraWifiSignalSensor",
     "async_setup_entry",
 ]
@@ -169,6 +176,23 @@ async def async_setup_entry(
         if device_type == DEVICE_TYPE_CHLORINATOR:
             if DeviceIdentifier.has_feature(device, "boost_remaining"):
                 entities.append(FluidraBoostRemainingSensor(coordinator, coordinator.api, pool_id, device_id))
+
+            # Families that split the countdown over an hours + minutes pair
+            # instead of the eXO's single minute register.
+            if isinstance(DeviceIdentifier.get_feature(device, "boost_remaining_hours"), dict):
+                entities.append(FluidraBoostRemainingHoursSensor(coordinator, coordinator.api, pool_id, device_id))
+
+            uv_lamp = DeviceIdentifier.get_feature(device, "uv_lamp")
+            if isinstance(uv_lamp, dict) and uv_lamp.get("running_hours") is not None:
+                entities.append(
+                    FluidraUvRunningHoursSensor(
+                        coordinator,
+                        coordinator.api,
+                        pool_id,
+                        device_id,
+                        uv_lamp["running_hours"],
+                    )
+                )
 
             sensors_config = DeviceIdentifier.get_feature(device, "sensors", {})
 

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -97,6 +97,162 @@ class FluidraBoostRemainingSensor(FluidraPoolEntity, SensorEntity):
             return None
 
 
+class FluidraBoostRemainingHoursSensor(FluidraPoolEntity, SensorEntity):
+    """Time left on a running boost cycle, on the families that split it in two.
+
+    The tecnoLC2/CC chlorinators do not carry the eXO's single-register minute
+    countdown (c51): the app builds its "Will set prod to max for 24h" label
+    from a pair of registers, hours and minutes, declared by the profile as the
+    ``boost_remaining_hours`` feature. Both are combined into one value in
+    hours, so a dashboard gets a single number instead of two halves.
+
+    0 is a real reading (boost off), not a missing one, and is reported as-is.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "boost_remaining_hours"
+    _attr_icon = "mdi:timer-sand"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the split boost countdown sensor."""
+        super().__init__(coordinator, pool_id, device_id)
+        self._api = api
+        self._attr_unique_id = f"fluidra_{device_id}_boost_remaining_hours"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
+        firmware = self.device_data.get("firmware_version_component")
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+            model="Chlorinator",
+            sw_version=str(firmware) if firmware is not None else None,
+            via_device=(DOMAIN, self._pool_id),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True once the device has reported component data."""
+        return self.coordinator.last_update_success and bool(self.device_data.get("components"))
+
+    def _read_part(self, component: Any) -> float | None:
+        """Return one half of the countdown, or None when it is missing."""
+        if component is None:
+            return None
+        components = self.device_data.get("components", {})
+        raw = components.get(str(component), {}).get("reportedValue")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            _LOGGER.debug("Unparsable boost countdown value %s on component %s", raw, component)
+            return None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the remaining boost time in hours.
+
+        Either half may be absent (a firmware that reports only whole hours, or
+        only the minutes of the last hour), so the value is whatever is
+        actually reported — None only when neither register answers.
+        """
+        feature = DeviceIdentifier.get_feature(self.device_data, "boost_remaining_hours", None)
+        if not isinstance(feature, dict):
+            return None
+
+        hours = self._read_part(feature.get("hours"))
+        minutes = self._read_part(feature.get("minutes"))
+        if hours is None and minutes is None:
+            return None
+
+        total = (hours or 0.0) + (minutes or 0.0) / 60
+        return round(total, 2)
+
+
+class FluidraUvRunningHoursSensor(FluidraPoolEntity, SensorEntity):
+    """Running hours of the UV lamp of a chlorinator that has one.
+
+    The register is a plain integer hour counter (factor 1, no decimals in the
+    app's own UI block), so it is exposed as a TOTAL_INCREASING duration — the
+    lamp-replacement interval is a running-hours threshold.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "uv_running_hours"
+    _attr_icon = "mdi:clock-outline"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        component_id: int,
+    ) -> None:
+        """Initialize the UV running-hours sensor."""
+        super().__init__(coordinator, pool_id, device_id)
+        self._api = api
+        self._component_id = component_id
+        self._attr_unique_id = f"fluidra_{device_id}_uv_running_hours"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
+        firmware = self.device_data.get("firmware_version_component")
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+            model="Chlorinator",
+            sw_version=str(firmware) if firmware is not None else None,
+            via_device=(DOMAIN, self._pool_id),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True once the device has reported this register.
+
+        Unlike the measurement sensors, availability is tied to the register
+        itself: a unit whose UV block is absent must not show a permanently
+        zero counter.
+        """
+        if not (self.coordinator.last_update_success and self.device_data.get("components")):
+            return False
+        components = self.device_data.get("components", {})
+        return components.get(str(self._component_id), {}).get("reportedValue") is not None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the UV lamp running hours."""
+        components = self.device_data.get("components", {})
+        raw = components.get(str(self._component_id), {}).get("reportedValue")
+        if raw is None:
+            return None
+        try:
+            return int(float(raw))
+        except (ValueError, TypeError):
+            _LOGGER.debug("Unparsable UV running hours %s on component %s", raw, self._component_id)
+            return None
+
+
 class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
     """Sensor for chlorinator measurements (pH, ORP, chlorine, temperature, salinity)."""
 

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -65,6 +65,9 @@
       "chlorinator_producing": {
         "name": "Producing"
       },
+      "filtration_state": {
+        "name": "Filtration running"
+      },
       "no_flow_alarm": {
         "name": "No flow fault"
       },
@@ -76,6 +79,9 @@
       },
       "speed_input_medium": {
         "name": "Medium speed input"
+      },
+      "uv_present": {
+        "name": "UV lamp detected"
       }
     },
     "button": {
@@ -173,6 +179,14 @@
           "static_color": "Static Color"
         }
       },
+      "pump_3speed": {
+        "name": "Three-speed pump",
+        "state": {
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High"
+        }
+      },
       "pump_speed": {
         "name": "Speed Level",
         "state": {
@@ -204,8 +218,14 @@
       "boost_remaining": {
         "name": "Boost Remaining"
       },
+      "boost_remaining_hours": {
+        "name": "Boost Remaining"
+      },
       "brightness": {
         "name": "Brightness"
+      },
+      "cabinet_packed_config": {
+        "name": "Packed pump config"
       },
       "chlorinator_battery_voltage": {
         "name": "Battery Voltage"
@@ -319,6 +339,9 @@
       "target_temperature": {
         "name": "Target Temperature"
       },
+      "uv_running_hours": {
+        "name": "UV Lamp Running Hours"
+      },
       "water_quality": {
         "name": "Water Quality",
         "state": {
@@ -335,9 +358,6 @@
       },
       "wifi_signal": {
         "name": "WiFi Signal"
-      },
-      "cabinet_packed_config": {
-        "name": "Packed pump config"
       }
     },
     "switch": {
@@ -544,9 +564,11 @@
     "step": {
       "init": {
         "data": {
+          "enable_realtime": "Realtime updates (experimental)",
           "scan_interval": "Update interval (seconds)"
         },
         "data_description": {
+          "enable_realtime": "Lets the Fluidra cloud push changes as they happen, instead of waiting for the next poll — a state change lands in about 2 seconds. Polling keeps running either way, so turning this off simply returns to the previous behaviour.",
           "scan_interval": "How often Home Assistant polls the Fluidra cloud. Lower values give fresher data but more requests."
         },
         "description": "Configure advanced options",

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -65,6 +65,9 @@
       "chlorinator_producing": {
         "name": "Producing"
       },
+      "filtration_state": {
+        "name": "Filtration running"
+      },
       "no_flow_alarm": {
         "name": "No flow fault"
       },
@@ -76,6 +79,9 @@
       },
       "speed_input_medium": {
         "name": "Medium speed input"
+      },
+      "uv_present": {
+        "name": "UV lamp detected"
       }
     },
     "button": {
@@ -173,6 +179,14 @@
           "static_color": "Static Color"
         }
       },
+      "pump_3speed": {
+        "name": "Three-speed pump",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
       "pump_speed": {
         "name": "Speed Level",
         "state": {
@@ -202,6 +216,9 @@
         "name": "Battery"
       },
       "boost_remaining": {
+        "name": "Boost Remaining"
+      },
+      "boost_remaining_hours": {
         "name": "Boost Remaining"
       },
       "brightness": {
@@ -321,6 +338,9 @@
       },
       "target_temperature": {
         "name": "Target Temperature"
+      },
+      "uv_running_hours": {
+        "name": "UV Lamp Running Hours"
       },
       "water_quality": {
         "name": "Water Quality",
@@ -544,9 +564,11 @@
     "step": {
       "init": {
         "data": {
+          "enable_realtime": "Realtime updates (experimental)",
           "scan_interval": "Update interval (seconds)"
         },
         "data_description": {
+          "enable_realtime": "Lets the Fluidra cloud push changes as they happen, instead of waiting for the next poll — a state change lands in about 2 seconds. Polling keeps running either way, so turning this off simply returns to the previous behaviour.",
           "scan_interval": "How often Home Assistant polls the Fluidra cloud. Lower values give fresher data but more requests."
         },
         "description": "Configure advanced options",

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -65,6 +65,9 @@
       "chlorinator_producing": {
         "name": "Produciendo"
       },
+      "filtration_state": {
+        "name": "Filtración en marcha"
+      },
       "no_flow_alarm": {
         "name": "Fallo de falta de caudal"
       },
@@ -76,6 +79,9 @@
       },
       "speed_input_medium": {
         "name": "Entrada velocidad media"
+      },
+      "uv_present": {
+        "name": "Lámpara UV detectada"
       }
     },
     "button": {
@@ -173,6 +179,14 @@
           "static_color": "Color Fijo"
         }
       },
+      "pump_3speed": {
+        "name": "Bomba de 3 velocidades",
+        "state": {
+          "high": "Velocidad alta",
+          "low": "Velocidad baja",
+          "medium": "Velocidad media"
+        }
+      },
       "pump_speed": {
         "name": "Nivel de Velocidad",
         "state": {
@@ -203,6 +217,9 @@
       },
       "boost_remaining": {
         "name": "Turbo restante"
+      },
+      "boost_remaining_hours": {
+        "name": "Tiempo de boost restante"
       },
       "brightness": {
         "name": "Brillo"
@@ -321,6 +338,9 @@
       },
       "target_temperature": {
         "name": "Temperatura Objetivo"
+      },
+      "uv_running_hours": {
+        "name": "Horas de funcionamiento de la lámpara UV"
       },
       "water_quality": {
         "name": "Calidad del Agua",
@@ -544,9 +564,11 @@
     "step": {
       "init": {
         "data": {
+          "enable_realtime": "Actualizaciones en tiempo real (experimental)",
           "scan_interval": "Intervalo de actualización (segundos)"
         },
         "data_description": {
+          "enable_realtime": "Permite que la nube de Fluidra envíe los cambios en cuanto se producen, en lugar de esperar al siguiente sondeo: un cambio de estado llega en unos 2 segundos. El sondeo sigue funcionando igualmente, así que desactivar esta opción vuelve al comportamiento anterior.",
           "scan_interval": "Frecuencia con la que Home Assistant consulta la nube de Fluidra. Un valor más bajo ofrece datos más recientes pero genera más solicitudes."
         },
         "description": "Configurar opciones avanzadas",

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -65,6 +65,9 @@
       "chlorinator_producing": {
         "name": "En production"
       },
+      "filtration_state": {
+        "name": "Filtration en marche"
+      },
       "no_flow_alarm": {
         "name": "Défaut absence de débit"
       },
@@ -76,6 +79,9 @@
       },
       "speed_input_medium": {
         "name": "Entrée vitesse moyenne"
+      },
+      "uv_present": {
+        "name": "Lampe UV détectée"
       }
     },
     "button": {
@@ -173,6 +179,14 @@
           "static_color": "Couleur fixe"
         }
       },
+      "pump_3speed": {
+        "name": "Pompe 3 vitesses",
+        "state": {
+          "high": "Grande vitesse",
+          "low": "Petite vitesse",
+          "medium": "Vitesse moyenne"
+        }
+      },
       "pump_speed": {
         "name": "Niveau de Vitesse",
         "state": {
@@ -203,6 +217,9 @@
       },
       "boost_remaining": {
         "name": "Boost restant"
+      },
+      "boost_remaining_hours": {
+        "name": "Temps de boost restant"
       },
       "brightness": {
         "name": "Luminosité"
@@ -321,6 +338,9 @@
       },
       "target_temperature": {
         "name": "Température Cible"
+      },
+      "uv_running_hours": {
+        "name": "Heures de fonctionnement de la lampe UV"
       },
       "water_quality": {
         "name": "Qualité de l'Eau",
@@ -544,9 +564,11 @@
     "step": {
       "init": {
         "data": {
+          "enable_realtime": "Mises à jour en temps réel (expérimental)",
           "scan_interval": "Intervalle de mise à jour (secondes)"
         },
         "data_description": {
+          "enable_realtime": "Laisse le cloud Fluidra pousser les changements au moment où ils surviennent, au lieu d'attendre l'interrogation suivante — un changement d'état arrive en 2 secondes environ. L'interrogation continue dans tous les cas : désactiver cette option revient simplement au comportement précédent.",
           "scan_interval": "Fréquence d'interrogation du cloud Fluidra par Home Assistant. Une valeur plus basse donne des données plus fraîches mais génère davantage de requêtes."
         },
         "description": "Configurer les options avancées",

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -65,6 +65,9 @@
       "chlorinator_producing": {
         "name": "A produzir"
       },
+      "filtration_state": {
+        "name": "Filtração em funcionamento"
+      },
       "no_flow_alarm": {
         "name": "Falha de ausência de caudal"
       },
@@ -76,6 +79,9 @@
       },
       "speed_input_medium": {
         "name": "Entrada velocidade média"
+      },
+      "uv_present": {
+        "name": "Lâmpada UV detetada"
       }
     },
     "button": {
@@ -173,6 +179,14 @@
           "static_color": "Cor Fixa"
         }
       },
+      "pump_3speed": {
+        "name": "Bomba de 3 velocidades",
+        "state": {
+          "high": "Velocidade alta",
+          "low": "Velocidade baixa",
+          "medium": "Velocidade média"
+        }
+      },
       "pump_speed": {
         "name": "Nível de Velocidade",
         "state": {
@@ -203,6 +217,9 @@
       },
       "boost_remaining": {
         "name": "Turbo restante"
+      },
+      "boost_remaining_hours": {
+        "name": "Tempo de boost restante"
       },
       "brightness": {
         "name": "Brilho"
@@ -321,6 +338,9 @@
       },
       "target_temperature": {
         "name": "Temperatura Alvo"
+      },
+      "uv_running_hours": {
+        "name": "Horas de funcionamento da lâmpada UV"
       },
       "water_quality": {
         "name": "Qualidade da Água",
@@ -544,9 +564,11 @@
     "step": {
       "init": {
         "data": {
+          "enable_realtime": "Atualizações em tempo real (experimental)",
           "scan_interval": "Intervalo de atualização (segundos)"
         },
         "data_description": {
+          "enable_realtime": "Permite que a nuvem da Fluidra envie as alterações assim que ocorrem, em vez de esperar pela sondagem seguinte — uma alteração de estado chega em cerca de 2 segundos. A sondagem continua a funcionar, pelo que desativar esta opção repõe o comportamento anterior.",
           "scan_interval": "Frequência com que o Home Assistant consulta a nuvem Fluidra. Um valor mais baixo fornece dados mais recentes mas gera mais pedidos."
         },
         "description": "Configurar opções avançadas",

--- a/plans/013-api-discovery-implementation.md
+++ b/plans/013-api-discovery-implementation.md
@@ -1,0 +1,1222 @@
+# Plan — Fluidra `uiconfig` / WebSocket / new registers / automations / telemetry
+
+> Source: `API-DISCOVERY.md` (APK `com.fluidra.iaqualinkplus_2.23.1.apks`, Flutter
+> AOT). Existing integration: v2.84.0, Platinum, 1312 tests, ~97.5 % coverage.
+> This plan does **not** implement anything; it is the sequence of self-contained
+> work sessions the operator will run later.
+
+## 0. Reading-the-doc audit (what's already covered, do not re-plan)
+
+The `API-DISCOVERY.md` doc lists a lot of surfaces. Several are already wired and
+must not be re-planned:
+
+| Surface | Existing module | Status |
+|---|---|---|
+| `GET /generic/devices` | `fluidra_api/_devices.py:60-226` | covered (`async_update_data`, `_discover_devices_for_pool`) |
+| `GET /generic/devices/{id}/components` (bulk + per-component) | `fluidra_api/_components.py:40-114` (`get_all_components`, `_parse_bulk_components`) | covered since v2.66.0 |
+| `GET /generic/pools/{id}` / `/status` | `fluidra_api/_devices.py:344-371` (`get_pool_details`) | covered |
+| `GET /generic/pools/{id}/schedulers` | `fluidra_api/_schedules.py:219-249` | covered (Issue #144/#67) — **not** the same as `/automations` |
+| `PUT /generic/devices/{id}/components/{cid}` (control write) | `fluidra_api/_components.py:131-184` + `control_device_component` + `write_verifier` | covered (Issues #133/#195) |
+| Per-component write formats (c9, c10, c11, c13, c15, c17, c20, c45, c258) | `fluidra_api/_commands.py` + per-family profiles in `device_registry/configs/` | covered (Pr #205, #210, #212, #195) |
+| Read-only (viewer) write guard | `entity.py:109-123`, `__init__.py:337-354` | covered (Issue #133) |
+
+Also **explicitly excluded** by the brief and not in scope here: Auth0 OAuth,
+Alexa/Google voice, subscription/paywall, pool sharing (`/pools/{id}/link`),
+`/configFiles`, `/v1/help`, `/v1/account/preferences/*`,
+`/v1/popup/pools/...`, `POST /generic/pools/link`, `/telemetry` is in scope
+(see Pass 4), `/pools/{id}/settings` is in scope for Pass 3 (capability
+detection), every other `/v1/...` page is a UI artefact, not a data source.
+
+This plan is therefore **only** the 6 KEEP items in the brief, in ROI order.
+
+---
+
+## Priority order and ROI
+
+| # | Pass | Risk | Value | Depends on | Confidence |
+|---|------|------|-------|-----------|-----------|
+| 1 | Boost chlorination + UV register entities | low (sensors) | medium (existing users) | — | high (doc + decodable) |
+| 2 | Pump 3-speed via c135/c137/c244 (binary_sensor + better select) | low | medium | — | high (doc + state machine known) |
+| 3 | Dynamic UI config loader (`/uiconfig`) — opt-in | medium (parser) | high (future-proof) | real account to capture | medium (response shape TBD) |
+| 4 | Telemetry endpoint `/telemetry` — rolling sensors | low | medium (analytics) | real account | low (shape TBD) |
+| 5 | WebSocket `wss://ws.fluidra-emea.com` (Issue #210 root cause) | medium (lifecycle) | high (UX) | Pass 1+2 stable | medium (handshake TBD) |
+| 6 | Automations endpoint (CRUD bridge) | medium | low-medium | real account, Pass 5 | low (shape TBD) |
+| 7 | Recommendations endpoint (diagnostic sensor) | low | low | real account | low (shape TBD) |
+
+Rationale: **5 is the highest-value but highest-uncertainty** — it solves
+Issue #210 (cloud notifies HA instead of waiting for the next poll) and is
+explicitly called out in the doc as "probably the most profitable
+optimisation". It needs a real-account capture to confirm the auth handshake,
+so it sits in the middle of the queue once the cheaper Pass 1/2 land. **3
+is the second-highest** because it removes the need to ever hand-code
+register ids again — but it is a refactor that touches every platform and
+must be opt-in. **6/7** are listed for completeness; the doc itself says
+"GET it first to see the shape", and the integration rule is to expose
+nothing we haven't decoded.
+
+All passes that need a real account MUST be carried out by the operator on
+their own pool: the integration has no access to a real Fluidra account
+from CI, and the doc itself flags every new endpoint as "not verified on
+hardware".
+
+---
+
+## Pass 1 — New registers: UV + Boost countdown + 3-speed state
+
+> **Statut au 2026-08-26 — IN PROGRESS (branche `feat/pass1-new-registers`).**
+> Le code et les tests sont écrits et verts (1959 tests, ruff + mypy propres) ;
+> il reste la seule étape qui exige le matériel : déclarer les nouvelles
+> fonctionnalités dans les profils, une fois les registres confirmés sur une
+> vraie installation.
+>
+> Livré :
+> - `binary_sensor.FluidraUvPresentBinarySensor` (masque UV, c252, diagnostic)
+> - `sensor.FluidraUvRunningHoursSensor` (heures lampe UV, c253)
+> - `sensor.FluidraBoostRemainingHoursSensor` (compte à rebours de boost réparti
+>   sur c118 heures + c111 minutes, restitué en heures)
+> - `binary_sensor.FluidraFiltrationStateBinarySensor` (état du bloc filtration,
+>   c135 avec repli c244)
+> - traductions en/fr/es/pt, icônes, `tests/test_new_registers.py` (26 tests)
+>
+> Écarts assumés par rapport au plan initial, et pourquoi :
+> - **Pas de `FluidraBoostActiveBinarySensor`.** L'état du boost est déjà exposé
+>   par `switch.FluidraChlorinatorBoostSwitch`, qui lit exactement le registre
+>   `boost_mode` (c245 avec repli c103 selon le profil). Un binary_sensor de plus
+>   aurait dupliqué l'état d'une entité existante.
+> - **Aucune constante `COMPONENT_*` ajoutée dans `const.py`.** La règle du
+>   fichier est explicite : « Only IDs with a single stable meaning get a name ».
+>   c135 en est le contre-exemple exact — il porte l'emplacement de quick-function
+>   actif sur une pompe Victoria VS (`configs/pumps.py`, profil vérifié) et l'état
+>   du bloc filtration sur le contrôleur du dump `configFile`. Les ids restent donc
+>   déclarés par profil, comme `cell_production_state` ou `speed_input_components`.
+> - **Pas de capteur d'état filtration sur les profils de pompes.** Même raison :
+>   sur la Victoria VS, c135 est déjà décodé autrement. La fonctionnalité vise le
+>   contrôleur (chlorinateur) qui pilote le bloc filtration.
+> - **Registres `boost_remaining` (c51, eXO) et `boost_remaining_hours`
+>   (c118/c111) séparés.** Familles disjointes ; aucune entité existante n'est
+>   touchée, donc aucun `unique_id` ne change.
+>
+> Reste à faire (bloqué sur relevé matériel) : ajouter `uv_lamp`,
+> `boost_remaining_hours` et `filtration_state` aux `features` des profils
+> concernés, ainsi que 111/118/135/244/252/253 à leurs `specific_components`.
+> Le relevé se fait sans capture réseau : en logs DEBUG, le coordinateur émet
+> déjà une ligne « reports N component(s) no profile maps » avec la valeur de
+> chaque registre qu'aucun profil ne mappe (`coordinator._log_unmapped_components`).
+
+> **Highest-value, lowest-risk pass.** All three additions are read-only
+> sensors derived from registers the doc identifies. None requires a new
+> write path. None depends on a real account at runtime — only the operator
+> must verify the units / factor on their own pool.
+
+### 1.1 Rationale
+
+- **UV (`c252`/`c253`)**: the doc shows a complete UI block ("UV lamp
+  running hours") that the integration has zero entity for. Adding a
+  binary_sensor (`uv_present`, c252) + a `sensor` (hours, c253) closes a
+  class of equipment the integration is currently silent on.
+- **Boost chlorination countdown (`c103`/`c245`/`c111`/`c118`)**:
+  `FluidraBoostRemainingSensor` already exists
+  (`sensor/chlorinator.py`) but is a textual countdown. Splitting it into
+  a proper `binary_sensor` (boost active) + a `sensor` (hours remaining,
+  state_class `measurement`) matches what the app does and what
+  automations need.
+- **Pump 3-speed state (`c135`/`c137`/`c244`)**: c11 is read for the
+  current speed percentage; c135/c244 carry the on/off state of the
+  filtration block. Adding a `binary_sensor` (filtration running) gives
+  automations a target the speed sensor alone cannot (a pump running at
+  speed=0 is not running).
+
+### 1.2 Endpoints + response shape
+
+All three live in the existing component bulk fetch. **No new endpoint.**
+The operator must:
+
+1. Open the Fluidra app on their pool.
+2. Note the current value of `c103`, `c111`, `c118`, `c245`, `c252`,
+   `c253`, `c135`, `c137`, `c244` from diagnostics export
+   (Settings → Devices → ⋯ → Download diagnostics — the integration
+   already redacts ids in its own diagnostics).
+3. Cross-check against `API-DISCOVERY.md` table §4.1.
+
+### 1.3 Code changes
+
+#### Constants (`custom_components/fluidra_pool/const.py`)
+
+- Add to the `COMPONENT_*` block:
+  - `COMPONENT_BOOST_ACTIVE = 103` (already implicitly referenced by
+    some profiles — verify by `grep` before naming)
+  - `COMPONENT_BOOST_STATE = 245` (alias for 103 in newer firmware)
+  - `COMPONENT_BOOST_MINUTES_REMAINING = 111`
+  - `COMPONENT_BOOST_HOURS_REMAINING = 118`
+  - `COMPONENT_UV_PRESENT = 252`
+  - `COMPONENT_UV_RUNNING_HOURS = 253`
+  - `COMPONENT_PUMP_FILTRATION_STATE = 135`
+  - `COMPONENT_PUMP_SPEED_STATE = 137`
+  - `COMPONENT_PUMP_MODE = 244`
+- Add `UV_RUNNING_HOURS_UNIT = "h"` (sensor unit).
+- Add `BOOST_REMAINING_UNIT = "h"` (state_class: measurement).
+- Add a 3-speed state map: `PUMP_3SPEED_STATE_TO_LABEL = {0: "off",
+  1: "low", 2: "medium", 3: "high"}` and reverse.
+
+#### Profile-aware scan set (`custom_components/fluidra_pool/device_registry/configs/`)
+
+- Identify which profiles gain the new registers. A grep of
+  `specific_components` across the configs (3-4 chlorinator files +
+  standard-tecnoLC2) will reveal whether c103/c111/c118/c252/c253 are
+  already scanned — likely c103 is, c111/c118 are not.
+- Add the new ids to the `specific_components` list of every chlorinator
+  profile (UV is opt-in per-profile since not all chlorinators have a UV
+  lamp). For c135/c137/c244, add to the pump profiles.
+- New device-registry feature gates: `"uv_lamp": True`,
+  `"boost_countdown": True`, `"filtration_state_binary": True`. A
+  profile that has the register but is unknown can still be polled —
+  the entity stays `unavailable` if the value is missing.
+
+#### New entities
+
+| Platform | Class | Key | Device class | Unit | State class | Source reg |
+|----------|-------|-----|--------------|------|-------------|-----------|
+| `binary_sensor` | `FluidraUvPresentBinarySensor` | `uv_present` | `run` (or `safety`?) | — | — | c252 |
+| `sensor` | `FluidraUvRunningHoursSensor` | `uv_running_hours` | `duration` | `h` | `total_increasing` | c253 |
+| `binary_sensor` | `FluidraBoostActiveBinarySensor` | `boost_active` | `running` | — | — | c103/c245 |
+| `sensor` | `FluidraBoostRemainingHoursSensor` | `boost_remaining_hours` | `duration` | `h` | `measurement` | c118 |
+| `binary_sensor` | `FluidraFiltrationStateBinarySensor` | `filtration_state` | `running` | — | — | c135 (c244 fallback) |
+
+- Implement all five under the existing `binary_sensor.py` /
+  `sensor/device.py` patterns, inheriting `FluidraPoolEntity` (per
+  plan 006). The `binary_sensor` ones follow
+  `FluidraChlorinatorAlarmSensor` (existing); the `sensor` ones follow
+  `FluidraRunningHoursSensor` (existing) for the total_increasing one
+  and a new pattern for the `measurement` boost_remaining.
+- Coalesce c103 and c245 (the doc notes both exist; on tecnoLC2 c103
+  is the boost write, c245 is the boost state on some firmware).
+  Precedence rule: read c245 first, fall back to c103.
+
+#### Coordinator integration
+
+- These sensors are read-only — they do not change coordinator flow.
+- Confirm the components_to_scan fan-out already includes the new ids
+  (no coordinator logic change expected).
+
+### 1.4 Tests
+
+**Unit** (new file `tests/test_new_registers.py`):
+- Mock `coordinator.data` with hand-crafted `device["components"]`
+  carrying the new registers. Construct the entity, assert:
+  - `native_value` is the expected number/text.
+  - `available` is `True` only when the register is present and the
+    parent is online.
+  - For c252: returns `True`/`False` based on the integer value (≥1).
+- Test the c103↔c245 fallback (both, only c103, only c245, neither →
+  `None` / unavailable).
+- Test the boost_remaining sensor when only c111 is present (compute
+  `hours + minutes/60`); when only c118 is present; when both are.
+
+**Integration** (extend `tests/test_binary_sensor.py` and
+`tests/test_sensor_full.py`):
+- Mock the full poll cycle (`mock_pool_data` extended) and assert
+  the entity is created with the right `unique_id` and
+  `_attr_device_class`.
+
+**Operator-side verification (no test)**:
+- One real pool with UV (any GenSalt with UV option).
+- One real pool without UV → boost countdown still works, uv sensor
+  stays `unavailable`.
+- One real pump with 3-speed state registers → c135 reads 1/0
+  correctly when toggling filtration.
+
+### 1.5 Risk + rollback
+
+- Risk: low. Sensors going `unavailable` is the only failure mode — no
+  control surface, no entity id collision (new sensors get new
+  `unique_id` keys).
+- Rollback: revert the commit. No migration needed (no `unique_id`
+  change to existing entities).
+- Feature flag: not required; profile-gated, so a profile that does
+  not declare the feature simply does not create the entity.
+
+### 1.6 Real-account dependency
+
+**Yes** for the unit / factor verification. The doc says c253 is
+integer hours with factor 1; the operator must confirm on their UV
+unit. The chlorinator boost behaviour (which of c103/c245 is read,
+whether `c118` reads hours since cycle start or hours remaining) must
+be confirmed.
+
+---
+
+## Pass 2 — Pump 3-speed control via c135 / c137 / c244
+
+> **Statut au 2026-08-26 — IN PROGRESS (branche `feat/pass1-new-registers`).**
+> Code et tests écrits et verts (1979 tests, ruff + mypy propres). Comme pour la
+> passe 1, il reste la déclaration en profil, qui exige du matériel.
+>
+> Livré : `select.FluidraThreeSpeedPumpSelect`, entièrement paramétré par le
+> profil (`pump_3speed`), + traductions en/fr/es/pt + `tests/test_pump_three_speed.py`
+> (16 tests).
+>
+> **Deux erreurs du plan initial, corrigées à l'écriture :**
+>
+> 1. **« Ajouter un `select` au lieu du `number` de pourcentage » — le `select`
+>    3 vitesses existe déjà.** `select.FluidraPumpSpeedSelect` (`select/pump.py`)
+>    offre `stopped/low/medium/high` depuis longtemps ; il n'y a jamais eu de
+>    `number` de vitesse. Ce qui manquait n'était pas l'entité mais la famille :
+>    l'existant écrit en dur sur c9/c11 et lit `speed_level_reported`, décodé par
+>    le coordinateur pour l'E30iQ. La nouvelle entité vise le cas où un
+>    contrôleur porte la vitesse sur un seul registre qu'il accepte aussi en
+>    écriture. Les deux s'excluent sur un même appareil : déclarer `pump_3speed`
+>    remplace le select E30iQ.
+> 2. **« Poser la fonctionnalité sur les profils eXO et Victoria » — impossible
+>    pour la Victoria.** Sur `victoria_smart_connect_pump` (profil **vérifié**,
+>    Issue #144), c135 est déjà décodé comme l'emplacement de quick-function
+>    actif et c136 son expiration ; c137 n'est même pas scanné. Y déclarer
+>    `pump_3speed` ferait écrire sur un registre dont la famille n'a jamais
+>    confirmé le sens. Le eXO NS25 est un chlorinateur avec sa propre carte de
+>    registres (boost c46, chlorination c38) : les c135/c137/c244 du dump
+>    viennent du `configFile` tecnoLC2, donc du contrôleur, pas d'un profil de
+>    pompe existant.
+>
+> **Aucune fonctionnalité `pump_3speed` n'est donc déclarée nulle part**, et
+> c'est délibéré : contrairement à la passe 1, il s'agit d'une **écriture**.
+> Le doc lui-même donne la table d'états comme « à confirmer », et poser à
+> l'aveugle un select qui écrit 1/2/3 sur c137 chez des utilisateurs reviendrait
+> à commander du matériel réel sur une hypothèse. Les deux tables — lecture et
+> écriture — vivent dans le profil (`write_map`, `read_map`), donc le jour où un
+> possesseur de pompe 3 vitesses confirme le mapping, c'est une édition de
+> profil, sans toucher au code.
+
+> **Refines existing control.** c11 is currently read for speed
+> percentage; the app uses c137 to map state 0/1/2 → write 1/2/3.
+> Adds a proper `select` instead of the existing `number` percentage
+> and surfaces the filtration state as a separate switch.
+
+### 2.1 Rationale
+
+- The current `number` speed entity works for variable-speed pumps
+  but the eXO/Victora 3-speed pumps benefit from a discrete
+  `select` (off/low/medium/high) matching what the app offers.
+- A `binary_sensor` for "filtration block active" (c135/c244)
+  independent from the pump on/off (c9/c13) lets automations target
+  the actual filter cycle, which the c9 on/off does not represent on
+  schedule-driven pumps (Victoria, eXO).
+- Distinct from Pass 1: Pass 1 only adds read sensors; this pass
+  re-shapes the control entity and resolves the state mapping.
+
+### 2.2 Endpoints + response shape
+
+- No new endpoint. Existing PUT `/components/{cid}` (c137) with
+  integer 1/2/3 — already used in the bulk fetch. The write payload
+  is `{"desiredValue": <int>}` exactly as the rest of
+  `control_device_component`.
+- **TBD on operator's pump**: does c137 read 0 when the pump is off
+  (and writing 1 starts it on low), or does c135 need to be 1 first?
+  The doc's table hints at `0→3, 1→1, 2→2` but the doc itself flags
+  this as "to be confirmed". This is the only real-account blocker.
+
+### 2.3 Code changes
+
+#### Constants (`const.py`)
+
+- Already have `COMPONENT_PUMP_SPEED = 11` (legacy c11). Add
+  `COMPONENT_PUMP_SPEED_3SPEED = 137`,
+  `COMPONENT_PUMP_FILTRATION_ON = 135`,
+  `COMPONENT_PUMP_MODE = 244`.
+- New map `PUMP_3SPEED_VALUE_TO_OPTION = {0: "off", 1: "low", 2:
+  "medium", 3: "high"}` (and inverse).
+
+#### Profile (`device_registry/configs/`)
+
+- Add a feature `pump_3speed: True` on the eXO and Victoria profiles.
+- Add c135, c137, c244 to `specific_components` for those families.
+- Gate the existing `FluidraPumpSpeedSensor` (number %) on
+  `not device.features.get("pump_3speed")` so the two do not collide.
+
+#### Entities
+
+- New `select` entity `FluidraPumpSpeedSelect` for 3-speed pumps
+  (option list: `off`, `low`, `medium`, `high`). On `select_option`,
+  translate the option back to 1/2/3 and call
+  `control_device_component(c137, value)` (NOT c11).
+- Refactor (or coexist with) the existing `binary_sensor` for pump
+  running to also use c135. The current implementation uses
+  `device["is_running"]` (set by the c9 PUT path) — for schedule-
+  driven pumps, that flag stays False even while the pump is running.
+  Resolution: prefer c135 over `is_running` when the feature is
+  declared; fall back otherwise.
+
+### 2.4 Tests
+
+**Unit** (extend `tests/test_select.py`):
+- Mock a 3-speed pump with c137 = 2; assert select shows "medium".
+- Mock option pick "high"; assert PUT on c137 with value 3.
+- Mock write returning 200 but cloud drop → assert
+  `HomeAssistantError("...")` is raised and optimistic state is
+  cleared (project rule from `entity.py` comment + `ARCHITECTURE.md`).
+
+**Integration** (extend `tests/test_switch.py`):
+- Verify the binary_sensor entity uses c135 when the feature is
+  declared; uses c9/is_running otherwise.
+
+**Real-account**:
+- One eXO or Victoria pump. Confirm the 0/1/2 ↔ option mapping.
+
+### 2.5 Risk + rollback
+
+- Risk: medium. Adding a new entity while the old one stays is the
+  safest path — the integration rule forbids changing an existing
+  `unique_id` (`ARCHITECTURE.md` §Hard rules). The old `number`
+  speed entity stays available for non-3-speed pumps.
+- Rollback: delete the new select/binary_sensor files, drop the
+  `pump_3speed` feature flag. Existing entities untouched.
+- Feature flag: yes — `pump_3speed` per profile. No config-flow
+  option needed.
+
+### 2.6 Real-account dependency
+
+**Yes**, must be verified on a 3-speed pump. The doc itself flags
+the 0↔off mapping as unconfirmed.
+
+---
+
+## Pass 3 — Dynamic UI config loader (`/uiconfig`)
+
+> **Statut au 2026-08-26 — PARTIEL, bloqué sur un paramètre inconnu.**
+> Lecteur et parseur livrés et verts (2002 tests, ruff + mypy propres,
+> `_uiconfig.py` à 94 % de couverture). Le câblage dans le coordinateur et
+> l'option de config flow ne sont **pas** livrés, et ne peuvent pas l'être.
+>
+> **Ce que la sonde a établi** (appels réels sur le compte de l'opérateur,
+> lecture seule, via le client de l'intégration) :
+>
+> | Requête | Réponse |
+> |---|---|
+> | `GET /uiconfig` sans paramètre | `400 Missing required request parameters: [deviceType, appId]` |
+> | `+ deviceType=connected` | `400 Missing required request parameters: [appId]` |
+> | `+ appId=iaqualink_plus` (et 4 variantes) | `500 Internal server error` |
+> | `+ appVr=` (8 formats : `2.23.1`, `2.23`, `223`, `2`, `v2.23.1`, `2.23.1.0`, `2230100`, +lang) | `400 Invalid appVr parameter` |
+>
+> L'endpoint **existe** — il ne rend jamais 404 — et il valide ses paramètres
+> côté serveur. `appId=iaqualink_plus` franchit la validation (le 400 devient
+> 500), ce qui en fait le meilleur candidat connu ; `appVr` reste introuvable.
+> Aucune valeur littérale d'`appId`/`appVr` n'apparaît dans les chaînes de
+> `libapp.so` — seulement les messages d'erreur qui les mentionnent
+> (« A non-empty appId is required for automations queries »,
+> « fetching config files without identification appId= », « appIdMinVr »).
+> **Un `curl` ne suffira donc pas : il faut une capture MITM de l'app
+> officielle** (ou un dump du `Dio` interceptor), ce qui corrige le §3.2 du
+> plan, qui pensait la capture faisable à la main.
+>
+> Conséquence pour la **passe 6** (automations) : même verrou, la chaîne de
+> l'APK le dit explicitement pour cet endpoint-là.
+>
+> **Livré** :
+> - `fluidra_api/_uiconfig.py` — `UiRegister` (dataclass gelée : `read_id`,
+>   `write_id`, `type`, `factor`, `decimals`, `min`/`max`/`steps`, `units`,
+>   plus `decode()`/`encode()` qui appliquent le facteur dans les deux sens),
+>   `UiConfigMixin.get_device_uiconfig()`, `parse_uiconfig()`,
+>   `build_dynamic_scan_set()`
+> - mixin assemblé dans `FluidraPoolAPI`, symboles exportés
+> - `tests/test_uiconfig.py` (23 tests)
+>
+> Le parseur accepte les quatre enveloppes plausibles (liste nue, wrapper
+> `configFile`/`components`/`registers`/`uiConfig`, mapping indexé par id) et
+> rend `None` — jamais un dict vide — sur tout le reste, comme
+> `_parse_bulk_components`. La forme d'un **bloc** de registre, elle, est
+> documentée par l'APK ; seule l'enveloppe est supposée.
+>
+> **Rien n'appelle `get_device_uiconfig()`**, et un test le verrouille
+> (`test_nothing_calls_the_endpoint_yet`) : le brancher aujourd'hui coûterait
+> une requête par appareil et par poll, toutes vouées à l'échec. Ce test est
+> ce qu'il faudra supprimer le jour où les paramètres seront connus.
+>
+> **Suite de la mesure (même jour) — une source qui répond, elle.**
+> `GET /generic/devices/{id}` renvoie `info.configuration.capabilities`, où le
+> cloud **déclare le registre des plannings de l'appareil**
+> (`schedulers: [{id: "pump", componentRead: 20, componentWrite: 20, type:
+> "minimal", enabled: true}]`, mesuré sur l'E30iQ de l'opérateur). C'est la
+> réponse d'autorité à l'Issue #174, que les profils résolvent aujourd'hui
+> depuis les drapeaux de type de pompe. Livré : `get_device_capabilities()` +
+> `parse_scheduler_capabilities()`, exposés dans les **diagnostics** sous
+> `cloud_schedulers`, avec le registre résolu par le profil et un booléen
+> `matches_profile`. Une requête par appareil au téléchargement des
+> diagnostics, **jamais sur le chemin de poll** — un test le verrouille.
+> `GET /generic/configFiles` et `/configFiles/identification/{thingType}`
+> répondent aussi (124 configFiles, 392 Ko) mais ne contiennent **aucun**
+> `readId`/`writeId`/`factor` : l'identification officielle y est (noms
+> commerciaux, 82 `prCode`, expression JSONata de détection des sondes), les
+> registres UI non. Détail complet dans `API-DISCOVERY.md` §9.
+>
+> **Écart avec le §3.3** : pas de `uiconfig_runtime.py` séparé ni de
+> `VisibilityRule`. Les helpers purs tiennent dans le même module que le
+> parseur (le projet ne sépare pas ailleurs), et les règles `hide`/`hideValue`
+> n'ont pas été implémentées — sans réponse réelle, leur syntaxe exacte est
+> une supposition de plus, et elles ne servent qu'à masquer des entités que
+> personne ne crée encore.
+
+> **Refactor — opt-in.** Replace the hard-coded `COMPONENT_*` lookups
+> for the *scan set* with a runtime loader that reads the cloud's own
+> `configFile` JSON. The hardcoded constants stay as the default; the
+> loader runs only when an option flag is on.
+
+### 3.1 Rationale
+
+- The doc shows that the Fluidra cloud serves a complete
+  `configFile` JSON describing every register, its readId/writeId,
+  factor, decimals, min/max, units, and visibility rules
+  (`hide`/`hideValue`). Loading it removes the need to hand-code
+  every new model and makes "device X has a register the integration
+  doesn't know" a non-issue.
+- Existing per-family profile specificity is preserved: a profile
+  that declares a `specific_components` list wins over the dynamic
+  set. This keeps the well-tested paths (tecnoLC2, Z250iQ, …) intact
+  while letting new families be discovered.
+- **Cost estimate matches the doc**: ~100 LoC for the parser + a
+  hook into `_fetch_components` / `_discover_devices_for_pool`.
+
+### 3.2 Endpoint + response shape
+
+- `GET /generic/devices/{id}/uiconfig` (Bearer, same auth as the
+  other generic endpoints).
+- **TBD — must be measured at runtime**: the response envelope is
+  not in the doc, only the inner `configFile` JSON (with `readId`/
+  `writeId` blocks). The operator MUST capture one raw response
+  (via `curl -H "Authorization: Bearer $TOKEN" ...` on their own
+  pool) and attach the first 200 lines to the implementation PR.
+- The 5-language translations files (en/fr/de/es/it) must each gain
+  a short description for the new options-flow toggle (see 3.5).
+
+### 3.3 Code changes
+
+#### New mixin (`custom_components/fluidra_pool/fluidra_api/_uiconfig.py`)
+
+- `class UiConfigMixin(FluidraAPIBase):`:
+  - `async def get_device_uiconfig(self, device_id: str) -> dict[str, Any] | None`
+    — `GET /generic/devices/{id}/uiconfig`, retry through the
+    standard `_request` funnel. Returns the raw payload or `None`
+    on failure (transient error → cached value used).
+  - `def parse_uiconfig(self, payload: Any) -> dict[int, UiRegister]` —
+    pure parser, returns a mapping `{readId: UiRegister}` (or
+    `None` for unparseable). `UiRegister` is a small dataclass:
+    `read_id: int`, `write_id: int | None`, `type: Literal[…]`,
+    `factor: float`, `decimals: int`, `min: float | None`,
+    `max: float | None`, `units: str | None`,
+    `visibility: VisibilityRule | None`. The `VisibilityRule`
+    captures the `hide` / `hideValue` expressions as a callable
+    `def visible(component_states: dict[int, Any]) -> bool` for
+    simple cases, or `None` (always visible) for the rest — the
+    doc lists simple `cXX==N` and `cXX==N || cYY==M` patterns
+    which are tractable, the more complex ones get a default
+    visible.
+- Wire the mixin into `FluidraPoolAPI` in `fluidra_api/client.py`.
+
+#### New module (`custom_components/fluidra_pool/uiconfig_runtime.py`)
+
+- Pure helpers, no `hass`, no I/O.
+- `def build_dynamic_scan_set(profile_specific: list[int],
+  uiconfig: dict[int, UiRegister] | None) -> list[int]`
+  — returns the union. Profile-specific ids always win.
+- `def apply_factor(raw_value: Any, reg: UiRegister) -> Any` —
+  applies `factor` and rounds to `decimals`. Inverse for writes.
+- `def option_list_for(reg: UiRegister) -> list[str] | None` —
+  for `selector` registers (`options: [...]` field if present in
+  the uiconfig; the doc hints at it but does not confirm).
+
+#### Coordinator hook (`coordinator/coordinator.py`)
+
+- In `_fetch_components`, when the option flag is on:
+  - On the first poll for a device, call
+    `api.get_device_uiconfig(device_id)` once and cache the result
+    on `device["uiconfig"]`.
+  - Merge the uiconfig register set with the profile
+    `specific_components` for the scan request.
+- One `uiconfig` request per device per session is the budget —
+  the doc already shows the cloud has it cached (no per-poll cost).
+- The existing `get_all_components` (bulk) is the actual fetch path
+  — the scan set change just makes sure the bulk response is
+  decoded against the *right* factor/units.
+
+#### Entity adapters
+
+- For Pass 1 / Pass 2 sensors that are already mapped (c103, c111,
+  c118, c252, c253, c135, c137, c244): the dynamic loader
+  re-affirms their unit/factor from the cloud. Existing entities
+  consume `device["components"][N]["reportedValue"]` as before —
+  no change to entity code, just the decoder.
+- **New** entities unlocked by the dynamic loader (chlorinator
+  pH/ORP probes on families that don't have a profile yet, secondary
+  salinity `c174`/`c185` that already exist in the doc table) get
+  auto-created ONLY if the user opts in. The opt-in path is the
+  safe one — we do not want a flood of new entities on a
+  user's existing pool without their consent.
+
+### 3.4 Config-flow integration
+
+- Add an options-flow toggle (in `config_flow.py`
+  `FluidraPoolOptionsFlowHandler.async_step_init`):
+  - `CONF_ENABLE_DYNAMIC_UICONFIG: bool = False` (default off).
+- Behind the flag:
+  - First-poll `uiconfig` fetch for every device.
+  - Dynamic entity creation gated on a per-register profile
+    feature (e.g. `auto_create` derived from the doc table).
+  - The flag is stored in `entry.options`, honoured by the
+    coordinator via `runtime_data.options_snapshot` (already
+    wired per `ARCHITECTURE.md`).
+- Bump `manifest.json` version (SemVer minor — 2.85.0) and
+  `hacs.json` minimum.
+
+### 3.5 Tests
+
+**Unit** (new `tests/test_uiconfig.py`):
+- Synthetic `configFile` JSON fixture (build from the doc's
+  table — at least 10 registers including a `hide` rule, a
+  `selector`, a `factor`).
+- Assert the parser returns the right `UiRegister` shape, the
+  factor applies correctly, the visibility rule hides the right
+  registers.
+- Assert `build_dynamic_scan_set` unions profile + dynamic.
+- Assert the config-flow toggle is round-tripped via
+  `entry.options`.
+
+**Integration** (extend `tests/test_init_setup.py`):
+- With the option off → no uiconfig request, no dynamic
+  entities. Existing behaviour preserved.
+- With the option on → first poll triggers exactly one
+  uiconfig request per device; subsequent polls do not.
+
+**Operator-side verification**:
+- Capture the real `/uiconfig` response from the operator's
+  account. Commit it under
+  `tests/fixtures/uiconfig_sample.json` (with redactions for
+  device id and pool id — the project already has a mask
+  helper, `utils.mask_device_id`).
+- Without that capture the parser is built on a guess and
+  may fail on the real envelope.
+
+### 3.6 Risk + rollback
+
+- Risk: medium. The parser is the riskiest part (response
+  shape TBD). Mitigated by opt-in flag, by `None` on parse
+  failure (falls through to hardcoded), and by a one-line
+  kill switch in the coordinator.
+- Rollback: turn the option off. No entity id change for
+  users who never enabled it.
+- Feature flag: yes — `CONF_ENABLE_DYNAMIC_UICONFIG` in
+  options flow.
+
+### 3.7 Real-account dependency
+
+**Yes — critical.** The parser cannot be validated without
+a real `/uiconfig` response. The operator must run a manual
+`curl` against the prod endpoint and paste the JSON into a
+fixture before the implementation work begins.
+
+---
+
+## Pass 4 — Telemetry endpoint `/telemetry`
+
+> **Statut au 2026-08-26 — BLOQUÉ (mesuré, pas supposé).** `GET /generic/telemetry` rend
+> **403**, et le corps n'est pas un refus de droits mais le message d'**AWS
+> SigV4** : « Invalid key=value pair (missing equal-sign) in Authorization
+> header ». Cette route attend une requête **signée IAM**, pas le Bearer
+> Cognito qui sert partout ailleurs dans l'intégration. Aucun niveau de compte
+> ne débloquera ça — il faut le schéma de signature, donc une capture de
+> l'app. Voir `API-DISCOVERY.md` §9.3.
+
+> **Read-only rolling sensors.** A single fetch per poll cycle
+> (per pool) yielding water-quality / device-state aggregates
+> over 24h/7d windows. Exposed as `state_class: measurement`
+> sensors so HA can compute `statistics` (mean, min, max) and
+> feed the Energy dashboard.
+
+### 4.1 Rationale
+
+- The doc lists `telemetry/{telemetry, telemetry_device,
+  telemetry_measure, telemetry_pool, telemetry_records,
+  telemetry_user}` DTOs and the `/telemetry` endpoint. The
+  official app uses these for water-quality trends and
+  device-state histories — the integration has zero telemetry
+  sensors today.
+- Maps cleanly to HA's `SensorStateClass.MEASUREMENT` for
+  non-cumulative quantities (pH, ORP, water temperature
+  history) and `TOTAL_INCREASING` for running hours
+  telemetry.
+
+### 4.2 Endpoint + response shape
+
+- `GET /telemetry` (Bearer). The doc does not show the
+  envelope. **TBD — must be measured.**
+- Probable shape (inferred from DTO names, **not** measured):
+  `{"devices": [...], "pools": [...], "user": [...],
+  "waterQuality": [...]}` with per-measurement records
+  carrying `value`, `unit`, `timestamp`, `registerId`.
+- The operator must capture one raw response and confirm.
+
+### 4.3 Code changes
+
+#### New mixin (`fluidra_api/_telemetry.py`)
+
+- `class TelemetryMixin(FluidraAPIBase):`:
+  - `async def get_telemetry(self, pool_id: str | None = None)
+    -> dict[str, Any] | None` — `GET /telemetry`, optional
+    `poolId` param. Returns raw payload or `None`.
+- Wire into `FluidraPoolAPI`.
+
+#### New module (`coordinator/telemetry.py`)
+
+- `def normalise_telemetry(payload: Any) -> list[TelemetryPoint]`:
+  pure parser. Each `TelemetryPoint` is a `dataclass`:
+  `register_id: int`, `value: float`, `unit: str | None`,
+  `timestamp: datetime`, `scope: Literal["device", "pool",
+  "water_quality", "user"]`. Pure function, no I/O.
+- `def latest_per_register(points: list[TelemetryPoint]) ->
+  dict[int, TelemetryPoint]`: collapse to most-recent per
+  register.
+
+#### Coordinator hook
+
+- New `_async_update_telemetry()` task, called once per
+  poll cycle (or at a coarser interval — telemetry records
+  may be coarse, e.g. hourly). Stash the result on
+  `coordinator.data[pool_id]["telemetry"]`.
+- Failure: keep the previous value, log at DEBUG. A single
+  failed fetch must not fail the whole poll (per the
+  `coordinator` comment on `EMPTY_COMPONENT_FETCH_THRESHOLD`).
+
+#### New sensors (`sensor/pool.py`)
+
+- `FluidraPoolTelemetrySensor` — pool-attached, picks
+  one of:
+  - latest pH (rolling)
+  - latest ORP (rolling)
+  - latest water temperature (rolling)
+- Each: `state_class = SensorStateClass.MEASUREMENT`,
+  `device_class` matches the metric (PH, VOLTAGE for ORP mV,
+  TEMPERATURE for °C).
+- **No aggregation across pools** — one set per pool.
+
+### 4.4 Tests
+
+**Unit** (`tests/test_telemetry.py`):
+- Synthetic telemetry payload fixture (build from the
+  inferred shape).
+- `normalise_telemetry` extracts the right number of points.
+- `latest_per_register` keeps the newest.
+- Sensor reads the latest value of its target register.
+
+**Integration** (extend `tests/test_sensor.py`):
+- A pool with telemetry enabled gets the new entities.
+- A pool where the endpoint returns 404 has no new entities
+  and no warning spam.
+
+**Real-account**:
+- Capture raw `/telemetry` for one pool. Without it the
+  parser is built on a guess.
+
+### 4.5 Risk + rollback
+
+- Risk: low. Read-only, opt-in via the dynamic-uiconfig
+  flag (Pass 3) or its own `CONF_ENABLE_TELEMETRY` toggle.
+- Rollback: turn the toggle off. No `unique_id` change.
+- Feature flag: yes.
+
+### 4.6 Real-account dependency
+
+**Yes**. The endpoint shape is not in the doc.
+
+---
+
+## Pass 5 — WebSocket `wss://ws.fluidra-emea.com`
+
+> **Statut au 2026-08-26 — IMPLÉMENTÉ (opt-in), déployé et connecté sur le HA dev.**
+>
+> Ancien statut : DÉBLOQUÉ, mesuré de bout en bout.
+> Le canal a été ouvert, abonné, et vérifié en poussant un vrai changement
+> d'état (accord explicite de l'opérateur pour commander sa pompe ; valeur
+> d'origine restaurée et vérifiée stable sur 60 s).
+>
+> **Ce que le plan supposait et qui est faux** : l'authentification ne se fait
+> pas par en-tête `Authorization`. Bearer et jeton brut donnent tous deux un
+> handshake **401**. Ce qui marche :
+> `wss://ws.fluidra-emea.com?token=<access_token>` — le jeton Cognito que
+> l'intégration détient déjà, en **paramètre de requête**.
+>
+> **Ce que le canal livre** : 2,5 s après une écriture,
+> `{"action":"componentChange","body":"{deviceId, deviceType, componentId,
+> reportedValue, ts}"}` — exactement le triplet que le coordinateur applique.
+> `subsDevice` et `subsPool` (non documenté) répondent `200 OK` ; une action
+> inconnue rend `Forbidden` sans fermer la connexion.
+>
+> À noter, mesuré au passage : après un démarrage manuel, l'E30iQ tourne à
+> 100 % pendant ~1 min avant de redescendre au niveau demandé (comportement
+> confirmé par l'opérateur). La valeur rapportée diverge donc de la consigne
+> pendant cette minute ; la grâce de vérification d'écriture (180 s minimum)
+> la couvre, et ne doit pas être raccourcie sans refaire ce calcul.
+>
+> **Robustesse mesurée** (`API-DISCOVERY.md` §10.5), qui fixe le cycle de vie :
+> une connexion silencieuse est coupée **à 600 s pile** avec `close_code=1006`
+> (délai d'inactivité d'API Gateway, fermeture abrupte), alors qu'un ping
+> toutes les 60 s la maintient **au moins 23 min** sans incident. Surtout, le
+> jeton n'est validé **qu'au handshake** : à +420 s, jeton expiré depuis
+> 2,5 min, `subsDevice` répond encore `200 OK`. Il ne faut donc **pas** rouvrir
+> la connexion à chaque rafraîchissement de jeton — ouvrir une fois, garder
+> vivant par ping, rouvrir seulement sur fermeture. `unsubsPool` rend `500` :
+> pour tout arrêter, fermer la connexion. Les réponses sont asynchrones et
+> décalées — boucle de lecture indépendante, corrélation par `action`.
+>
+> Détail complet et traces dans `API-DISCOVERY.md` §10.
+
+> **Livré** :
+> - `fluidra_api/_websocket.py` — `parse_frame()` (double décodage : le `body`
+>   est une chaîne JSON dans l'enveloppe), `ComponentChange`, et
+>   `FluidraWebsocketClient` (connexion, abonnements, ping toutes les 240 s,
+>   reconnexion 5 s → 300 s en backoff, arrêt propre)
+> - coordinateur : `async_start_realtime()` / `async_stop_realtime()`,
+>   `_handle_realtime_change()` qui passe le changement poussé par
+>   **`_process_component_state`, le décodeur du poll** — pas de second chemin
+>   qui pourrait diverger — puis `async_set_updated_data()` pour réveiller les
+>   entités sans aller sur le réseau
+> - option `enable_realtime` (défaut **off**) dans le flux d'options, avec
+>   traductions en/fr/es/pt
+> - `tests/test_realtime.py` (34 tests, dont la trame mesurée telle quelle)
+>
+> **Principes tenus** : le poll reste la source de vérité et tourne à
+> l'identique ; le canal ne peut pas casser l'intégration (toute exception est
+> rattrapée et déclenche une reconnexion, un callback qui échoue ne ferme pas
+> la connexion) ; la découverte d'appareils reste au poll (un changement sur un
+> appareil inconnu est ignoré) ; l'arrêt est attendu dans `async_unload_entry`
+> plutôt que confié à un `async_on_unload` qui aurait laissé une tâche
+> résiduelle.
+>
+> **Vérifié en réel** : activé sur le HA dev, `Realtime channel connected,
+> subscribing to 1 device(s)`, sans erreur.
+
+> **The structural fix for Issue #210.** The cloud pushes
+> state-change notifications over a WebSocket. Subscribing
+> after login lets the coordinator refresh its state
+> immediately after a PUT (or any external change) instead of
+> waiting for the next 30 s poll. The REST polling remains
+> the source of truth; the WS is a *fast trigger*.
+
+### 5.1 Rationale
+
+- Issue #210 is fundamentally a latency problem: after a
+  control write, the cloud often has the new value within
+  1-2 s, but the integration only re-polls every 30 s, so
+  the user sees their toggle stuck for up to 30 s after the
+  write. The WebSocket is the cloud's own solution.
+- The doc says: subscribe with
+  `{"action": "subsDevice", "deviceType": "connected",
+  "deviceId": "<id>"}`, server pushes
+  `{"action": "command", "commandId": "..."}` which
+  correlates to a previous write. There is no `value` in
+  the push — the WS just says "something changed, go read".
+- The integration rule (per `ARCHITECTURE.md` §Optimistic
+  state + Issue #210) is to keep the optimistic value
+  visible until the REST confirms. The WS simply makes the
+  confirmation arrive faster.
+
+### 5.2 Endpoint + handshake
+
+- `wss://ws.fluidra-emea.com` (Bearer auth — exact header
+  shape TBD).
+- Doc says "header d'auth supposé Bearer après login, à
+  confirmer par capture". **Critical real-account blocker.**
+- The operator MUST capture a handshake (e.g. via
+  `websocat wss://ws.fluidra-emea.com -H "Authorization:
+  Bearer $TOKEN"`) and attach the first 30 s of frames
+  before the implementation work begins. Without it the
+  auth header / ping interval / reconnection logic are
+  guesses.
+
+### 5.3 Code changes
+
+#### New mixin (`fluidra_api/_websocket.py`)
+
+- `class WebSocketMixin(FluidraAPIBase):`:
+  - `async def connect(self) -> None` — open the WS,
+    authenticate, store the connection on `self._ws`.
+  - `async def subscribe_device(self, device_id: str) ->
+    None` — send the `subsDevice` frame. Idempotent.
+  - `async def _reader_loop(self) -> None` — long-running
+    task: read frames, parse, push to the listener queue.
+  - `async def _ping_loop(self) -> None` — periodic ping
+    (interval TBD, start with 25 s).
+  - `async def _reconnect(self) -> None` — exponential
+    backoff reusing the existing
+    `INITIAL_BACKOFF/MAX_BACKOFF/BACKOFF_MULTIPLIER` from
+    `api_resilience.py`.
+  - `def add_listener(self, callback) -> None` — register
+    a coroutine to fire on every pushed frame.
+- Reuses the auth primitives from `_auth.py` and the
+  circuit-breaker-aware reconnect pattern from
+  `_session.py`. The WS is **outside** the REST
+  circuit breaker (per `ARCHITECTURE.md` rule about
+  Cognito — different hosts) but the per-pool refresh
+  failure isolation (in the coordinator) still applies.
+- Wire into `FluidraPoolAPI` in `client.py`. The WS is
+  started lazily on the first `subscribe_device` call and
+  owned by the API instance for its lifetime.
+
+#### Coordinator hook (`coordinator/coordinator.py`)
+
+- On entry setup, after the first successful poll, call
+  `api.subscribe_device(device_id)` for every
+  `connected`-type device.
+- Add a listener via `api.add_listener(...)`: on every
+  pushed `command` frame, call
+  `coordinator.async_request_refresh()` (the existing
+  debounced refresh — already does the right thing per
+  `ARCHITECTURE.md`).
+- **No state mutation in the listener** — the WS only
+  triggers a re-read, the actual state comes from the
+  REST response. This avoids the
+  poll-vs-ws-conflict trap (see Cross-cutting concerns).
+
+#### Lifecycle
+
+- Start WS in `__init__.py:async_setup_entry` AFTER the
+  first successful poll, so a failed login does not block
+  setup.
+- Stop WS in `async_unload_entry` BEFORE closing the
+  REST session, so a clean shutdown order is preserved.
+- If the WS is disabled (option flag off, see 5.5) the
+  coordinator behaves exactly as today.
+
+### 5.4 Tests
+
+**Unit** (`tests/test_fluidra_api_websocket.py`):
+- Synthetic WS server (`aiohttp.web` test server) that
+  accepts the connect + subs, then pushes a frame.
+- Assert the listener fires within X ms of the push.
+- Reconnect test: kill the server, assert exponential
+  backoff is honoured, restart, assert reconnect.
+- Auth-failure test: server returns 401 → WS closes, no
+  reconnect loop spam (the integration rule from
+  `ARCHITECTURE.md` §Resilience).
+
+**Integration** (extend `tests/test_coordinator.py`):
+- With WS enabled, push a frame, assert
+  `async_request_refresh` was called.
+- With WS disabled (option off), no WS connect attempt.
+
+**Real-account**:
+- Capture handshake + first 30 s. **Required** for the
+  implementation to be mergeable.
+
+### 5.5 Config flow
+
+- `CONF_ENABLE_WEBSOCKET: bool = False` (default off,
+  behind the same options-flow page as Pass 3 and Pass 4).
+- First release with WS: default OFF. Second minor
+  release after field reports: flip to default ON.
+
+### 5.6 Risk + rollback
+
+- Risk: medium. The lifecycle (start, stop, reconnect) is
+  the riskiest part. The REST path is untouched so a WS
+  bug is fully recoverable.
+- Rollback: option off. The integration continues to
+  poll-only, same as v2.84.0.
+- Feature flag: yes — `CONF_ENABLE_WEBSOCKET`.
+- Observability: log every connect/disconnect/reconnect
+  at INFO (single line, no payload), every frame at
+  DEBUG. A WS that flaps every 30 s should be loud.
+
+### 5.7 Real-account dependency
+
+**Yes — critical.** Auth header, ping interval, and the
+exact "command" payload shape are all unconfirmed. The
+doc itself flags this.
+
+---
+
+## Pass 6 — Automations endpoint (`/pools/{id}/automations`)
+
+> **Statut au 2026-08-26 — BLOQUÉ (mesuré, pas supposé).** `GET /generic/pools/{id}/automations` rend
+> **403**, et le corps n'est pas un refus de droits mais le message d'**AWS
+> SigV4** : « Invalid key=value pair (missing equal-sign) in Authorization
+> header ». Cette route attend une requête **signée IAM**, pas le Bearer
+> Cognito qui sert partout ailleurs dans l'intégration. Aucun niveau de compte
+> ne débloquera ça — il faut le schéma de signature, donc une capture de
+> l'app. Voir `API-DISCOVERY.md` §9.3.
+
+> **Bridge CRUD for the app's "automations" feature**
+> (distinct from `/schedulers`). The doc says it is
+> "plus haut niveau" (higher level) — likely the
+> conditional wizards the app offers, separate from
+> per-schedule times. Whether this is worth a full HA
+> service surface depends on the actual shape, which
+> is not in the doc.
+
+### 6.1 Rationale
+
+- If "automations" is a thin CRUD over a small fixed
+  schema (e.g. "if mode==X then run schedule Y"), it
+  maps cleanly to a service. If it is a freeform
+  conditional graph, an HA service would be too
+  opinionated.
+- Per the doc's own recommendation: "GET it first to
+  see the shape". This pass is intentionally
+  exploratory and degrades gracefully.
+
+### 6.2 Endpoint + response shape
+
+- `GET/POST /generic/pools/{id}/automations` (and
+  likely `PUT/DELETE /generic/pools/{id}/automations/
+  {aid}`). Bearer auth.
+- **TBD — must be measured.** Capture a real GET
+  response first. If the body is empty or the
+  endpoint 404s, defer the whole pass.
+
+### 6.3 Code paths (sketch only — implement after capture)
+
+- If GET returns a non-empty list with a stable schema:
+  - `AutomationMixin.get_pool_automations(pool_id) ->
+    list[Automation] | None` in a new mixin.
+  - `sensor/pool.py:FluidraPoolAutomationCountSensor` —
+    pool-attached, `state_class = MEASUREMENT`, value is
+    the count.
+  - If the schema permits a stable write shape: a
+    `fluidra_pool.set_automation` service, registered
+    in `__init__.py:_async_register_services` following
+    the existing schedule-service pattern.
+- If GET returns empty / 404: log once at INFO, no
+  entity, defer to a future pass.
+
+### 6.4 Tests
+
+- Same capture-then-test pattern as Pass 4. No test
+  without a real payload fixture.
+
+### 6.5 Risk + rollback
+
+- Risk: low to medium depending on shape.
+- Rollback: drop the entity / service. No existing
+  `unique_id` is touched.
+
+### 6.6 Real-account dependency
+
+**Yes**. Cannot proceed without a capture.
+
+---
+
+## Pass 7 — Recommendations endpoint (`/pools/{id}/recommendations`)
+
+> **Statut au 2026-08-26 — BLOQUÉ (mesuré, pas supposé).** `GET /generic/pools/{id}/recommendations` rend
+> **403**, et le corps n'est pas un refus de droits mais le message d'**AWS
+> SigV4** : « Invalid key=value pair (missing equal-sign) in Authorization
+> header ». Cette route attend une requête **signée IAM**, pas le Bearer
+> Cognito qui sert partout ailleurs dans l'intégration. Aucun niveau de compte
+> ne débloquera ça — il faut le schéma de signature, donc une capture de
+> l'app. Voir `API-DISCOVERY.md` §9.3.
+
+> **Lowest-risk read.** A single diagnostic sensor per
+> pool carrying the latest recommendation text from the
+> cloud (e.g. "shock treatment recommended", "filter
+> backwash due"). One sensor per pool, no control.
+
+### 7.1 Rationale
+
+- The doc lists this as "non exposé par l'intégration".
+  The information is useful (it is what the app shows
+  on the pool home screen) and it is a single GET, so
+  the cost is one HTTP call per pool per poll cycle.
+- Maps to a `sensor` with `state_class = None` (text
+  recommendation, not a measurement) and
+  `device_class = ENUM` if the recommendations are from
+  a fixed list, else no `device_class`.
+
+### 7.2 Endpoint + response shape
+
+- `GET /generic/pools/{id}/recommendations` (Bearer).
+- **TBD — must be measured.** The doc says
+  "vides / filtrage" which suggests the payload may
+  filter by context (e.g. only return recommendations
+  relevant to current water-quality readings).
+- One real capture needed.
+
+### 7.3 Code changes
+
+- `RecommendationsMixin.get_pool_recommendations(pool_id)
+  -> list[Recommendation] | None` in a new mixin.
+- `sensor/pool.py:FluidraPoolRecommendationSensor` —
+  pool-attached. `native_value` is the most recent
+  recommendation's short text; attributes carry the
+  full list and the timestamp.
+- Coordinator hook: one fetch per pool per poll cycle.
+  Failure: keep previous value, log at DEBUG.
+- No new config-flow option — this is read-only and
+  cheap, safe to enable by default. (If a poll-cycle
+  cost shows up in profiling, gate it then.)
+
+### 7.4 Tests
+
+- Synthetic payload (built from the real capture once
+  it exists). Test the most-recent pick and the
+  attribute shape.
+
+### 7.5 Risk + rollback
+
+- Risk: low.
+- Rollback: drop the entity file. No `unique_id` change.
+
+### 7.6 Real-account dependency
+
+**Yes** for the response shape.
+
+---
+
+## Cross-cutting concerns
+
+### Config flow
+
+- New options-flow toggles added in `config_flow.py`
+  `FluidraPoolOptionsFlowHandler.async_step_init`:
+  - `CONF_ENABLE_WEBSOCKET` (Pass 5) — default off.
+  - `CONF_ENABLE_DYNAMIC_UICONFIG` (Pass 3) — default
+    off.
+  - `CONF_ENABLE_TELEMETRY` (Pass 4) — default off.
+  - `CONF_ENABLE_RECOMMENDATIONS` (Pass 7) — default
+    on (cheap, read-only).
+- Each option MUST be honoured by the coordinator
+  via the existing `runtime_data.options_snapshot`
+  reload-on-change machinery (`ARCHITECTURE.md`
+  §Hard rules: update listener reloads only on
+  *options* changes).
+- Each option requires a translation key in
+  `strings.json` and all 5 `translations/*.json`
+  files (en, fr, de, es, it — count files in
+  `translations/`). Existing pattern in
+  `__init__.py:_async_register_services`.
+
+### Capability detection
+
+- The `_discover_devices_for_pool` already returns
+  per-device metadata including `thing_type` (Issue
+  #195). Add to that metadata:
+  - `device["capabilities"]["websocket"]` — set
+    `True` for `connection_type == "connected"` (the
+    doc's WS is for connected devices only).
+  - `device["capabilities"]["uiconfig"]` — set
+    `True` after the first successful uiconfig GET
+    (Pass 3).
+  - `device["capabilities"]["telemetry"]` — set
+    `True` after the first successful `/telemetry`
+    response (Pass 4).
+- All capabilities are read on the first successful
+  poll and cached on the device dict (consistent
+  with the existing `thing_type` caching pattern in
+  `_devices.py:197,222`).
+
+### Polling vs WebSocket conflict resolution
+
+- **Single source of truth**: the REST bulk fetch
+  (`get_all_components`, `_components.py:40`). The WS
+  frame is a *trigger* to re-read, never a *writer*
+  of state.
+- The listener (Pass 5) calls
+  `coordinator.async_request_refresh()` only — it
+  does NOT mutate `device["components"]` directly.
+- The existing debouncer (1.5 s cooldown, per
+  `coordinator.py:104-109`) coalesces multiple WS
+  triggers into a single poll, which is exactly the
+  right shape for "20 devices all pushed a frame
+  in 200 ms".
+- Optimistic state (`ARCHITECTURE.md` §Optimistic
+  state) is unchanged: optimistic value is shown
+  until either the next REST poll confirms it (now
+  triggered by the WS instead of by the 30 s timer)
+  or the optimistic timeout elapses.
+- A WS frame for a device whose REST read is
+  currently in-flight: the in-flight read wins, the
+  WS just triggers the *next* read. No race.
+
+### Error handling
+
+- Reuse the existing `api_resilience.py` exception
+  hierarchy: `FluidraConnectionError`,
+  `FluidraAuthError`, `FluidraCircuitBreakerError`.
+  The WS introduces no new error class.
+- WS auth failures: do NOT trigger a reauth flow on
+  the first failure (the REST path is still
+  healthy). Only escalate to reauth if the REST
+  path also returns 401 — same primitive as today.
+- Per-pool refresh failure isolation (existing
+  `coordinator.py:_refresh_pool`) extends naturally
+  to telemetry: a failed telemetry fetch is logged
+  at DEBUG, not promoted to a per-pool failure.
+- The `connection_error` repair issue (existing,
+  `repairs.py:async_create_connection_issue`,
+  raised at `CONNECTION_ISSUE_THRESHOLD` consecutive
+  poll failures) MUST NOT count WS disconnects —
+  a WS that drops every 30 s on a flaky network
+  must not surface a "pool offline" repair issue
+  while the REST polls keep succeeding. Guard with
+  an explicit `connection_issue_counts_ws =
+  False` flag in the listener.
+
+### Documentation
+
+- `CHANGELOG.md` (SemVer, Keep a Changelog — already
+  followed, `CHANGELOG.md:1-7`) for every release
+  that ships a pass. Minor bumps for new entities /
+  options (2.85.0, 2.86.0, …).
+- `manifest.json` and `hacs.json` version bump
+  per release (per `CHANGELOG.md:7`).
+- `README.md` — when a pass lands, add a one-line
+  description of the new entity in the supported
+  features list. Do not re-document the API
+  surface (the doc and the changelog already do).
+- `ARCHITECTURE.md` — when Pass 3 (uiconfig) lands,
+  add a one-paragraph note in §Key mechanisms
+  about the dynamic loader and its opt-in flag.
+  When Pass 5 (WS) lands, add a one-paragraph
+  note in §Data flow about the WS as a refresh
+  trigger.
+- `CLAUDE.md` — leave untouched. The project
+  guidelines are stable; the new options
+  conform to them (Ruff, type hints, no
+  `Co-Authored-By` in commits, `helpers.py`
+  for pure functions, mixin pattern in
+  `fluidra_api/`).
+
+### Release cadence
+
+- Pass 1 and Pass 2 ship together as **v2.85.0** —
+  read-only and control-only additions, low risk,
+  SemVer minor.
+- Pass 3 ships as **v2.86.0** — opt-in refactor,
+  SemVer minor.
+- Pass 4 ships as **v2.87.0** — opt-in read,
+  SemVer minor.
+- Pass 5 ships as **v2.88.0** — opt-in WS,
+  SemVer minor. **First release stays default-off**
+  per 5.5. After one minor cycle of field
+  reports, default flips to on at **v2.89.0** —
+  a SemVer patch since behaviour is unchanged
+  for opted-in users.
+- Pass 6 and Pass 7 ship as **v2.90.0** once
+  the real-account capture exists. If the
+  capture does not exist at the time of the
+  release, drop them and re-evaluate after the
+  next pass.
+
+### Test gates
+
+- Every pass MUST land with:
+  - All existing 1312 tests green.
+  - Per-pass coverage ≥ 90 % on the new module(s).
+  - mypy `--strict` clean (existing CI gate per
+    `ARCHITECTURE.md` §Tests).
+  - Ruff clean.
+  - A live deploy on the operator's HA dev
+    instance via `scp -r custom_components/
+    fluidra_pool/ ha-dev:/config/custom_components/
+    && ssh ha-dev 'ha core restart'` and a
+    zero-error log read (`ARCHITECTURE.md` §Tests
+    + `ha-debugging-09` skill).
+- For Pass 3/4/5/6/7, the operator MUST commit
+  the real-account capture (redacted of device
+  ids via the existing `utils.mask_device_id`)
+  under `tests/fixtures/<endpoint>_sample.json`
+  before the implementation PR can be reviewed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ skips = ["B101", "B105", "B110"]  # B101: assert, B105: hardcoded password (fals
 
 [tool.codespell]
 skip = "*.json,*.yaml,*.yml,.git"
-ignore-words-list = "hass,informations,authentification,formater,potentiel,complet,valide,conflit,conflits,groupe,correspondant,mis"
+ignore-words-list = "hass,informations,authentification,formater,potentiel,complet,valide,conflit,conflits,groupe,correspondant,mis,ot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,7 @@ exclude_dirs = ["tests", ".venv"]
 skips = ["B101", "B105", "B110"]  # B101: assert, B105: hardcoded password (false positive on const names), B110: try/except/pass (common in HA)
 
 [tool.codespell]
-skip = "*.json,*.yaml,*.yml,.git"
+# API-DISCOVERY.md and the plans are written in French: codespell reads them
+# as misspelt English and flags dozens of ordinary French words.
+skip = "*.json,*.yaml,*.yml,.git,API-DISCOVERY.md,plans/*,./plans/*"
 ignore-words-list = "hass,informations,authentification,formater,potentiel,complet,valide,conflit,conflits,groupe,correspondant,mis,ot"

--- a/tests/test_config_flow_extra.py
+++ b/tests/test_config_flow_extra.py
@@ -22,6 +22,7 @@ from custom_components.fluidra_pool.api_resilience import (
     FluidraMFARequired,
 )
 from custom_components.fluidra_pool.const import (
+    CONF_ENABLE_REALTIME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -70,7 +71,9 @@ async def test_options_flow_create_entry(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == {CONF_SCAN_INTERVAL: 120}
+    # The realtime toggle rides along with its default: the form always submits
+    # every option it shows, and off is what a user who never touched it gets.
+    assert result["data"] == {CONF_SCAN_INTERVAL: 120, CONF_ENABLE_REALTIME: False}
     assert entry.options[CONF_SCAN_INTERVAL] == 120
 
 

--- a/tests/test_new_registers.py
+++ b/tests/test_new_registers.py
@@ -1,0 +1,341 @@
+"""Tests for the registers added by Pass 1 of the API-discovery plan.
+
+Covers the UV lamp block (presence mask + running hours), the split
+hours/minutes boost countdown of the tecnoLC2/CC chlorinators, and the
+controller-reported filtration state — all read-only, all profile-declared.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.fluidra_pool.binary_sensor import (
+    FluidraFiltrationStateBinarySensor,
+    FluidraUvPresentBinarySensor,
+)
+from custom_components.fluidra_pool.binary_sensor import (
+    async_setup_entry as binary_sensor_setup_entry,
+)
+from custom_components.fluidra_pool.device_registry.configs.chlorinators import CHLORINATOR_CONFIGS
+from custom_components.fluidra_pool.device_registry.configs.pumps import PUMP_CONFIGS
+from custom_components.fluidra_pool.sensor import (
+    FluidraBoostRemainingHoursSensor,
+    FluidraUvRunningHoursSensor,
+)
+from custom_components.fluidra_pool.sensor import async_setup_entry as sensor_setup_entry
+
+POOL_ID = "pool-1"
+DEVICE_ID = "TEST-DEV-001"
+
+UV_PRESENT = 252
+UV_HOURS = 253
+BOOST_HOURS = 118
+BOOST_MINUTES = 111
+FILTRATION_STATE = 135
+FILTRATION_FALLBACK = 244
+
+
+def _device(components: dict | None = None, features: dict | None = None, device_id: str = DEVICE_ID) -> dict:
+    """Build a chlorinator whose identify cache is pinned to a known feature set."""
+    return {
+        "device_id": device_id,
+        "name": "Chlorinator",
+        "family": "Chlorinators",
+        "type": "chlorinator",
+        "model": "Chlorinator",
+        "online": True,
+        "components": components if components is not None else {},
+        "_identify_cache": {
+            "key": (device_id, "Chlorinators", "Chlorinator", "chlorinator", ""),
+            "config": SimpleNamespace(
+                device_type="chlorinator",
+                features=features or {},
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=["sensor_info"],
+            ),
+        },
+    }
+
+
+def _coord(devices: list[dict]) -> Any:
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": devices}}
+    coordinator.last_update_success = True
+    return coordinator
+
+
+# --- UV presence mask (c252) -------------------------------------------------
+
+
+def _uv_present(device: dict) -> FluidraUvPresentBinarySensor:
+    return FluidraUvPresentBinarySensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, UV_PRESENT)
+
+
+def test_uv_present_true_when_block_reported() -> None:
+    """A non-zero mask means the app shows the UV block, so the lamp is there."""
+    assert _uv_present(_device({"252": {"reportedValue": 1}})).is_on is True
+
+
+def test_uv_present_false_when_masked() -> None:
+    """A zero mask is the app's own "no UV lamp" signal."""
+    assert _uv_present(_device({"252": {"reportedValue": 0}})).is_on is False
+
+
+def test_uv_present_none_when_register_absent() -> None:
+    """A firmware that never reports the register stays unknown, not off."""
+    assert _uv_present(_device({})).is_on is None
+
+
+def test_uv_present_none_on_unparsable_value() -> None:
+    """Unparsable readings degrade to unknown rather than raising."""
+    assert _uv_present(_device({"252": {"reportedValue": "n/a"}})).is_on is None
+
+
+def test_uv_present_unavailable_without_components() -> None:
+    """No component data at all means unavailable, like the other chlorinator sensors."""
+    assert _uv_present(_device({})).available is False
+
+
+# --- UV running hours (c253) -------------------------------------------------
+
+
+def _uv_hours(device: dict) -> FluidraUvRunningHoursSensor:
+    return FluidraUvRunningHoursSensor(_coord([device]), SimpleNamespace(), POOL_ID, DEVICE_ID, UV_HOURS)
+
+
+def test_uv_running_hours_value() -> None:
+    """The counter is a plain integer hour count (factor 1)."""
+    assert _uv_hours(_device({"253": {"reportedValue": 1234}})).native_value == 1234
+
+
+def test_uv_running_hours_accepts_float_reading() -> None:
+    """A float-shaped reading is truncated to whole hours, not rejected."""
+    assert _uv_hours(_device({"253": {"reportedValue": 12.0}})).native_value == 12
+
+
+def test_uv_running_hours_none_on_unparsable_value() -> None:
+    """Unparsable readings degrade to None."""
+    assert _uv_hours(_device({"253": {"reportedValue": "n/a"}})).native_value is None
+
+
+def test_uv_running_hours_unavailable_when_register_missing() -> None:
+    """A unit without a UV lamp must not show a permanently zero counter."""
+    sensor = _uv_hours(_device({"172": {"reportedValue": 250}}))
+    assert sensor.available is False
+    assert sensor.native_value is None
+
+
+def test_uv_running_hours_available_when_register_reported() -> None:
+    """The register answering is what makes the counter meaningful."""
+    assert _uv_hours(_device({"253": {"reportedValue": 0}})).available is True
+
+
+# --- Boost countdown split over hours + minutes (c118 / c111) ----------------
+
+
+def _boost(components: dict, feature: dict | None = None) -> FluidraBoostRemainingHoursSensor:
+    features = {
+        "boost_remaining_hours": feature if feature is not None else {"hours": BOOST_HOURS, "minutes": BOOST_MINUTES}
+    }
+    return FluidraBoostRemainingHoursSensor(
+        _coord([_device(components, features)]), SimpleNamespace(), POOL_ID, DEVICE_ID
+    )
+
+
+def test_boost_remaining_combines_both_halves() -> None:
+    """23 h 30 min left reads as 23.5 h, the way the app's own label builds it."""
+    assert _boost({"118": {"reportedValue": 23}, "111": {"reportedValue": 30}}).native_value == 23.5
+
+
+def test_boost_remaining_hours_only() -> None:
+    """A firmware reporting only whole hours still yields a value."""
+    assert _boost({"118": {"reportedValue": 12}}).native_value == 12.0
+
+
+def test_boost_remaining_minutes_only() -> None:
+    """A firmware reporting only the minutes of the last hour still yields a value."""
+    assert _boost({"111": {"reportedValue": 45}}).native_value == 0.75
+
+
+def test_boost_remaining_zero_is_a_real_reading() -> None:
+    """Boost off reports 0, which must stay 0 rather than turning unknown."""
+    assert _boost({"118": {"reportedValue": 0}, "111": {"reportedValue": 0}}).native_value == 0.0
+
+
+def test_boost_remaining_none_when_neither_register_answers() -> None:
+    """Neither half reported means unknown."""
+    assert _boost({"172": {"reportedValue": 250}}).native_value is None
+
+
+def test_boost_remaining_none_without_feature_mapping() -> None:
+    """A device whose profile declares no register pair reports nothing."""
+    sensor = FluidraBoostRemainingHoursSensor(
+        _coord([_device({"118": {"reportedValue": 5}}, {})]), SimpleNamespace(), POOL_ID, DEVICE_ID
+    )
+    assert sensor.native_value is None
+
+
+def test_boost_remaining_ignores_unparsable_half() -> None:
+    """One bad half does not sink the other."""
+    assert _boost({"118": {"reportedValue": 3}, "111": {"reportedValue": "n/a"}}).native_value == 3.0
+
+
+# --- Filtration state (c135, c244 fallback) ---------------------------------
+
+
+def _filtration(components: dict, fallback: int | None = FILTRATION_FALLBACK) -> FluidraFiltrationStateBinarySensor:
+    return FluidraFiltrationStateBinarySensor(
+        _coord([_device(components)]),
+        SimpleNamespace(),
+        POOL_ID,
+        DEVICE_ID,
+        FILTRATION_STATE,
+        fallback,
+    )
+
+
+def test_filtration_running_from_primary_register() -> None:
+    """The primary register wins whenever it answers."""
+    assert _filtration({"135": {"reportedValue": 1}}).is_on is True
+
+
+def test_filtration_stopped_from_primary_register() -> None:
+    """Zero on the primary register means the block is stopped."""
+    assert _filtration({"135": {"reportedValue": 0}, "244": {"reportedValue": 2}}).is_on is False
+
+
+def test_filtration_second_speed_still_counts_as_running() -> None:
+    """The block state is 0/1/2 — anything non-zero is running."""
+    assert _filtration({"135": {"reportedValue": 2}}).is_on is True
+
+
+def test_filtration_falls_back_when_primary_absent() -> None:
+    """Firmware versions that only carry the second register still report."""
+    assert _filtration({"244": {"reportedValue": 1}}).is_on is True
+
+
+def test_filtration_none_when_no_register_answers() -> None:
+    """Neither register reported means unknown, not stopped."""
+    assert _filtration({"172": {"reportedValue": 250}}).is_on is None
+
+
+def test_filtration_none_without_fallback_declared() -> None:
+    """A profile may declare no fallback at all."""
+    assert _filtration({"244": {"reportedValue": 1}}, fallback=None).is_on is None
+
+
+def test_filtration_none_on_unparsable_value() -> None:
+    """Unparsable readings degrade to unknown."""
+    assert _filtration({"135": {"reportedValue": "n/a"}}).is_on is None
+
+
+# --- Platform wiring ---------------------------------------------------------
+
+
+async def _run_setup(setup_entry: Any, devices: list[dict]) -> list[Any]:
+    pool = {"id": POOL_ID, "name": "Pool", "devices": devices}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    coordinator.async_add_listener = lambda cb: lambda: None
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await setup_entry(MagicMock(), entry, async_add)
+    return added
+
+
+async def test_binary_sensors_created_only_when_features_declared() -> None:
+    """UV presence and filtration state are opt-in per profile."""
+    with_features = _device(
+        {"252": {"reportedValue": 1}, "135": {"reportedValue": 1}},
+        {
+            "uv_lamp": {"present": UV_PRESENT, "running_hours": UV_HOURS},
+            "filtration_state": {"state": FILTRATION_STATE, "fallback": FILTRATION_FALLBACK},
+        },
+        device_id="dev1",
+    )
+    without_features = _device({"252": {"reportedValue": 1}}, {}, device_id="dev2")
+    added = await _run_setup(binary_sensor_setup_entry, [with_features, without_features])
+
+    uids = {e.unique_id for e in added}
+    assert "fluidra_pool_pool-1_dev1_uv_present" in uids
+    assert "fluidra_pool_pool-1_dev1_filtration_state" in uids
+    assert "fluidra_pool_pool-1_dev2_uv_present" not in uids
+    assert "fluidra_pool_pool-1_dev2_filtration_state" not in uids
+
+
+async def test_sensors_created_only_when_features_declared() -> None:
+    """The UV counter and the split boost countdown are opt-in per profile."""
+    with_features = _device(
+        {"253": {"reportedValue": 10}, "118": {"reportedValue": 1}},
+        {
+            "uv_lamp": {"present": UV_PRESENT, "running_hours": UV_HOURS},
+            "boost_remaining_hours": {"hours": BOOST_HOURS, "minutes": BOOST_MINUTES},
+        },
+        device_id="dev1",
+    )
+    without_features = _device({"253": {"reportedValue": 10}}, {}, device_id="dev2")
+    added = await _run_setup(sensor_setup_entry, [with_features, without_features])
+
+    uids = {e.unique_id for e in added}
+    assert "fluidra_dev1_uv_running_hours" in uids
+    assert "fluidra_dev1_boost_remaining_hours" in uids
+    assert "fluidra_dev2_uv_running_hours" not in uids
+    assert "fluidra_dev2_boost_remaining_hours" not in uids
+
+
+# --- Profile declarations (plan 013, Pass 1) ---------------------------------
+
+
+def test_tecnolc2_profiles_declare_the_ui_config_registers() -> None:
+    """Every tecnoLC2 chlorinator gains the UV block and the filtration state."""
+    for name, config in CHLORINATOR_CONFIGS.items():
+        if config.features.get("sensors", {}).get("temperature") != 172:
+            continue
+        features = config.features
+        assert features["uv_lamp"] == {"present": UV_PRESENT, "running_hours": UV_HOURS}, name
+        assert features["filtration_state"] == {
+            "state": FILTRATION_STATE,
+            "fallback": FILTRATION_FALLBACK,
+        }, name
+        scanned = set(features["specific_components"])
+        assert {UV_PRESENT, UV_HOURS, FILTRATION_STATE, FILTRATION_FALLBACK} <= scanned, name
+
+
+def test_boost_countdown_only_on_profiles_that_have_a_boost() -> None:
+    """The hours/minutes pair is meaningless on a unit with no boost register."""
+    for name, config in CHLORINATOR_CONFIGS.items():
+        features = config.features
+        if features.get("sensors", {}).get("temperature") != 172:
+            continue
+        if features.get("boost_mode") is None:
+            assert "boost_remaining_hours" not in features, name
+            continue
+        assert features["boost_remaining_hours"] == {"hours": BOOST_HOURS, "minutes": BOOST_MINUTES}, name
+        assert {BOOST_HOURS, BOOST_MINUTES} <= set(features["specific_components"]), name
+
+
+def test_non_tecnolc2_chlorinators_are_left_alone() -> None:
+    """The catch-all, the DM lineup and the eXO read these ids differently."""
+    for name in ("chlorinator", "dm24049704_chlorinator", "ns25_exo_chlorinator"):
+        features = CHLORINATOR_CONFIGS[name].features
+        assert "uv_lamp" not in features, name
+        assert "filtration_state" not in features, name
+        assert "boost_remaining_hours" not in features, name
+
+
+def test_victoria_pump_keeps_its_own_meaning_for_c135() -> None:
+    """c135 is the active quick-function slot there — it must never be read as filtration."""
+    features = PUMP_CONFIGS["victoria_smart_connect_pump"].features
+    assert "filtration_state" not in features
+    assert FILTRATION_STATE in features["specific_components"]

--- a/tests/test_pump_three_speed.py
+++ b/tests/test_pump_three_speed.py
@@ -1,0 +1,243 @@
+"""Tests for the three-speed pump select (plan 013, Pass 2).
+
+The controller carries the speed on a single register it also accepts writes
+on, unlike the E30iQ, which is driven through its own c9/c11 pair by
+:class:`FluidraPumpSpeedSelect`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import pytest
+
+from custom_components.fluidra_pool.api_resilience import FluidraError
+from custom_components.fluidra_pool.select import (
+    FluidraPumpSpeedSelect,
+    FluidraThreeSpeedPumpSelect,
+    async_setup_entry,
+)
+
+POOL_ID = "pool-1"
+DEVICE_ID = "TEST-PUMP-001"
+COMPONENT = 137
+
+
+def _device(
+    components: dict | None = None,
+    features: dict | None = None,
+    device_id: str = DEVICE_ID,
+    **extra: Any,
+) -> dict:
+    device = {
+        "device_id": device_id,
+        "name": "Filtration pump",
+        "family": "Pumps",
+        "type": "pump",
+        "model": "Pump",
+        "online": True,
+        "components": components if components is not None else {},
+        "_identify_cache": {
+            "key": (device_id, "Pumps", "Pump", "pump", ""),
+            "config": SimpleNamespace(
+                device_type="pump",
+                features=features or {},
+                components_range=25,
+                required_components=[0, 1, 2, 3],
+                entities=["select", "sensor_info"],
+            ),
+        },
+    }
+    device.update(extra)
+    return device
+
+
+def _coord(devices: list[dict], access_level: str | None = None) -> Any:
+    pool: dict[str, Any] = {"id": POOL_ID, "name": "Pool", "devices": devices}
+    if access_level is not None:
+        pool["access_level"] = access_level
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+def _select(
+    components: dict,
+    *,
+    write_map: dict | None = None,
+    read_map: dict | None = None,
+    api: Any = None,
+    access_level: str | None = None,
+) -> FluidraThreeSpeedPumpSelect:
+    entity = FluidraThreeSpeedPumpSelect(
+        _coord([_device(components)], access_level),
+        api or SimpleNamespace(),
+        POOL_ID,
+        DEVICE_ID,
+        COMPONENT,
+        write_map,
+        read_map,
+    )
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+# --- Reading the speed -------------------------------------------------------
+
+
+def test_options_come_from_the_write_table() -> None:
+    """The offered options are exactly the speeds the profile can write."""
+    assert _select({}).options == ["low", "medium", "high"]
+
+
+@pytest.mark.parametrize(("reported", "expected"), [(0, "low"), (1, "medium"), (2, "high")])
+def test_current_option_uses_the_read_table(reported: int, expected: str) -> None:
+    """The reported integer is translated through the profile's read table."""
+    assert _select({"137": {"reportedValue": reported}}).current_option == expected
+
+
+def test_current_option_none_when_register_absent() -> None:
+    """Nothing reported means unknown, not a default speed."""
+    assert _select({}).current_option is None
+
+
+def test_current_option_none_on_value_outside_the_table() -> None:
+    """An unmapped value means the profile's table is wrong for this unit -- say nothing."""
+    assert _select({"137": {"reportedValue": 7}}).current_option is None
+
+
+def test_current_option_none_on_unparsable_value() -> None:
+    """Unparsable readings degrade to unknown."""
+    assert _select({"137": {"reportedValue": "n/a"}}).current_option is None
+
+
+def test_read_and_write_tables_are_profile_overridable() -> None:
+    """A family numbering its speeds differently is a profile edit, not a code change."""
+    entity = _select(
+        {"137": {"reportedValue": 3}},
+        write_map={"eco": 5, "boost": 6},
+        read_map={3: "eco", 4: "boost"},
+    )
+    assert entity.options == ["eco", "boost"]
+    assert entity.current_option == "eco"
+
+
+# --- Writing the speed -------------------------------------------------------
+
+
+async def test_select_option_writes_the_mapped_value() -> None:
+    """Picking a speed writes the profile's value on the declared register."""
+    api = SimpleNamespace(control_device_component=AsyncMock(return_value=True))
+    entity = _select({"137": {"reportedValue": 0}}, api=api)
+
+    await entity.async_select_option("high")
+
+    api.control_device_component.assert_awaited_once_with(DEVICE_ID, COMPONENT, 3)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_unknown_option_is_ignored() -> None:
+    """An option outside the table never reaches the network."""
+    api = SimpleNamespace(control_device_component=AsyncMock(return_value=True))
+    entity = _select({}, api=api)
+
+    await entity.async_select_option("turbo")
+
+    api.control_device_component.assert_not_awaited()
+
+
+async def test_refused_write_raises_and_clears_the_optimistic_state() -> None:
+    """A write the cloud refuses must not leave the UI showing the new speed."""
+    api = SimpleNamespace(control_device_component=AsyncMock(return_value=False))
+    entity = _select({"137": {"reportedValue": 0}}, api=api)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("medium")
+
+    assert entity.current_option == "low"
+
+
+async def test_transport_error_raises_and_clears_the_optimistic_state() -> None:
+    """Same for a transport failure."""
+    api = SimpleNamespace(control_device_component=AsyncMock(side_effect=FluidraError("boom")))
+    entity = _select({"137": {"reportedValue": 0}}, api=api)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("medium")
+
+    assert entity.current_option == "low"
+
+
+async def test_viewer_account_cannot_write() -> None:
+    """The read-only guard fires before any optimistic state is set (Issue #133)."""
+    api = SimpleNamespace(control_device_component=AsyncMock(return_value=True))
+    entity = _select({"137": {"reportedValue": 0}}, api=api, access_level="viewer")
+
+    with pytest.raises(ServiceValidationError):
+        await entity.async_select_option("high")
+
+    api.control_device_component.assert_not_awaited()
+
+
+# --- Platform wiring ---------------------------------------------------------
+
+
+async def _run_setup(devices: list[dict]) -> list[Any]:
+    pool = {"id": POOL_ID, "name": "Pool", "devices": devices}
+    coordinator = MagicMock()
+    coordinator.data = {POOL_ID: pool}
+    coordinator.last_update_success = True
+    coordinator.api = SimpleNamespace(cached_pools=[pool], get_pools=AsyncMock(return_value=[pool]))
+    coordinator.get_pools_from_data = lambda: [{"id": POOL_ID, **coordinator.data[POOL_ID]}]
+    coordinator.async_add_listener = lambda cb: lambda: None
+
+    added: list[Any] = []
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        async_on_unload=lambda _unsub: None,
+    )
+    async_add = MagicMock(side_effect=lambda ents, *a, **k: added.extend(list(ents)))
+    await async_setup_entry(MagicMock(), entry, async_add)
+    return added
+
+
+async def test_three_speed_select_created_only_when_declared() -> None:
+    """No profile feature, no entity."""
+    declared = _device(
+        {"137": {"reportedValue": 1}},
+        {"pump_3speed": {"component": COMPONENT}},
+        device_id="dev1",
+        variable_speed=True,
+    )
+    plain = _device({}, {}, device_id="dev2", variable_speed=True)
+    added = await _run_setup([declared, plain])
+
+    uids = {e.unique_id for e in added}
+    assert "fluidra_pool_pool-1_dev1_pump_3speed" in uids
+    assert "fluidra_pool_pool-1_dev2_pump_3speed" not in uids
+
+
+async def test_three_speed_replaces_the_e30iq_speed_select() -> None:
+    """The two speed controls are mutually exclusive on the same pump."""
+    declared = _device(
+        {"137": {"reportedValue": 1}},
+        {"pump_3speed": {"component": COMPONENT}},
+        device_id="dev1",
+        variable_speed=True,
+    )
+    added = await _run_setup([declared])
+
+    assert not any(isinstance(e, FluidraPumpSpeedSelect) for e in added)
+    assert any(isinstance(e, FluidraThreeSpeedPumpSelect) for e in added)
+
+
+async def test_plain_variable_speed_pump_keeps_its_select() -> None:
+    """An E30iQ is untouched by this pass."""
+    added = await _run_setup([_device({}, {}, device_id="dev2", variable_speed=True)])
+
+    assert any(isinstance(e, FluidraPumpSpeedSelect) for e in added)

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,0 +1,356 @@
+"""Tests for the realtime WebSocket channel (plan 013, Pass 5).
+
+Every behaviour asserted here comes from a measurement recorded in
+``API-DISCOVERY.md`` §10: the frame shape, the asynchronous replies, the abrupt
+1006 close on idle timeout, and the fact that the channel must never be able to
+break the polling path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.fluidra_pool.fluidra_api._websocket import (
+    ComponentChange,
+    FluidraWebsocketClient,
+    parse_frame,
+)
+
+DEVICE_ID = "LE24500883"
+
+# Verbatim from the measured session (API-DISCOVERY.md §10.3).
+REAL_FRAME = (
+    '{"statusCode":200,"action":"componentChange",'
+    '"body":"{\\"deviceId\\":\\"LE24500883\\",\\"deviceType\\":\\"connected\\",'
+    '\\"componentId\\":11,\\"reportedValue\\":1,\\"ts\\":1787767038}"}'
+)
+SUBSCRIBE_ACK = (
+    '{"statusCode":200,"action":"subsDevice",'
+    '"body":"{\\"deviceId\\":\\"LE24500883\\",\\"deviceType\\":\\"connected\\",\\"message\\":\\"OK\\"}"}'
+)
+FORBIDDEN = '{"message": "Forbidden", "connectionId":"abc==", "requestId":"def="}'
+
+
+# --- Frame parsing -----------------------------------------------------------
+
+
+def test_parses_the_measured_frame() -> None:
+    """The exact payload the cloud sent during the end-to-end measurement."""
+    change = parse_frame(REAL_FRAME)
+    assert change == ComponentChange(device_id=DEVICE_ID, component_id=11, reported_value=1, timestamp=1787767038)
+
+
+def test_parses_bytes() -> None:
+    """aiohttp can hand the payload over as bytes."""
+    assert parse_frame(REAL_FRAME.encode()) is not None
+
+
+def test_parses_an_already_decoded_body() -> None:
+    """The body is a JSON string in practice, but a dict must work too."""
+    change = parse_frame(
+        {"action": "componentChange", "body": {"deviceId": DEVICE_ID, "componentId": 9, "reportedValue": 0}}
+    )
+    assert change is not None
+    assert change.component_id == 9
+    assert change.timestamp is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        SUBSCRIBE_ACK,  # subscription acknowledgement, not a state change
+        FORBIDDEN,  # reply to an unknown action
+        "not json",
+        b"\xff\xfe",  # undecodable bytes
+        None,
+        42,
+        '{"action":"componentChange"}',  # no body
+        '{"action":"componentChange","body":"not json"}',
+        '{"action":"componentChange","body":{"componentId":11,"reportedValue":1}}',  # no device
+        '{"action":"componentChange","body":{"deviceId":"","componentId":11,"reportedValue":1}}',
+        '{"action":"componentChange","body":{"deviceId":"X","reportedValue":1}}',  # no component
+        '{"action":"componentChange","body":{"deviceId":"X","componentId":"n/a","reportedValue":1}}',
+        '{"action":"componentChange","body":{"deviceId":"X","componentId":11}}',  # no value
+    ],
+)
+def test_non_changes_are_ignored(payload: Any) -> None:
+    """Anything that is not a usable state change parses to None, never raises."""
+    assert parse_frame(payload) is None
+
+
+def test_a_zero_value_is_a_real_change() -> None:
+    """0 is a legitimate reported value and must not be mistaken for absent."""
+    change = parse_frame(
+        {"action": "componentChange", "body": {"deviceId": "X", "componentId": 11, "reportedValue": 0}}
+    )
+    assert change is not None
+    assert change.reported_value == 0
+
+
+def test_unparsable_timestamp_does_not_lose_the_change() -> None:
+    """A bad ts costs the timestamp, not the change."""
+    change = parse_frame(
+        {"action": "componentChange", "body": {"deviceId": "X", "componentId": 11, "reportedValue": 3, "ts": "n/a"}}
+    )
+    assert change is not None
+    assert change.timestamp is None
+
+
+# --- Client behaviour --------------------------------------------------------
+
+
+class _FakeWS:
+    """Minimal stand-in for an aiohttp WebSocket response."""
+
+    def __init__(self, frames: list[Any]) -> None:
+        self._frames = frames
+        self.sent: list[dict[str, Any]] = []
+        self.pings = 0
+        self.closed = False
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+    async def ping(self, data: bytes = b"") -> None:
+        self.pings += 1
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def __aenter__(self) -> _FakeWS:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.closed = True
+
+    def __aiter__(self) -> Any:
+        async def gen() -> Any:
+            for frame in self._frames:
+                message = MagicMock()
+                message.type = _TEXT
+                message.data = frame
+                yield message
+
+        return gen()
+
+
+class _TextType:
+    pass
+
+
+_TEXT = _TextType()
+
+
+def _client(frames: list[Any], on_change: Any, token: str | None = "token") -> tuple[FluidraWebsocketClient, _FakeWS]:
+    ws = _FakeWS(frames)
+    session = MagicMock()
+    session.ws_connect = MagicMock(return_value=ws)
+    client = FluidraWebsocketClient(session, lambda: token, on_change)
+    return client, ws
+
+
+@pytest.fixture(autouse=True)
+def _text_message_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the fake frames look like aiohttp TEXT messages."""
+    import custom_components.fluidra_pool.fluidra_api._websocket as module
+
+    monkeypatch.setattr(module.aiohttp, "WSMsgType", MagicMock(TEXT=_TEXT))
+
+
+async def test_subscribes_to_every_device_on_connect() -> None:
+    """One subsDevice per known device, sent without waiting for a reply."""
+    client, ws = _client([], lambda change: None)
+    client._device_ids = [DEVICE_ID, "OTHER"]
+
+    await client._connect_once()
+
+    assert ws.sent == [
+        {"action": "subsDevice", "deviceType": "connected", "deviceId": DEVICE_ID},
+        {"action": "subsDevice", "deviceType": "connected", "deviceId": "OTHER"},
+    ]
+
+
+async def test_changes_reach_the_callback() -> None:
+    """The measured frame ends up as a ComponentChange on the callback."""
+    seen: list[ComponentChange] = []
+    client, _ = _client([SUBSCRIBE_ACK, REAL_FRAME], seen.append)
+    client._device_ids = [DEVICE_ID]
+
+    await client._connect_once()
+
+    assert [(c.device_id, c.component_id, c.reported_value) for c in seen] == [(DEVICE_ID, 11, 1)]
+    assert client.changes_received == 1
+
+
+async def test_async_callbacks_are_awaited() -> None:
+    """The coordinator's handler is a coroutine — it must actually run."""
+    seen: list[ComponentChange] = []
+
+    async def handler(change: ComponentChange) -> None:
+        await asyncio.sleep(0)
+        seen.append(change)
+
+    client, _ = _client([REAL_FRAME], handler)
+    await client._connect_once()
+
+    assert len(seen) == 1
+
+
+async def test_a_failing_callback_does_not_close_the_channel() -> None:
+    """A bad handler must not cost the connection, nor the frames after it."""
+    seen: list[ComponentChange] = []
+
+    def handler(change: ComponentChange) -> None:
+        if not seen:
+            seen.append(change)
+            raise RuntimeError("boom")
+        seen.append(change)
+
+    client, _ = _client([REAL_FRAME, REAL_FRAME], handler)
+    await client._connect_once()
+
+    assert len(seen) == 2
+
+
+async def test_refuses_to_connect_without_a_token() -> None:
+    """The handshake validates the token, so there is no point trying."""
+    client, _ = _client([], lambda change: None, token=None)
+    with pytest.raises(RuntimeError):
+        await client._connect_once()
+
+
+async def test_update_devices_subscribes_only_the_new_ones() -> None:
+    """A device discovered on a later poll is subscribed without reconnecting."""
+    client, ws = _client([], lambda change: None)
+    client._device_ids = [DEVICE_ID]
+    client._ws = ws
+
+    await client.update_devices([DEVICE_ID, "NEW"])
+
+    assert ws.sent == [{"action": "subsDevice", "deviceType": "connected", "deviceId": "NEW"}]
+    assert client._device_ids == [DEVICE_ID, "NEW"]
+
+
+async def test_update_devices_is_a_noop_without_a_connection() -> None:
+    """The new ids are remembered for the next connect, nothing is sent."""
+    client, _ = _client([], lambda change: None)
+    client._device_ids = [DEVICE_ID]
+
+    await client.update_devices([DEVICE_ID, "NEW"])
+
+    assert client._device_ids == [DEVICE_ID, "NEW"]
+
+
+async def test_stop_is_safe_before_start() -> None:
+    """Teardown must never raise, whatever state the channel is in."""
+    client, _ = _client([], lambda change: None)
+    await client.stop()
+    assert client.connected is False
+
+
+# --- Coordinator wiring ------------------------------------------------------
+
+
+def _coordinator(options: dict[str, Any] | None = None) -> Any:
+    """Build a real coordinator over a mock API, with no HA event loop needed."""
+    from unittest.mock import AsyncMock
+
+    from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
+
+    hass = MagicMock()
+    api = MagicMock()
+    api.access_token = "token"
+    api.write_verifier = None
+    entry = MagicMock()
+    entry.options = options if options is not None else {}
+
+    coordinator = FluidraDataUpdateCoordinator.__new__(FluidraDataUpdateCoordinator)
+    coordinator.hass = hass
+    coordinator.api = api
+    coordinator.config_entry = entry
+    coordinator._realtime = None
+    coordinator.realtime_changes = 0
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.data = {
+        "pool-1": {
+            "id": "pool-1",
+            "devices": [
+                {"device_id": DEVICE_ID, "name": "Pump", "type": "pump", "components": {"11": {"reportedValue": 0}}}
+            ],
+        }
+    }
+    return coordinator
+
+
+def test_realtime_is_off_by_default() -> None:
+    """Opt-in: an entry that never enabled it does not open the channel."""
+    assert _coordinator().realtime_enabled is False
+
+
+def test_realtime_reads_the_option() -> None:
+    """The toggle from the options flow is what decides."""
+    from custom_components.fluidra_pool.const import CONF_ENABLE_REALTIME
+
+    assert _coordinator({CONF_ENABLE_REALTIME: True}).realtime_enabled is True
+
+
+def test_known_device_ids_walks_every_pool() -> None:
+    """Subscriptions cover the devices the coordinator actually knows."""
+    assert _coordinator()._known_device_ids() == [DEVICE_ID]
+
+
+async def test_pushed_change_updates_the_component_and_notifies() -> None:
+    """A push lands on the same decoder as a poll, then wakes the entities."""
+    coordinator = _coordinator()
+    change = ComponentChange(device_id=DEVICE_ID, component_id=11, reported_value=2, timestamp=1787767038)
+
+    await coordinator._handle_realtime_change(change)
+
+    device = coordinator.data["pool-1"]["devices"][0]
+    assert device["components"]["11"]["reportedValue"] == 2
+    assert device["components"]["11"]["ts"] == 1787767038
+    assert coordinator.realtime_changes == 1
+    coordinator.async_set_updated_data.assert_called_once_with(coordinator.data)
+
+
+async def test_change_for_an_unknown_device_is_ignored() -> None:
+    """Discovery stays the poll's job; a stray push must not invent a device."""
+    coordinator = _coordinator()
+
+    await coordinator._handle_realtime_change(
+        ComponentChange(device_id="SOMEONE-ELSE", component_id=11, reported_value=2)
+    )
+
+    assert coordinator.realtime_changes == 0
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+async def test_change_before_the_first_poll_is_ignored() -> None:
+    """No data yet means nothing to update, and no crash."""
+    coordinator = _coordinator()
+    coordinator.data = None
+
+    await coordinator._handle_realtime_change(ComponentChange(device_id=DEVICE_ID, component_id=11, reported_value=2))
+
+    assert coordinator.realtime_changes == 0
+
+
+async def test_start_does_nothing_when_the_option_is_off() -> None:
+    """No option, no connection, no request."""
+    coordinator = _coordinator()
+
+    await coordinator.async_start_realtime()
+
+    assert coordinator._realtime is None
+
+
+async def test_stop_is_safe_when_nothing_was_started() -> None:
+    """Unload must never raise because the channel was never opened."""
+    coordinator = _coordinator()
+    await coordinator.async_stop_realtime()
+    assert coordinator._realtime is None

--- a/tests/test_thing_type_identification.py
+++ b/tests/test_thing_type_identification.py
@@ -1,0 +1,150 @@
+"""Identification by Fluidra's own family id (``thingType``).
+
+The cloud labels every device with the family it belongs to — measured on the
+operator's own hardware and cross-checked against the 124 configFiles the cloud
+publishes (``API-DISCOVERY.md`` §9.5). Until now that label drove a single
+special case (the tecnoLC2 rescue); these tests cover it as a general signal,
+and pin what it must *not* do.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS, DeviceIdentifier
+
+
+def _device(**overrides: Any) -> dict[str, Any]:
+    device = {
+        "device_id": "UNKNOWN-SERIAL-42",
+        "name": "Device",
+        "family": "",
+        "model": "",
+        "type": "",
+        "components": {},
+    }
+    device.update(overrides)
+    return device
+
+
+# --- The signal works --------------------------------------------------------
+
+
+def test_pump_recognised_by_family_id_alone() -> None:
+    """A pump whose serial matches no pattern still lands on the E30iQ profile."""
+    device = _device(thing_type="eppvs", type="pump")
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["e30iq_pump"]
+
+
+def test_victoria_recognised_without_its_model_string() -> None:
+    """Recognition no longer depends on the cloud spelling out the model."""
+    device = _device(thing_type="mppvs", type="pump")
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["victoria_smart_connect_pump"]
+
+
+def test_exo_recognised_beyond_the_ns_serials() -> None:
+    """GenSalt OT iQ and Hydroxinator share the eXO family without an NS serial."""
+    device = _device(thing_type="exr", type="chlorinator", family="Chlorinators")
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["ns25_exo_chlorinator"]
+
+
+def test_family_id_read_from_the_status_tree_too() -> None:
+    """Before discovery copies it, the label lives in the raw status entry."""
+    device = _device(type="pump", status={"thingType": "eppvs"})
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["e30iq_pump"]
+
+
+# --- What it must not do -----------------------------------------------------
+
+
+def test_serial_match_still_wins_over_the_family_id() -> None:
+    """A profile written for one unit stays more specific than its family.
+
+    The tecnoLC2 family covers dozens of rebadged units with different register
+    maps; a serial-specific profile must never be displaced by the family label.
+    """
+    device = _device(
+        device_id="CC25052635.nn_1",
+        type="chlorinator",
+        family="Chlorinators",
+        model="Chlorinator",
+        thing_type="exr",  # deliberately the wrong family
+    )
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["cc25052635_chlorinator"]
+
+
+def test_unknown_family_id_changes_nothing() -> None:
+    """A label no profile claims falls through to the usual catch-all."""
+    device = _device(thing_type="brand-new-family", type="pump")
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["generic_pump"]
+
+
+def test_frozen_heat_pump_rules_are_untouched() -> None:
+    """Z250iQ/Z260iQ identification is a no-touch zone: no family id declared.
+
+    Their cloud family ("amt") lumps Z250iQ, Z260iQ, PX25, PX26 and Eco Elyo
+    together, while the profiles are separated by the component-7 signature —
+    declaring the family here would blur exactly what that logic disambiguates.
+    """
+    for name in ("z250iq_heat_pump", "z260iq_heat_pump", "lg_heat_pump"):
+        assert DEVICE_CONFIGS[name].thing_type_patterns == []
+
+
+def test_ambiguous_heat_pump_family_is_not_declared() -> None:
+    """ "nhpp" covers Z450, Z650iQ, Verti/Silent/Eco Elyo — too coarse to route on."""
+    assert DEVICE_CONFIGS["z650iq_heat_pump"].thing_type_patterns == []
+
+
+def test_declared_families_are_the_measured_ones() -> None:
+    """Only labels confirmed against the cloud's own configFiles are declared."""
+    declared = {
+        name: config.thing_type_patterns for name, config in DEVICE_CONFIGS.items() if config.thing_type_patterns
+    }
+    assert declared == {
+        "e30iq_pump": ["eppvs"],
+        "victoria_smart_connect_pump": ["mppvs"],
+        "ns25_exo_chlorinator": ["exr"],
+        "z550iq_heat_pump": ["zs500"],
+        "command_connect_cabinet": ["SRC"],
+    }
+
+
+# --- The family id reaches the bug reports -----------------------------------
+
+
+def test_unmapped_register_log_names_the_family(caplog: Any) -> None:
+    """The one log line users paste into issues must carry the family id.
+
+    Without it a maintainer sees register numbers with nothing to hang them on;
+    with it, an unreported model can be matched to a known family straight away
+    (README "Adding New Equipment").
+    """
+    import logging
+
+    from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
+
+    coordinator = FluidraDataUpdateCoordinator.__new__(FluidraDataUpdateCoordinator)
+    coordinator._unmapped_logged = set()
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        coordinator._log_unmapped_components(
+            "DEV-1", {11: {"reportedValue": 1}, 99: {"reportedValue": 7}}, {11}, "eppvs"
+        )
+
+    assert "thing_type=eppvs" in caplog.text
+    assert "99" in caplog.text
+
+
+def test_unmapped_register_log_says_unknown_when_absent(caplog: Any) -> None:
+    """A device whose family the cloud never named still logs readably."""
+    import logging
+
+    from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
+
+    coordinator = FluidraDataUpdateCoordinator.__new__(FluidraDataUpdateCoordinator)
+    coordinator._unmapped_logged = set()
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        coordinator._log_unmapped_components("DEV-1", {99: {"reportedValue": 7}}, set(), "")
+
+    assert "thing_type=unknown" in caplog.text

--- a/tests/test_thing_type_identification.py
+++ b/tests/test_thing_type_identification.py
@@ -106,6 +106,7 @@ def test_declared_families_are_the_measured_ones() -> None:
         "ns25_exo_chlorinator": ["exr"],
         "z550iq_heat_pump": ["zs500"],
         "command_connect_cabinet": ["SRC"],
+        "blue_connect_silver": ["BC3"],
     }
 
 
@@ -148,3 +149,48 @@ def test_unmapped_register_log_says_unknown_when_absent(caplog: Any) -> None:
         coordinator._log_unmapped_components("DEV-1", {99: {"reportedValue": 7}}, set(), "")
 
     assert "thing_type=unknown" in caplog.text
+
+
+# --- Blue Connect (Issue #186) -----------------------------------------------
+
+
+def test_blue_connect_recognised_without_serial_or_name() -> None:
+    """A Blue Connect that matches neither WA* nor "gold" still reads correctly.
+
+    Before this, such a unit fell to the chlorinator catch-all, which reads
+    c12/c13/c14 as something other than temperature/pH/ORP.
+    """
+    device = _device(thing_type="BC3", type="chlorinator", family="Data collectors")
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["blue_connect_silver"]
+
+
+def test_blue_connect_family_read_from_component_7() -> None:
+    """The line publishes its family id on c7, not only on the device entry."""
+    device = _device(
+        type="chlorinator",
+        family="Data collectors",
+        components={"7": {"reportedValue": "BC3"}},
+    )
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["blue_connect_silver"]
+
+
+def test_named_gold_still_wins_over_the_shared_family() -> None:
+    """ "BC3" covers Silver and Gold alike, so the richer profile must keep priority."""
+    device = _device(
+        name="Blue Connect Gold",
+        thing_type="BC3",
+        type="chlorinator",
+        family="Data collectors",
+    )
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["blue_connect_gold"]
+
+
+def test_component_7_product_codes_do_not_mislabel_heat_pumps() -> None:
+    """Heat pumps put a product code on c7; it must match no family pattern."""
+    device = _device(
+        device_id="LF12345",
+        type="heat_pump",
+        components={"7": {"reportedValue": "BXWAD"}},
+    )
+    config = DeviceIdentifier.identify_device(device)
+    assert config is DEVICE_CONFIGS["z260iq_heat_pump"]

--- a/tests/test_uiconfig.py
+++ b/tests/test_uiconfig.py
@@ -1,0 +1,335 @@
+"""Tests for the cloud UI-config reader and parser (plan 013, Pass 3).
+
+The endpoint itself is not reachable yet — it demands an ``appId``/``appVr``
+pair the APK never spells out — so the fetch path is tested for what it must
+guarantee today: never raise, never claim a register map it does not have.
+The parser is tested against the register-block shape the APK does document.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.fluidra_pool.api_resilience import FluidraAuthError, FluidraError
+from custom_components.fluidra_pool.fluidra_api import (
+    FluidraPoolAPI,
+    UiRegister,
+    build_dynamic_scan_set,
+    parse_scheduler_capabilities,
+    parse_uiconfig,
+)
+
+DEVICE_ID = "TEST-DEV-001"
+
+# One block per shape the doc's register table shows: a plain gauge, a setpoint
+# with a write id and a factor, a bounded slider, and a string-typed register.
+SAMPLE_BLOCKS = [
+    {"readId": 172, "type": "number", "factor": 0.1, "decimals": 1, "min": 0, "max": 50, "units": "°C"},
+    {"readId": 165, "writeId": 8, "type": "number", "factor": 0.01, "decimals": 2, "min": 0, "max": 14},
+    {
+        "readId": 20,
+        "writeId": 20,
+        "type": "number",
+        "factor": 1,
+        "decimals": 0,
+        "min": 300,
+        "max": 850,
+        "steps": 10,
+        "units": "mV",
+    },
+    {"readId": 253, "type": "number", "factor": 1, "decimals": 0, "units": "h"},
+    {"readId": 6, "type": "string"},
+]
+
+
+def _api() -> FluidraPoolAPI:
+    api = FluidraPoolAPI("user@example.invalid", None)
+    api.access_token = "token"
+    api._build_auth_headers = lambda: {}  # type: ignore[method-assign]
+    return api
+
+
+# --- Parser ------------------------------------------------------------------
+
+
+def test_parses_a_bare_list_of_blocks() -> None:
+    """The simplest envelope: the payload is the list itself."""
+    registers = parse_uiconfig(SAMPLE_BLOCKS)
+    assert registers is not None
+    assert set(registers) == {172, 165, 20, 253, 6}
+    assert registers[165].write_id == 8
+    assert registers[20].steps == 10
+    assert registers[172].units == "°C"
+
+
+@pytest.mark.parametrize("wrapper", ["configFile", "components", "registers", "uiConfig"])
+def test_parses_every_plausible_wrapper(wrapper: str) -> None:
+    """The envelope is unconfirmed, so each plausible wrapper is accepted."""
+    registers = parse_uiconfig({wrapper: SAMPLE_BLOCKS})
+    assert registers is not None
+    assert set(registers) == {172, 165, 20, 253, 6}
+
+
+def test_parses_a_mapping_keyed_by_register_id() -> None:
+    """A block may carry no readId of its own when the key already is one."""
+    registers = parse_uiconfig({"172": {"factor": 0.1, "decimals": 1}, "253": {"units": "h"}})
+    assert registers is not None
+    assert set(registers) == {172, 253}
+    assert registers[172].factor == 0.1
+
+
+def test_unrecognisable_payloads_return_none() -> None:
+    """None, not an empty map: an empty map reads as "this device has no registers"."""
+    for payload in (None, "text", 42, [], {}, [{"no": "readId"}], {"nope": "value"}):
+        assert parse_uiconfig(payload) is None
+
+
+def test_malformed_blocks_are_skipped_not_fatal() -> None:
+    """One bad block must not cost the whole map."""
+    registers = parse_uiconfig([{"readId": "n/a"}, {"readId": 253, "factor": "x"}, *SAMPLE_BLOCKS])
+    assert registers is not None
+    assert 253 in registers
+    assert registers[253].factor == 1.0  # unparsable factor falls back to neutral
+
+
+# --- Value decoding ----------------------------------------------------------
+
+
+def test_decode_applies_factor_and_rounds() -> None:
+    """A temperature reported as 213 with factor 0.1 is 21.3 °C."""
+    register = UiRegister(read_id=172, factor=0.1, decimals=1)
+    assert register.decode(213) == 21.3
+
+
+def test_decode_rejects_non_numeric() -> None:
+    """Same contract as every other decoder in the integration."""
+    register = UiRegister(read_id=172, factor=0.1, decimals=1)
+    assert register.decode("n/a") is None
+    assert register.decode(None) is None
+
+
+def test_encode_is_the_inverse_and_keeps_whole_values_integral() -> None:
+    """pH 7.00 goes out as 700, not 700.0 — desiredValue is sent as-is."""
+    register = UiRegister(read_id=165, write_id=8, factor=0.01, decimals=2)
+    encoded = register.encode(7.0)
+    assert encoded == 700
+    assert isinstance(encoded, int)
+
+
+def test_encode_keeps_a_fractional_result_fractional() -> None:
+    """A factor that does not divide cleanly must not be silently rounded away."""
+    register = UiRegister(read_id=1, factor=3.0)
+    assert register.encode(1.0) == pytest.approx(1 / 3)
+
+
+def test_encode_refuses_a_zero_factor() -> None:
+    """A zero factor would divide by zero rather than mean anything."""
+    assert UiRegister(read_id=1, factor=0.0).encode(5) is None
+
+
+# --- Scan set ----------------------------------------------------------------
+
+
+def test_scan_set_is_the_union_profile_first() -> None:
+    """The profile's list is the decoded truth; the cloud's is a superset."""
+    registers = parse_uiconfig(SAMPLE_BLOCKS)
+    assert build_dynamic_scan_set([10, 172], registers) == [10, 172, 6, 20, 165, 253]
+
+
+def test_scan_set_unchanged_without_a_uiconfig() -> None:
+    """No cloud map, no change — the behaviour every user has today."""
+    assert build_dynamic_scan_set([10, 172], None) == [10, 172]
+    assert build_dynamic_scan_set([10, 172], {}) == [10, 172]
+
+
+# --- Fetch path --------------------------------------------------------------
+
+
+async def test_fetch_requires_authentication() -> None:
+    """Consistent with the other read paths."""
+    api = FluidraPoolAPI("user@example.invalid", None)
+    api.access_token = None
+    with pytest.raises(FluidraAuthError):
+        await api.get_device_uiconfig(DEVICE_ID)
+
+
+async def test_fetch_returns_none_on_the_current_400() -> None:
+    """Today's real answer: the endpoint rejects the request for want of appId."""
+    api = _api()
+    api._request = AsyncMock(  # type: ignore[method-assign]
+        return_value=(400, {"message": "Missing required request parameters: [appId]"}, {})
+    )
+    assert await api.get_device_uiconfig(DEVICE_ID) is None
+
+
+async def test_fetch_returns_none_on_transport_error() -> None:
+    """A failing request leaves the caller on its hand-written profile."""
+    api = _api()
+    api._request = AsyncMock(side_effect=FluidraError("boom"))  # type: ignore[method-assign]
+    assert await api.get_device_uiconfig(DEVICE_ID) is None
+
+
+async def test_fetch_parses_a_successful_response() -> None:
+    """The day the parameters are known, this is the whole path."""
+    api = _api()
+    api._request = AsyncMock(return_value=(200, {"configFile": SAMPLE_BLOCKS}, {}))  # type: ignore[method-assign]
+
+    registers = await api.get_device_uiconfig(DEVICE_ID)
+
+    assert registers is not None
+    assert registers[165].write_id == 8
+
+
+async def test_fetch_returns_none_on_a_200_it_cannot_read() -> None:
+    """A 200 carrying an unknown envelope is not a register map."""
+    api = _api()
+    api._request = AsyncMock(return_value=(200, {"unexpected": "envelope"}, {}))  # type: ignore[method-assign]
+    assert await api.get_device_uiconfig(DEVICE_ID) is None
+
+
+def test_nothing_calls_the_endpoint_yet() -> None:
+    """The reader is wired into the client but deliberately unused.
+
+    It costs a request per device per poll if hooked up before the parameters
+    are known, and every one of those would fail. This test is the guard on
+    that promise, and the thing to delete when Pass 3 is finished.
+    """
+    import pathlib
+
+    root = pathlib.Path("custom_components/fluidra_pool")
+    callers = [
+        path for path in root.rglob("*.py") if path.name != "_uiconfig.py" and "get_device_uiconfig" in path.read_text()
+    ]
+    assert callers == []
+
+
+def test_client_exposes_the_reader() -> None:
+    """The mixin is assembled into the concrete client."""
+    assert hasattr(FluidraPoolAPI("user@example.invalid", None), "get_device_uiconfig")
+
+
+def test_register_defaults_are_neutral() -> None:
+    """A block that declares nothing must not distort the value it carries."""
+    register: Any = UiRegister(read_id=99)
+    assert register.factor == 1.0
+    assert register.decimals == 0
+    assert register.decode(42) == 42
+
+
+# --- Scheduler capabilities (the endpoint that does answer) ------------------
+
+CAPABILITY_PAYLOAD = {
+    "id": DEVICE_ID,
+    "info": {
+        "name": "E30iQ",
+        "configuration": {
+            "capabilities": {
+                "schedulers": [
+                    {
+                        "technologies": ["cloud"],
+                        "componentWrite": 20,
+                        "id": "pump",
+                        "type": "minimal",
+                        "componentRead": 20,
+                        "enabled": True,
+                    }
+                ],
+                "ota": {"enabled": True},
+            }
+        },
+    },
+}
+
+
+def test_parses_the_scheduler_block() -> None:
+    """The cloud states which register holds this device's schedules."""
+    capabilities = parse_scheduler_capabilities(CAPABILITY_PAYLOAD)
+    assert len(capabilities) == 1
+    capability = capabilities[0]
+    assert capability.scheduler_id == "pump"
+    assert capability.component_read == 20
+    assert capability.component_write == 20
+    assert capability.scheduler_type == "minimal"
+    assert capability.enabled is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        "text",
+        {},
+        {"info": "not a dict"},
+        {"info": {"configuration": {}}},
+        {"info": {"configuration": {"capabilities": {}}}},
+        {"info": {"configuration": {"capabilities": {"schedulers": "nope"}}}},
+    ],
+)
+def test_missing_capability_blocks_yield_an_empty_list(payload: Any) -> None:
+    """A device that declares nothing is a normal answer, not an error."""
+    assert parse_scheduler_capabilities(payload) == []
+
+
+def test_malformed_scheduler_entries_are_skipped() -> None:
+    """One unusable block must not cost the others."""
+    payload = {
+        "info": {
+            "configuration": {
+                "capabilities": {
+                    "schedulers": [
+                        "not a block",
+                        {"id": "aux", "componentWrite": "n/a", "componentRead": None},
+                        {"id": "pump", "componentWrite": 20, "componentRead": 20, "enabled": True},
+                    ]
+                }
+            }
+        }
+    }
+    capabilities = parse_scheduler_capabilities(payload)
+    assert [c.scheduler_id for c in capabilities] == ["aux", "pump"]
+    assert capabilities[0].component_write is None
+    assert capabilities[0].enabled is False
+
+
+async def test_capability_fetch_returns_the_parsed_blocks() -> None:
+    """The happy path, against the shape a real device answers with."""
+    api = _api()
+    api._request = AsyncMock(return_value=(200, CAPABILITY_PAYLOAD, {}))  # type: ignore[method-assign]
+
+    capabilities = await api.get_device_capabilities(DEVICE_ID)
+
+    assert [c.component_write for c in capabilities] == [20]
+
+
+async def test_capability_fetch_is_quiet_on_failure() -> None:
+    """Diagnostics must never fail because of this call."""
+    api = _api()
+    api._request = AsyncMock(return_value=(500, {"message": "boom"}, {}))  # type: ignore[method-assign]
+    assert await api.get_device_capabilities(DEVICE_ID) == []
+
+    api._request = AsyncMock(side_effect=FluidraError("boom"))  # type: ignore[method-assign]
+    assert await api.get_device_capabilities(DEVICE_ID) == []
+
+
+async def test_capability_fetch_requires_authentication() -> None:
+    """Same contract as every other read path."""
+    api = FluidraPoolAPI("user@example.invalid", None)
+    api.access_token = None
+    with pytest.raises(FluidraAuthError):
+        await api.get_device_capabilities(DEVICE_ID)
+
+
+def test_capability_reader_is_not_on_the_poll_path() -> None:
+    """One request per device per poll would buy nothing — diagnostics only."""
+    import pathlib
+
+    root = pathlib.Path("custom_components/fluidra_pool")
+    callers = {
+        path.name
+        for path in root.rglob("*.py")
+        if path.name != "_uiconfig.py" and "get_device_capabilities" in path.read_text()
+    }
+    assert callers == {"diagnostics.py"}


### PR DESCRIPTION
Built from the reverse-engineering of the official app (2.23.1) and, more importantly, from **measurements made against the live cloud on a real account**. Several assumptions in the original plan turned out to be wrong; each is documented where it mattered.

## Realtime channel (opt-in, off by default)

The cloud pushes `componentChange` frames about **2 s** after a state change, instead of being polled for them — the root of #210.

Everything about the lifecycle comes from a measurement:

| Measured | Consequence in the code |
|---|---|
| An `Authorization` header gets a 401; `?token=` connects | auth by query parameter |
| A silent connection is dropped at **600 s exactly**, close code `1006` | 240 s keepalive, and `1006` treated as routine rather than an error |
| The token is checked **only at handshake time** — the channel still works 2.5 min after it expires | no reconnect when the token is refreshed |
| Replies arrive out of step with what was sent | single reader loop, nothing waits for a reply |
| `unsubsPool` answers 500 | closing the socket is how you stop everything |

Pushed changes go through `_process_component_state`, the very decoder the poll uses, so there is no second path that could drift. **Polling remains the source of truth and runs unchanged** — the channel only ever shortens the wait.

## New read-only registers (tecnoLC2 line-up)

UV lamp presence and running hours, the boost countdown split over its hours/minutes pair, and the live filtration state. Entities stay unavailable or unknown when a register never answers, rather than reporting a made-up zero.

## Three-speed pump select

For controllers carrying the speed on a single writable register. Both the read and write tables live in the profile, so a family numbering its speeds differently is a profile edit, not a code change.

**No profile declares it yet, deliberately**: the mapping is unconfirmed on hardware and this one *writes*. Declaring it blind would command real equipment on a guess.

## Identification by Fluidra's own family id (`thingType`)

Already fetched on every device, until now used for a single special case. It now scores below a serial match (which stays more specific) and above the generic `model`/`family` strings the whole line-up shares — so **a model nobody has reported yet lands on the right register map instead of a catch-all that misreads it**.

Declared only where the cloud's own configFiles make the mapping unambiguous: `eppvs`, `mppvs`, `exr`, `zs500`, `SRC`. Two abstentions are pinned by tests: the Z250iQ/Z260iQ family (separated by the component-7 signature — a no-touch zone) and the coarse Z450/Z650iQ/Elyo family, where routing everyone to the Z650iQ profile would give wrong readings with the appearance of a verified profile.

## Cloud configuration readers

The UI-config parser is ready but **nothing calls it** (a test enforces that): the endpoint demands an `appId`/`appVr` pair the APK never spells out. The scheduler-capabilities endpoint *does* answer, and now feeds diagnostics with what the cloud declares about each device's schedule register, next to what the profile resolved — one request when diagnostics are downloaded, never on the poll path.

## What the measurements closed

`/telemetry`, `/automations`, `/recommendations` and `/settings` return 403 — **not a permissions problem**: the body is the AWS SigV4 message, so those routes want a signed IAM request rather than the Cognito bearer. No account level unlocks them.

## Verification

- **2060 tests** (from 1959), ruff and mypy clean, coverage 96%
- Deployed on a live Home Assistant throughout: setup ~1.5 s, no errors, entities unchanged, realtime channel connected
- The unmapped-register debug line now names the device's `thing_type`, which is what a maintainer needs to place an unreported model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional realtime cloud updates for faster device state changes.
  * Added device recognition for more equipment families.
  * Added UV lamp, filtration state, boost countdown, and UV runtime sensors.
  * Added three-speed pump controls with configurable modes.
  * Expanded diagnostics with scheduler capabilities and device configuration details.

* **Documentation**
  * Updated setup guidance, configuration options, translations, and API discovery documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Blue Connect recognition (#186)

The dump on that issue shows the unit reporting `"BC3"` — the Blue Connect family id — on **component 7**, the slot where heat pumps put a product code instead. The family signal now reads component 7 when the device entry carries no `thingType`; `BXWAA`/`BXWAD` match no declared family pattern, so heat pumps cannot be mislabelled.

`BC3` is declared on the **Silver** profile only, and the Gold gains its own `QX…` serial prefix. The label covers both models, so declaring it on both ties them on score and hands every unnamed Blue Connect to the richer Gold profile — leaving a Silver with conductivity, salinity and battery entities its hardware can never fill, which is what #183 was about.

Writing this exposed a mistake in the scoring weight introduced earlier in this PR: the family signal outranked the product name, so a unit calling itself *Blue Connect Gold* was pulled onto the Silver mapping. A family is less specific than a product name, and the score now says so:

```
serial 50  >  product name 30  >  cloud family 25  >  generic shared strings 20
```

Net effect: a Blue Connect matching neither serial prefix, whose name says nothing, lands on the Blue Connect mapping instead of the chlorinator catch-all that reads c12/c13/c14 as something other than temperature/pH/ORP.
