### PR TITLE
fix(deps): keep device_info typed and tests passing on HA 2026.9

### DIFF
--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.util import dt as dt_util
 from .const import DEVICE_TYPE_CHLORINATOR, DOMAIN, FluidraPoolConfigEntry
 from .device_registry import DeviceIdentifier
 from .entity import FluidraPoolEntity
+from .helpers import link_to_pool
 from .platform_setup import async_setup_dynamic_platform
 
 if TYPE_CHECKING:
@@ -62,13 +63,15 @@ class FluidraChlorinatorProducingBinarySensor(FluidraPoolEntity, BinarySensorEnt
         """Return device information."""
         device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model="Chlorinator",
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model="Chlorinator",
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import copy
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from homeassistant.const import CONF_SCAN_INTERVAL
@@ -50,6 +50,24 @@ from ..write_verification import WriteVerifier
 from ._parsers import calculate_auto_speed_from_schedules, parse_dm24049704_schedule_format
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _async_get_device(
+    registry: dr.DeviceRegistry, identifier: tuple[str, str], config_entry_id: str | None
+) -> dr.DeviceEntry | None:
+    """Return the device carrying ``identifier``, or None.
+
+    HA 2026.9 deprecated ``async_get_device`` — identifiers are no longer unique
+    across config entries — in favour of ``async_get_device_by_identifier``,
+    which scopes the lookup to one entry. That method does not exist at the HA
+    floor declared in ``hacs.json``, so the old call stays as the fallback; it
+    keeps working until HA 2027.8, by which time the floor will have moved and
+    this whole function can go.
+    """
+    lookup = getattr(registry, "async_get_device_by_identifier", None)
+    if lookup is None or config_entry_id is None:
+        return registry.async_get_device(identifiers={identifier})
+    return cast("dr.DeviceEntry | None", lookup(identifier, config_entry_id))
 
 
 class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -1002,13 +1020,14 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _sync_device_firmware(self, pools: list[dict[str, Any]]) -> None:
         """Mirror reported firmware versions into the HA device registry (no-op if unchanged)."""
         registry = dr.async_get(self.hass)
+        config_entry_id = self.config_entry.entry_id if self.config_entry else None
         for pool in pools:
             for device in pool.get("devices", []):
                 device_id = device.get("device_id")
                 firmware = device.get("firmware_version_component")
                 if not device_id or firmware is None:
                     continue
-                entry = registry.async_get_device(identifiers={(DOMAIN, str(device_id))})
+                entry = _async_get_device(registry, (DOMAIN, str(device_id)), config_entry_id)
                 if entry is not None and entry.sw_version != str(firmware):
                     registry.async_update_device(entry.id, sw_version=str(firmware))
 

--- a/custom_components/fluidra_pool/entity.py
+++ b/custom_components/fluidra_pool/entity.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DEVICE_MODEL_FALLBACK, DEVICE_MODEL_MAP, DOMAIN
+from .helpers import link_to_pool
 
 if TYPE_CHECKING:
     from .coordinator import FluidraDataUpdateCoordinator
@@ -70,13 +71,15 @@ class FluidraPoolEntity(CoordinatorEntity):
 
         device_name = device_data.get("name", f"Device {self._device_id}")
         firmware = device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=device_data.get("manufacturer", "Fluidra"),
-            model=default_model,
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=device_data.get("manufacturer", "Fluidra"),
+                model=default_model,
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -9,11 +9,33 @@ from __future__ import annotations
 
 from datetime import time
 import logging
-from typing import Any
+from typing import Any, cast
 
-from .const import EXO_LED_COLOURS_LUMIPLUS, EXO_LED_COLOURS_ZODIAC_NL
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN, EXO_LED_COLOURS_LUMIPLUS, EXO_LED_COLOURS_ZODIAC_NL
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def link_to_pool(info: DeviceInfo, pool_id: str) -> DeviceInfo:
+    """Attach ``info`` to its parent pool device and return it.
+
+    HA 2026.9 dropped ``via_device`` from the ``DeviceInfo`` TypedDict in favour
+    of ``via_device_id``, which carries the *registry id* of the parent instead
+    of its identifiers. Two reasons keep us on the old key for now:
+
+    - ``via_device_id`` needs a lookup (``async_get_device_id_by_identifier``)
+      that does not exist at the HA floor declared in ``hacs.json``, and that
+      raises when the pool device is not registered yet — which is exactly the
+      state ``device_info`` is evaluated in for the first platform set up.
+    - ``via_device`` stays accepted by the registry until HA 2027.8.
+
+    So the key is written here, outside the TypedDict literal that no longer
+    types it, and this is the single place to migrate once the floor allows it.
+    """
+    cast(dict[str, Any], info)["via_device"] = (DOMAIN, pool_id)
+    return info
 
 
 def resolve_schedule_component(device_data: dict[str, Any], default: int = 20) -> int:

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -26,6 +26,7 @@ from homeassistant.util import dt as dt_util
 from ..const import DOMAIN
 from ..device_registry import DeviceIdentifier
 from ..entity import FluidraPoolEntity
+from ..helpers import link_to_pool
 
 if TYPE_CHECKING:
     from ..coordinator import FluidraDataUpdateCoordinator
@@ -66,13 +67,15 @@ class FluidraBoostRemainingSensor(FluidraPoolEntity, SensorEntity):
         """Return device information."""
         device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model="Chlorinator",
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model="Chlorinator",
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property
@@ -134,13 +137,15 @@ class FluidraBoostRemainingHoursSensor(FluidraPoolEntity, SensorEntity):
         """Return device information."""
         device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model="Chlorinator",
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model="Chlorinator",
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property
@@ -217,13 +222,15 @@ class FluidraUvRunningHoursSensor(FluidraPoolEntity, SensorEntity):
         """Return device information."""
         device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model="Chlorinator",
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model="Chlorinator",
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property
@@ -413,13 +420,15 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
         """Return device information."""
         device_name = self.device_data.get("name") or f"Chlorinator {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model="Chlorinator",
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model="Chlorinator",
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     @property

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -19,6 +19,7 @@ from ..entity import FluidraPoolControlEntity
 from ..helpers import (
     get_aux_schedule_data,
     get_schedule_data,
+    link_to_pool,
     resolve_aux_schedule_component,
     resolve_schedule_component,
 )
@@ -240,13 +241,15 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
 
         device_name = self.device_data.get("name") or f"Device {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model=default_model,
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model=default_model,
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )
 
     def _get_schedule_days(self, schedule: dict[str, Any] | None) -> set[int]:
