### PR TITLE
fix(diagnostics): make an unverified profile reportable (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,20 @@ Your equipment isn't listed or is only partially recognised? Help us add it:
      logs:
        custom_components.fluidra_pool: debug
    ```
-2. **Open an [issue](https://github.com/foXaCe/Fluidra-pool/issues)** with:
+2. **Switch the missing feature on and off in the official app** while the logs run. The
+   first debug dump lists every register no profile maps; each following change is logged
+   on its own line, so the register that moved with the feature is the one to report.
+3. **Download diagnostics** from the integration's device page (credentials are redacted).
+   When a device sits on a guessed profile — the one that raises the *unverified profile*
+   repair warning — the dump carries an `unverified_devices` block with **all** of its
+   registers, not only the handful that profile reads.
+4. **Open an [issue](https://github.com/foXaCe/Fluidra-pool/issues)** with:
    - Your equipment model and serial prefix
-   - The device-discovery debug logs — these now include the device's `thing_type`
-     (Fluidra's own family id, e.g. `eppvs`, `tecnoLC2`) and every register no profile
-     maps yet, which is usually enough to identify what is missing
+   - The diagnostics file and the debug logs — both carry the device's `thing_type`
+     (Fluidra's own family id, e.g. `eppvs`, `tecnoLC2`), which is what places an
+     unreported model on the right register map
    - The features/values shown in the official Fluidra Pool app
-3. **Test and share** your results — most new models are added this way.
+5. **Test and share** your results — most new models are added this way.
 
 ---
 

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -273,16 +273,19 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         the user had to restart Home Assistant between every step (Issue #221, a
         Z350iQ whose real ON/OFF register is still unknown). A poll that changed
         nothing is still silent, so an idle device does not fill the log.
+
+        Removals count as changes too: a register that vanishes from the bulk
+        response must clear the snapshot, otherwise a later reappearance with
+        the same value stays silent.
         """
         if not _LOGGER.isEnabledFor(logging.DEBUG):
             return
         unmapped = {cid: bulk[cid].get("reportedValue") for cid in sorted(bulk) if cid not in wanted}
-        if not unmapped:
-            return
-
         previous = self._unmapped_snapshots.get(device_id)
-        self._unmapped_snapshots[device_id] = unmapped
         if previous is None:
+            if not unmapped:
+                return
+            self._unmapped_snapshots[device_id] = unmapped
             _LOGGER.debug(
                 "Device %s (thing_type=%s) reports %d component(s) no profile maps — "
                 "toggle a missing feature in the Fluidra app and compare to find its "
@@ -294,11 +297,18 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return
 
-        changes = {
-            cid: f"{previous.get(cid)} -> {value}"
-            for cid, value in unmapped.items()
-            if cid not in previous or previous[cid] != value
-        }
+        # Always refresh the snapshot once tracking has started, including the
+        # empty case — otherwise a removed register sticks and a same-value
+        # reappearance is never logged.
+        self._unmapped_snapshots[device_id] = unmapped
+        changes: dict[int, str] = {}
+        for cid in previous.keys() | unmapped.keys():
+            was_present = cid in previous
+            is_present = cid in unmapped
+            old = previous[cid] if was_present else None
+            new: Any = unmapped[cid] if is_present else "<absent>"
+            if not was_present or not is_present or old != new:
+                changes[cid] = f"{old} -> {new}"
         if changes:
             _LOGGER.debug(
                 "Device %s (thing_type=%s): %d unmapped component(s) changed — whatever "

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -83,9 +83,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # the same account answer it fine (Issue #175), and a shared counter was
         # reset by their successes so the unsupported one was retried every poll.
         self._bulk_fetch_failures: dict[str, int] = {}
-        # Devices whose unmapped registers have already been dumped at DEBUG — see
-        # _log_unmapped_components; log once per session, not on every poll.
-        self._unmapped_logged: set[str] = set()
+        # Last unmapped-register values seen per device — see
+        # _log_unmapped_components. The full dump goes out once per device, then
+        # only the registers whose value moved, so a poll that changed nothing
+        # stays quiet.
+        self._unmapped_snapshots: dict[str, dict[int, Any]] = {}
 
         # Realtime channel (opt-in, plan 013 Pass 5). None until started; the
         # poll runs identically whether it is up or not.
@@ -263,12 +265,24 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         The device's ``thingType`` goes in the same line: it is Fluidra's own
         family identifier, and it is what tells a maintainer which register map
         an unreported model should be reading (README "Adding New Equipment").
+
+        "Compare" needs more than one reading, so after the first full dump the
+        registers whose value moved are logged again, on their own. A single
+        dump per session made the instruction impossible to follow: switching
+        the device on in the app produced no second line to compare against, and
+        the user had to restart Home Assistant between every step (Issue #221, a
+        Z350iQ whose real ON/OFF register is still unknown). A poll that changed
+        nothing is still silent, so an idle device does not fill the log.
         """
-        if not _LOGGER.isEnabledFor(logging.DEBUG) or device_id in self._unmapped_logged:
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
             return
-        self._unmapped_logged.add(device_id)
         unmapped = {cid: bulk[cid].get("reportedValue") for cid in sorted(bulk) if cid not in wanted}
-        if unmapped:
+        if not unmapped:
+            return
+
+        previous = self._unmapped_snapshots.get(device_id)
+        self._unmapped_snapshots[device_id] = unmapped
+        if previous is None:
             _LOGGER.debug(
                 "Device %s (thing_type=%s) reports %d component(s) no profile maps — "
                 "toggle a missing feature in the Fluidra app and compare to find its "
@@ -277,6 +291,22 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 thing_type or "unknown",
                 len(unmapped),
                 unmapped,
+            )
+            return
+
+        changes = {
+            cid: f"{previous.get(cid)} -> {value}"
+            for cid, value in unmapped.items()
+            if cid not in previous or previous[cid] != value
+        }
+        if changes:
+            _LOGGER.debug(
+                "Device %s (thing_type=%s): %d unmapped component(s) changed — whatever "
+                "just happened on the device is carried by one of these registers: %s",
+                device_id,
+                thing_type or "unknown",
+                len(changes),
+                changes,
             )
 
     async def _fetch_components_parallel(

--- a/custom_components/fluidra_pool/diagnostics.py
+++ b/custom_components/fluidra_pool/diagnostics.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 
 from .api_resilience import FluidraAuthError
 from .const import FluidraPoolConfigEntry
+from .device_registry import DEVICE_CONFIGS, DeviceIdentifier
 from .helpers import resolve_schedule_component
 from .utils import mask_device_id
 
@@ -129,8 +130,95 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Fluidra
         # nothing, but in a bug report it settles "my schedule writes land on
         # the wrong slot" outright (Issue #174).
         "cloud_schedulers": await _collect_scheduler_capabilities(coordinator, coordinator_data),
+        # Every register of the devices whose profile is a guess. Without this
+        # block a report about an unreported model can only ever contain the
+        # registers the guess already reads (Issue #221).
+        "unverified_devices": await _collect_unverified_device_registers(coordinator, coordinator_data),
         "pools": _redact_pools_data(coordinator_data),
     }
+
+
+def _profile_name(config: Any) -> str:
+    """Return the registry key of a resolved profile (for a bug report to quote)."""
+    for name, candidate in DEVICE_CONFIGS.items():
+        if candidate is config:
+            return name
+    return "unknown"
+
+
+def _register_sort_key(item: tuple[Any, Any]) -> tuple[int, int, str]:
+    """Sort registers numerically, tolerating a payload that keyed them as strings."""
+    key = item[0]
+    text = str(key)
+    return (0, int(text), "") if text.lstrip("-").isdigit() else (1, 0, text)
+
+
+def _device_thing_type(device: dict[str, Any]) -> str:
+    """Read Fluidra's own family id the way the identifier does."""
+    thing_type = str(device.get("thing_type", ""))
+    if thing_type:
+        return thing_type
+    status = device.get("status")
+    return str(status.get("thingType", "")) if isinstance(status, dict) else ""
+
+
+async def _collect_unverified_device_registers(coordinator: Any, pools_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Dump every register of the devices resolved on an unverified profile.
+
+    A catch-all profile scans only the handful of registers it guesses at, so
+    ``device["components"]`` — and therefore the rest of this download — can
+    never contain the register that actually carries the state. Issue #221 is
+    the case in point: a Z350iQ reads OFF in Home Assistant because component 13
+    is not its ON/OFF flag, and no diagnostics export could show which register
+    is, because that register was never polled. The bulk endpoint returns all of
+    them, so ask for it here — once per download, and only for the devices whose
+    mapping is a guess. On the poll path it would cost a request per device per
+    cycle and buy nothing (same reasoning as ``cloud_schedulers``).
+
+    Never fails the diagnostics download: an endpoint that refuses, a device the
+    cloud says nothing about, or an expired token all come back as a shorter list.
+    """
+    api = getattr(coordinator, "api", None)
+    if api is None or not hasattr(api, "get_all_components"):
+        return []
+
+    collected: list[dict[str, Any]] = []
+    for pool in pools_data.values():
+        if not isinstance(pool, dict):
+            continue
+        for device in pool.get("devices", []):
+            if not isinstance(device, dict):
+                continue
+            device_id = device.get("device_id")
+            if not device_id:
+                continue
+            config = DeviceIdentifier.identify_device(device)
+            if config is None or config.verified:
+                continue
+            try:
+                bulk = await api.get_all_components(device_id)
+            except (FluidraAuthError, OSError, TimeoutError):
+                continue
+            if not isinstance(bulk, dict):
+                continue
+            scanned = sorted(int(cid) for cid in device.get("components", {}) if str(cid).isdigit())
+            collected.append(
+                {
+                    "device_id": mask_device_id(device_id),
+                    # What the cloud calls this family — the single field that
+                    # tells a maintainer which register map the unit should read.
+                    "thing_type": _device_thing_type(device) or "unknown",
+                    "profile": _profile_name(config),
+                    "profile_verified": False,
+                    # The gap between the two lists is the point of this block.
+                    "scanned_components": scanned,
+                    "all_registers": {
+                        str(cid): _redact_component_data(cid, state)
+                        for cid, state in sorted(bulk.items(), key=_register_sort_key)
+                    },
+                }
+            )
+    return collected
 
 
 async def _collect_scheduler_capabilities(coordinator: Any, pools_data: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_bulk_fetch.py
+++ b/tests/test_bulk_fetch.py
@@ -360,3 +360,29 @@ async def test_unchanged_unmapped_registers_never_log_again(
 
     assert len([r for r in caplog.records if "no profile maps" in r.getMessage()]) == 1
     assert not [r for r in caplog.records if "changed" in r.getMessage()]
+
+
+async def test_unmapped_register_removal_then_reappearance_is_logged(
+    coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """present → absent → present must log both transitions.
+
+    Returning early when the current poll has no unmapped registers left the
+    previous snapshot untouched. A register that vanished, then came back with
+    the same value, stayed silent — the whole point of the comparison log
+    (CodeRabbit on PR #224).
+    """
+    mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}})
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        await coordinator._fetch_components("DEV-1", [9])
+        mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}})
+        await coordinator._fetch_components("DEV-1", [9])
+        mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}})
+        await coordinator._fetch_components("DEV-1", [9])
+
+    changes = [r.getMessage() for r in caplog.records if "changed" in r.getMessage()]
+    assert len(changes) == 2
+    assert "77" in changes[0]
+    assert "0 -> <absent>" in changes[0]
+    assert "77" in changes[1]
+    assert "None -> 0" in changes[1]

--- a/tests/test_bulk_fetch.py
+++ b/tests/test_bulk_fetch.py
@@ -308,3 +308,55 @@ async def test_unmapped_logging_tracked_per_device(
         await coordinator._fetch_components("DEV-1", [9])
         await coordinator._fetch_components("DEV-2", [9])
     assert len([r for r in caplog.records if "no profile maps" in r.getMessage()]) == 2
+
+
+async def test_unmapped_register_change_is_logged_for_comparison(
+    coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A register that moves is logged again, alone — that is the whole comparison.
+
+    The dump tells users to toggle the feature in the app and compare, which
+    needs a second reading. With a single dump per session the only way to get
+    one was to restart Home Assistant between every step, so an unreported model
+    could never be decoded from a live cycle (Issue #221, Z350iQ).
+    """
+    mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}})
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        await coordinator._fetch_components("DEV-1", [9])
+        mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 1}})
+        await coordinator._fetch_components("DEV-1", [9])
+
+    changes = [r for r in caplog.records if "changed" in r.getMessage()]
+    assert len(changes) == 1
+    assert "77" in changes[0].getMessage()
+    assert "0 -> 1" in changes[0].getMessage()
+
+
+async def test_unmapped_register_new_key_counts_as_a_change(
+    coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A register the device only starts reporting later is surfaced too."""
+    mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}})
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        await coordinator._fetch_components("DEV-1", [9])
+        mock_api.get_all_components = AsyncMock(
+            return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}, 88: {"reportedValue": 5}}
+        )
+        await coordinator._fetch_components("DEV-1", [9])
+
+    changes = [r for r in caplog.records if "changed" in r.getMessage()]
+    assert len(changes) == 1
+    assert "88" in changes[0].getMessage()
+
+
+async def test_unchanged_unmapped_registers_never_log_again(
+    coordinator: FluidraDataUpdateCoordinator, mock_api: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An idle device stays silent: only movement is worth a line."""
+    mock_api.get_all_components = AsyncMock(return_value={9: {"reportedValue": 1}, 77: {"reportedValue": 0}})
+    with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
+        for _ in range(4):
+            await coordinator._fetch_components("DEV-1", [9])
+
+    assert len([r for r in caplog.records if "no profile maps" in r.getMessage()]) == 1
+    assert not [r for r in caplog.records if "changed" in r.getMessage()]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.fluidra_pool.diagnostics import (
     REDACTED,
@@ -326,3 +326,126 @@ async def test_diagnostics_report_no_lost_writes_when_none_were_seen() -> None:
     diagnostics = await async_get_config_entry_diagnostics(None, entry)
 
     assert diagnostics["lost_writes"] == []
+
+
+async def test_diagnostics_dump_every_register_of_an_unverified_device() -> None:
+    """A guessed profile must ship its whole register set, not just what it reads.
+
+    The generic heat-pump profile polls components 0-3 plus 13/14/15, so the
+    pools block can only ever contain those. That is exactly the device for which
+    nobody knows the map yet: Issue #221's Z350iQ reads OFF because component 13
+    is not its ON/OFF flag, and no export could show which register is.
+    """
+    device = {
+        "device_id": "FE25000001",
+        "name": "Z350iQ",
+        "family": "Heat Pumps",
+        "type": "heat_pump",
+        "thing_type": "hpc",
+        "components": {"13": {"reportedValue": 0}, "15": {"reportedValue": 280}},
+    }
+    api = SimpleNamespace(
+        get_all_components=AsyncMock(
+            return_value={
+                1: {"reportedValue": "FE25000001"},
+                13: {"reportedValue": 0},
+                21: {"reportedValue": 1},
+                37: {"reportedValue": 274},
+            }
+        )
+    )
+    coordinator = SimpleNamespace(
+        data={"pool-abc": {"id": "pool-abc", "devices": [device]}},
+        last_update_success=True,
+        update_interval=timedelta(seconds=30),
+        api=api,
+    )
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.version = 1
+    entry.domain = "fluidra_pool"
+    entry.title = "Fluidra Pool"
+    entry.data = {}
+    entry.options = {}
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+
+    diagnostics = await async_get_config_entry_diagnostics(None, entry)
+
+    dumped = diagnostics["unverified_devices"]
+    assert len(dumped) == 1
+    assert dumped[0]["profile"] == "generic_heat_pump"
+    # The family id is what places an unreported model on a register map.
+    assert dumped[0]["thing_type"] == "hpc"
+    assert dumped[0]["scanned_components"] == [13, 15]
+    # Registers the profile never polls — the whole point of the block.
+    assert dumped[0]["all_registers"]["21"]["reportedValue"] == 1
+    assert dumped[0]["all_registers"]["37"]["reportedValue"] == 274
+    # Redaction still applies: component 1 carries the serial.
+    assert dumped[0]["all_registers"]["1"]["reportedValue"] == REDACTED
+    assert dumped[0]["device_id"] != "FE25000001"
+
+
+async def test_diagnostics_skip_the_register_dump_for_verified_devices() -> None:
+    """A verified profile already documents its map — no extra cloud request."""
+    device = {
+        "device_id": "ZB25000001",
+        "name": "Z650iQ",
+        "family": "Heat Pumps",
+        "type": "heat_pump",
+        "components": {"10": {"reportedValue": 1}},
+    }
+    api = SimpleNamespace(get_all_components=AsyncMock(return_value={10: {"reportedValue": 1}}))
+    coordinator = SimpleNamespace(
+        data={"pool-abc": {"id": "pool-abc", "devices": [device]}},
+        last_update_success=True,
+        update_interval=timedelta(seconds=30),
+        api=api,
+    )
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.version = 1
+    entry.domain = "fluidra_pool"
+    entry.title = "Fluidra Pool"
+    entry.data = {}
+    entry.options = {}
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+
+    diagnostics = await async_get_config_entry_diagnostics(None, entry)
+
+    assert diagnostics["unverified_devices"] == []
+    api.get_all_components.assert_not_awaited()
+
+
+async def test_diagnostics_survive_a_refused_register_dump() -> None:
+    """A cloud that refuses the bulk endpoint must not fail the whole download."""
+    device = {
+        "device_id": "FE25000001",
+        "name": "Z350iQ",
+        "family": "Heat Pumps",
+        "type": "heat_pump",
+        "thing_type": "hpc",
+        "components": {},
+    }
+    api = SimpleNamespace(get_all_components=AsyncMock(side_effect=TimeoutError))
+    coordinator = SimpleNamespace(
+        data={"pool-abc": {"id": "pool-abc", "devices": [device]}},
+        last_update_success=True,
+        update_interval=timedelta(seconds=30),
+        api=api,
+    )
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.version = 1
+    entry.domain = "fluidra_pool"
+    entry.title = "Fluidra Pool"
+    entry.data = {}
+    entry.options = {}
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+
+    diagnostics = await async_get_config_entry_diagnostics(None, entry)
+
+    assert diagnostics["unverified_devices"] == []
+    assert diagnostics["coordinator"]["last_update_success"] is True

--- a/tests/test_thing_type_identification.py
+++ b/tests/test_thing_type_identification.py
@@ -125,7 +125,7 @@ def test_unmapped_register_log_names_the_family(caplog: Any) -> None:
     from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
 
     coordinator = FluidraDataUpdateCoordinator.__new__(FluidraDataUpdateCoordinator)
-    coordinator._unmapped_logged = set()
+    coordinator._unmapped_snapshots = {}
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
         coordinator._log_unmapped_components(
@@ -143,7 +143,7 @@ def test_unmapped_register_log_says_unknown_when_absent(caplog: Any) -> None:
     from custom_components.fluidra_pool.coordinator import FluidraDataUpdateCoordinator
 
     coordinator = FluidraDataUpdateCoordinator.__new__(FluidraDataUpdateCoordinator)
-    coordinator._unmapped_logged = set()
+    coordinator._unmapped_snapshots = {}
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.fluidra_pool.coordinator.coordinator"):
         coordinator._log_unmapped_components("DEV-1", {99: {"reportedValue": 7}}, set(), "")


### PR DESCRIPTION
Refs #221.

A device that lands on a catch-all profile is exactly the device whose register map nobody
knows yet — and it was the one the integration could say the least about. `generic_heat_pump`
polls components 0-3 plus 13/14/15, so `device["components"]`, and therefore every diagnostics
download, could only ever carry those seven registers.

Issue #221 is the case in point: a Zodiac Z350iQ (`thingType` `hpc`, no profile) reads OFF in
Home Assistant because component 13 is not its ON/OFF flag. The reporter was asked for the
register that really carries the state — but no export or log they could produce contained it,
because that register was never polled and the one debug dump that does list every register
fired once per session, so a full OFF → ON → OFF cycle produced nothing to compare.

## What changed

Two read-only changes. Neither guesses a register mapping.

- **`unverified_devices` in diagnostics** — for each device resolved on a `verified=False`
  profile, every register the bulk endpoint returns, next to the profile name, the cloud's
  `thingType` and the registers the profile actually scans. One request per unverified device
  per download, on the same path as `cloud_schedulers`; the poll path is untouched. Redaction
  is the existing per-component one (serial/MAC/IP slots stay hidden).
- **Unmapped-register dump follows the device** — the full dump still goes out once, then each
  register whose value moved is logged on its own line. "Toggle the feature in the app and
  compare" needs a second reading; before this the only way to get one was to restart Home
  Assistant between every step. A poll that changed nothing stays silent.

`README.md` — "Adding New Equipment" now describes the cycle that actually produces the answer.

## Measured

```
$ .venv-test/bin/python -c '<identify a Z350iQ>'
profil          : generic_heat_pump | verified = False
specific_comps  : [13, 14, 15]
registres lus   : [0, 1, 2, 3, 13, 14, 15]
jamais lus (ex.): [10, 12, 17, 19, 21, 28, 37, 39, 44, 48, 60, 61, 67]

$ .venv-test/bin/python -m pytest -q
2070 passed in 27.44s

$ ruff check custom_components/fluidra_pool/ tests/
All checks passed!

$ mypy custom_components/fluidra_pool/diagnostics.py custom_components/fluidra_pool/coordinator/coordinator.py
Success: no issues found in 2 source files
```

Tests: 2060 → 2070.

## What this does not do

It does not add a `Z350iQ` profile: that needs the real register map, and inventing one — or
routing `hpc` onto the Z650iQ/Z550iQ map — would be the mis-read this project already fixed
once (#216). #221 stays open until a reporter's dump names the ON/OFF register.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now include complete, redacted register details for devices with unverified profiles.
  * Debug logs identify register value changes, newly reported registers, and removed registers.
* **Bug Fixes**
  * Unchanged registers are no longer repeatedly logged.
  * Diagnostics remain available when register retrieval fails.
* **Documentation**
  * Updated equipment setup instructions with steps for collecting debug logs and diagnostics, including toggling features to help identify devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->