@@ -340,11 +343,13 @@ class FluidraLightScheduleTimeEntity(_FluidraTimeEntityBase):
         """Return device info."""
         device_name = self.device_data.get("name") or f"Pool Light {self._device_id}"
         firmware = self.device_data.get("firmware_version_component")
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=device_name,
-            manufacturer=self.device_data.get("manufacturer", "Fluidra"),
-            model=self.device_data.get("model", "LumiPlus Connect"),
-            sw_version=str(firmware) if firmware is not None else None,
-            via_device=(DOMAIN, self._pool_id),
+        return link_to_pool(
+            DeviceInfo(
+                identifiers={(DOMAIN, self._device_id)},
+                name=device_name,
+                manufacturer=self.device_data.get("manufacturer", "Fluidra"),
+                model=self.device_data.get("model", "LumiPlus Connect"),
+                sw_version=str(firmware) if firmware is not None else None,
+            ),
+            self._pool_id,
         )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 # Test/CI dependencies (pinned for reproducible CI runs).
 # pytest-homeassistant-custom-component pins a compatible Home Assistant,
 # pytest and pytest-asyncio as transitive dependencies.
-pytest-homeassistant-custom-component==0.13.357
+pytest-homeassistant-custom-component==0.13.361
 pytest-cov==7.1.0
 mypy==2.3.1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,6 +11,7 @@ import pytest
 
 from custom_components.fluidra_pool.api_resilience import FluidraConnectionError
 from custom_components.fluidra_pool.const import (
+    DOMAIN,
     EMPTY_COMPONENT_FETCH_THRESHOLD,
     OFFLINE_GRACE_POLLS,
     STALE_DEVICE_THRESHOLD,
@@ -379,10 +380,27 @@ class TestSyncDeviceFirmware:
 
     _POOLS = [{"id": "p1", "devices": [{"device_id": "D1", "firmware_version_component": "2.0"}]}]
 
+    @staticmethod
+    def _coordinator(hass: HomeAssistant, mock_api: AsyncMock) -> FluidraDataUpdateCoordinator:
+        """A coordinator that knows its config entry, as it does once set up.
+
+        DataUpdateCoordinator.__init__ overwrites self.config_entry from the
+        current-entry ContextVar, which is only set inside async_setup_entry, so
+        constructing one here leaves it None. Assign it back to get the shape
+        production actually runs with.
+        """
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_1"
+        config_entry.options = {}
+        coord = FluidraDataUpdateCoordinator(hass, mock_api, config_entry)
+        coord.config_entry = config_entry
+        return coord
+
     def _sync(self, hass: HomeAssistant, mock_api: AsyncMock, pools, registry_entry):
-        coord = FluidraDataUpdateCoordinator(hass, mock_api)
+        """Run the sync as production does: with a config entry, on a modern registry."""
+        coord = self._coordinator(hass, mock_api)
         dev_reg = MagicMock()
-        dev_reg.async_get_device.return_value = registry_entry
+        dev_reg.async_get_device_by_identifier.return_value = registry_entry
         with patch(
             "custom_components.fluidra_pool.coordinator.coordinator.dr.async_get",
             return_value=dev_reg,
@@ -395,6 +413,7 @@ class TestSyncDeviceFirmware:
         entry.id = "reg_1"
         entry.sw_version = "1.0"
         dev_reg = self._sync(hass, mock_api, self._POOLS, entry)
+        dev_reg.async_get_device_by_identifier.assert_called_once_with((DOMAIN, "D1"), "entry_1")
         dev_reg.async_update_device.assert_called_once_with("reg_1", sw_version="2.0")
 
     def test_noop_when_firmware_unchanged(self, hass: HomeAssistant, mock_api: AsyncMock):
@@ -410,7 +429,41 @@ class TestSyncDeviceFirmware:
     def test_skips_devices_without_firmware_or_id(self, hass: HomeAssistant, mock_api: AsyncMock):
         pools = [{"id": "p1", "devices": [{"device_id": "D1"}, {"firmware_version_component": "9"}]}]
         dev_reg = self._sync(hass, mock_api, pools, MagicMock())
-        dev_reg.async_get_device.assert_not_called()
+        dev_reg.async_get_device_by_identifier.assert_not_called()
+
+    def test_falls_back_when_registry_predates_the_scoped_lookup(self, hass: HomeAssistant, mock_api: AsyncMock):
+        """At the HA floor there is no async_get_device_by_identifier — use the old call."""
+        coord = self._coordinator(hass, mock_api)
+        entry = MagicMock()
+        entry.id = "reg_1"
+        entry.sw_version = "1.0"
+        # spec= gives a registry that only exposes the two methods the floor has.
+        dev_reg = MagicMock(spec=["async_get_device", "async_update_device"])
+        dev_reg.async_get_device.return_value = entry
+        with patch(
+            "custom_components.fluidra_pool.coordinator.coordinator.dr.async_get",
+            return_value=dev_reg,
+        ):
+            coord._sync_device_firmware(self._POOLS)
+        dev_reg.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "D1")})
+        dev_reg.async_update_device.assert_called_once_with("reg_1", sw_version="2.0")
+
+    def test_falls_back_without_a_config_entry(self, hass: HomeAssistant, mock_api: AsyncMock):
+        """The scoped lookup needs an entry id; without one, the unscoped call still works."""
+        coord = FluidraDataUpdateCoordinator(hass, mock_api)
+        entry = MagicMock()
+        entry.id = "reg_1"
+        entry.sw_version = "1.0"
+        dev_reg = MagicMock()
+        dev_reg.async_get_device.return_value = entry
+        with patch(
+            "custom_components.fluidra_pool.coordinator.coordinator.dr.async_get",
+            return_value=dev_reg,
+        ):
+            coord._sync_device_firmware(self._POOLS)
+        dev_reg.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "D1")})
+        dev_reg.async_get_device_by_identifier.assert_not_called()
+        dev_reg.async_update_device.assert_called_once_with("reg_1", sw_version="2.0")
 
 
 class TestUpdateDataOutagePath:

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -110,11 +110,11 @@ async def test_setup_entry_loaded(hass: HomeAssistant, mock_api: AsyncMock) -> N
 async def test_setup_entry_registers_devices(hass: HomeAssistant, mock_api: AsyncMock) -> None:
     """The pool device and the pump device are written to the device registry."""
     _prepare_api(mock_api)
-    await _setup(hass, mock_api)
+    entry = await _setup(hass, mock_api)
 
     registry = dr.async_get(hass)
-    pool_device = registry.async_get_device(identifiers={(DOMAIN, POOL_ID)})
-    pump_device = registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    pool_device = registry.async_get_device_by_identifier((DOMAIN, POOL_ID), entry.entry_id)
+    pump_device = registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id)
 
     assert pool_device is not None
     assert pool_device.manufacturer == "Fluidra"
@@ -154,7 +154,7 @@ async def test_setup_entry_device_without_id_skipped(hass: HomeAssistant, mock_a
     assert entry.state is ConfigEntryState.LOADED
     registry = dr.async_get(hass)
     # The named pump is registered, the anonymous one is not.
-    assert registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)}) is not None
+    assert registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id) is not None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -157,6 +157,29 @@ async def test_setup_entry_device_without_id_skipped(hass: HomeAssistant, mock_a
     assert registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id) is not None
 
 
+async def test_firmware_sync_writes_to_the_real_registry(hass: HomeAssistant, mock_api: AsyncMock) -> None:
+    """The coordinator's firmware sync reaches a real device registry, no deprecation on the way.
+
+    The unit tests for _sync_device_firmware mock the registry, so they cannot
+    catch a signature drift in the scoped lookup the coordinator now uses. This
+    one drives the actual registry the installed HA ships.
+    """
+    _prepare_api(mock_api)
+    entry = await _setup(hass, mock_api)
+    coordinator = entry.runtime_data.coordinator
+    # Production wires the entry through the current-entry ContextVar.
+    assert coordinator.config_entry is entry
+
+    registry = dr.async_get(hass)
+    assert registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id).sw_version is None
+
+    pools = [{"id": POOL_ID, "devices": [{"device_id": DEVICE_ID, "firmware_version_component": "9.9.9"}]}]
+    coordinator._sync_device_firmware(pools)
+
+    device = registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id)
+    assert device.sw_version == "9.9.9"
+
+
 # --------------------------------------------------------------------------- #
 # async_unload_entry
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
`pytest-homeassistant-custom-component` 0.13.361 (PR #223) pulls in Home Assistant
2026.9.0b4, which reworks the device registry and breaks two CI jobs on that branch.
This PR fixes both, plus the one deprecation that CI tolerated but users would see.

## What actually broke

**Typing (mypy), 8 errors** — `DeviceInfo` no longer declares `via_device`. HA replaced it
with `via_device_id`, which carries the parent device's *registry id* rather than its
identifiers, so every `DeviceInfo(..., via_device=(DOMAIN, pool_id))` literal is now an
extra key under strict mypy.

**Tests, 2 failures** — `DeviceRegistry.async_get_device` is deprecated (identifiers are no
longer unique across config entries) and `report_usage` raises for core callers. The two
failing assertions in `tests/test_init_setup.py` call it directly, so they are the core
callers.

**Not a CI failure, fixed anyway** — the coordinator's firmware sync called the same
deprecated `async_get_device`. For a custom integration HA only logs a warning
(`custom_integration_behavior=LOG`), which is why the suite stayed green, but the warning
lands in users' logs and the call stops working in HA 2027.8.

## The fix

**`via_device`** stays accepted by the registry until HA **2027.8**, and `via_device_id` needs
`async_get_device_id_by_identifier` — which does not exist at the HA floor declared in
`hacs.json` (2025.4.0), and which raises when the pool device is not registered yet, exactly
the state `device_info` is evaluated in for the first platform set up. So this keeps writing
`via_device`, but from a single `link_to_pool()` helper in `helpers.py`, outside the
TypedDict literal that no longer types it. One place to migrate when the floor moves.

**`async_get_device`** is replaced by `async_get_device_by_identifier`, scoped to the
integration's own config entry, behind a small `_async_get_device()` shim in the coordinator
that falls back to the old call when the installed core predates the scoped method or when
no config entry is known. Both branches are covered, and a new test in `test_init_setup.py`
drives the firmware sync against a **real** device registry — the unit tests mock it, so they
could not catch a signature drift.

The four tests asserting `info["via_device"] == (DOMAIN, POOL_ID)` are untouched and still
pass, so the parent link itself is unchanged.

`requirements_test.txt` carries the same bump as #223, so merging this makes that PR a no-op.

## Verified locally with `pytest-homeassistant-custom-component==0.13.361`

```
$ mypy custom_components/fluidra_pool/
Success: no issues found in 67 source files

$ pytest tests/ --cov=custom_components/fluidra_pool --cov-fail-under=90
Required test coverage of 90% reached. Total coverage: 95.46%
2067 passed in 29.56s

$ ruff check custom_components/fluidra_pool/ tests/
All checks passed!
$ ruff format --check custom_components/fluidra_pool/ tests/
136 files already formatted

$ python3.13 scripts/check_floor_compat.py   # venv with homeassistant==2025.4.0
OK: imported 67 modules against homeassistant==2025.4.0
```

Zero `async_get_device ... is deprecated` warnings across the whole run.

## Noted, not changed here

`FluidraDataUpdateCoordinator.__init__` assigns `self.config_entry`, then calls
`super().__init__()` without `config_entry=`, which overwrites it from the current-entry
ContextVar. It happens to resolve to the right entry in production (asserted by the new
test), but the explicit assignment is dead. Tidying that is unrelated to this bump.

Refs #223.
