### PR TITLE
fix: address the CodeRabbit review of PR #220

### DIFF
--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -380,7 +380,13 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if str(device.get("device_id")) != change.device_id:
                     continue
                 device.setdefault("components", {})
-                state: dict[str, Any] = {"reportedValue": change.reported_value}
+                # The push only carries the reported value: seed from what the
+                # poll stored so the rest of the component — `desiredValue`
+                # above all, which feeds pump_desired/auto_desired — survives.
+                # _process_component_state replaces the whole component entry.
+                previous = device["components"].get(str(change.component_id))
+                state: dict[str, Any] = dict(previous) if isinstance(previous, dict) else {}
+                state["reportedValue"] = change.reported_value
                 if change.timestamp is not None:
                     state["ts"] = change.timestamp
                 self._process_component_state(device, str(pool_id), change.component_id, state)

--- a/custom_components/fluidra_pool/device_registry/identifier.py
+++ b/custom_components/fluidra_pool/device_registry/identifier.py
@@ -241,7 +241,14 @@ class DeviceIdentifier:
             comp7_value,
         )
         cache = device.get("_identify_cache")
-        if isinstance(cache, dict) and cache.get("key") == cache_key:
+        # The family id is checked alongside the key, not inside it: it can arrive
+        # after a first identification (the device tree may omit ``thingType``
+        # while the status tree, attached later in the same poll, carries it) and
+        # none of the key's fields move with it, so the stale generic result would
+        # be served for the rest of the poll. An entry that records no family id
+        # states nothing about it and is left valid.
+        cached_thing_type = cache.get("thing_type", thing_type) if isinstance(cache, dict) else thing_type
+        if isinstance(cache, dict) and cache.get("key") == cache_key and cached_thing_type == thing_type:
             # The tecnoLC2 signature is re-evaluated here (not baked into the cache) so
             # it activates as soon as c8/c172 are scanned, without a key change.
             return _tecnolc2_signature_override(cache.get("config"), components, thing_type)
@@ -255,7 +262,7 @@ class DeviceIdentifier:
             comp7_value=comp7_value,
             thing_type=thing_type,
         )
-        device["_identify_cache"] = {"key": cache_key, "config": result}
+        device["_identify_cache"] = {"key": cache_key, "thing_type": thing_type, "config": result}
         return _tecnolc2_signature_override(result, components, thing_type)
 
     @staticmethod

--- a/custom_components/fluidra_pool/fluidra_api/_websocket.py
+++ b/custom_components/fluidra_pool/fluidra_api/_websocket.py
@@ -205,8 +205,11 @@ class FluidraWebsocketClient:
             raise RuntimeError("no access token available")
 
         headers = {"User-Agent": FLUIDRA_USER_AGENT}
+        # autoping=True so aiohttp answers the gateway's own PING frames: the
+        # read loop drops every non-text frame, so an unanswered PING would let
+        # the gateway drop us. heartbeat stays None — the keepalive below is ours.
         async with self._session.ws_connect(
-            f"{self._url}?token={token}", headers=headers, autoping=False, heartbeat=None
+            f"{self._url}?token={token}", headers=headers, autoping=True, heartbeat=None
         ) as ws:
             self._ws = ws
             self.connected = True

--- a/custom_components/fluidra_pool/select/pump.py
+++ b/custom_components/fluidra_pool/select/pump.py
@@ -244,7 +244,8 @@ class FluidraThreeSpeedPumpSelect(FluidraPoolControlEntity, SelectEntity):
             return None
         try:
             reported = int(float(raw))
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
+            # OverflowError included: float("inf") parses, int() of it does not.
             _LOGGER.debug("Unparsable three-speed value %s on component %s", raw, self._component)
             return None
 

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -248,7 +248,8 @@ class FluidraUvRunningHoursSensor(FluidraPoolEntity, SensorEntity):
             return None
         try:
             return int(float(raw))
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
+            # OverflowError included: float("inf") parses, int() of it does not.
             _LOGGER.debug("Unparsable UV running hours %s on component %s", raw, self._component_id)
             return None
 

--- a/tests/test_new_registers.py
+++ b/tests/test_new_registers.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from custom_components.fluidra_pool.binary_sensor import (
     FluidraFiltrationStateBinarySensor,
     FluidraUvPresentBinarySensor,
@@ -119,6 +121,12 @@ def test_uv_running_hours_accepts_float_reading() -> None:
 def test_uv_running_hours_none_on_unparsable_value() -> None:
     """Unparsable readings degrade to None."""
     assert _uv_hours(_device({"253": {"reportedValue": "n/a"}})).native_value is None
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan", float("inf")])
+def test_uv_running_hours_none_on_non_finite_value(raw: Any) -> None:
+    """A non-finite reading parses as a float but not as an int -- report nothing."""
+    assert _uv_hours(_device({"253": {"reportedValue": raw}})).native_value is None
 
 
 def test_uv_running_hours_unavailable_when_register_missing() -> None:

--- a/tests/test_pump_three_speed.py
+++ b/tests/test_pump_three_speed.py
@@ -116,6 +116,12 @@ def test_current_option_none_on_unparsable_value() -> None:
     assert _select({"137": {"reportedValue": "n/a"}}).current_option is None
 
 
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan", float("inf")])
+def test_current_option_none_on_non_finite_value(raw: Any) -> None:
+    """A non-finite reading parses as a float but not as an int -- stay unknown."""
+    assert _select({"137": {"reportedValue": raw}}).current_option is None
+
+
 def test_read_and_write_tables_are_profile_overridable() -> None:
     """A family numbering its speeds differently is a profile edit, not a code change."""
     entity = _select(

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -174,6 +174,17 @@ async def test_subscribes_to_every_device_on_connect() -> None:
     ]
 
 
+async def test_server_pings_are_answered_automatically() -> None:
+    """The read loop drops non-text frames, so aiohttp must answer PINGs itself."""
+    client, _ = _client([], lambda change: None)
+
+    await client._connect_once()
+
+    kwargs = client._session.ws_connect.call_args.kwargs
+    assert kwargs["autoping"] is True
+    assert kwargs["heartbeat"] is None
+
+
 async def test_changes_reach_the_callback() -> None:
     """The measured frame ends up as a ComponentChange on the callback."""
     seen: list[ComponentChange] = []
@@ -316,6 +327,26 @@ async def test_pushed_change_updates_the_component_and_notifies() -> None:
     assert device["components"]["11"]["ts"] == 1787767038
     assert coordinator.realtime_changes == 1
     coordinator.async_set_updated_data.assert_called_once_with(coordinator.data)
+
+
+async def test_pushed_change_keeps_the_polled_desired_value() -> None:
+    """The push only carries the reported value -- the rest of the component stays.
+
+    ``_process_component_state`` replaces the whole component entry, so a push
+    built from scratch would drop the polled ``desiredValue`` and blank out
+    pump_desired / auto_desired / speed_level_desired until the next poll.
+    """
+    coordinator = _coordinator()
+    device = coordinator.data["pool-1"]["devices"][0]
+    device["components"]["11"] = {"reportedValue": 0, "desiredValue": 3, "extra": "kept"}
+
+    await coordinator._handle_realtime_change(ComponentChange(device_id=DEVICE_ID, component_id=11, reported_value=2))
+
+    component = device["components"]["11"]
+    assert component["reportedValue"] == 2
+    assert component["desiredValue"] == 3
+    assert component["extra"] == "kept"
+    assert device["speed_level_desired"] == 3
 
 
 async def test_change_for_an_unknown_device_is_ignored() -> None:

--- a/tests/test_thing_type_identification.py
+++ b/tests/test_thing_type_identification.py
@@ -57,6 +57,20 @@ def test_family_id_read_from_the_status_tree_too() -> None:
 # --- What it must not do -----------------------------------------------------
 
 
+def test_family_id_arriving_late_invalidates_the_cache() -> None:
+    """The label can land after a first identification — the cache must not hide it.
+
+    The device tree may omit ``thingType`` while the status tree, attached later
+    in the same poll, carries it. The result is cached on the device dict, so the
+    family id has to be part of the cache key or the generic answer sticks.
+    """
+    device = _device(type="pump")
+    assert DeviceIdentifier.identify_device(device) is not DEVICE_CONFIGS["e30iq_pump"]
+
+    device["status"] = {"thingType": "eppvs"}
+    assert DeviceIdentifier.identify_device(device) is DEVICE_CONFIGS["e30iq_pump"]
+
+
 def test_serial_match_still_wins_over_the_family_id() -> None:
     """A profile written for one unit stays more specific than its family.
 


### PR DESCRIPTION
CodeRabbit reviewed #220 a few minutes before it was merged, so its four findings never got triaged. Each one was re-checked against the merged code; all four are real, and each fix comes with a test that fails without it.

## The findings

| Finding | Verdict | Fix |
|---|---|---|
| Realtime push drops the polled `desiredValue` | real | seed the pushed state from the stored component |
| Identification cache ignores the family id (`thingType`) | real | check it alongside the cache key |
| `int(float("inf"))` raises `OverflowError` in two parsers | real | catch it with the other conversion errors |
| `autoping=False` leaves server PING frames unanswered | real | enable `autoping`, keep our own keepalive |

**Realtime push.** `_handle_realtime_change` built the component entry from scratch, and `_process_component_state` assigns `device["components"][id] = component_state` wholesale. A push on c9/c10/c11 therefore wiped the polled `desiredValue`, and `pump_desired`, `auto_desired` and `speed_level_desired` read `None` until the next poll restored them.

**Identification cache.** The cache key holds device id, family, model, type and the component-7 signature — not `thingType`. The family id can arrive after a first identification: the device tree may omit it while the status tree, attached later in the same poll, carries it (the fallback in `identify_device` exists for exactly that). The stale generic profile was then served for the rest of the poll. It is checked next to the key rather than added to it — the key's exact shape is pinned by 24 test files, and widening the tuple broke 206 tests for no functional gain. An entry that records no family id states nothing about it and stays valid.

**Non-finite registers.** `float("inf")` parses, `int()` of it raises `OverflowError`, which neither parser catches — a cloud value of `"inf"` would propagate out of a property instead of degrading to unknown.

**WebSocket autoping.** The read loop skips every non-text frame, so a PING from the gateway was received and dropped. `heartbeat` stays `None`; the custom keepalive is untouched.

## Gate

```
2073 passed, 2 failed          # both failures pre-exist on origin/main (FOXA-501:
                               # pytest-homeassistant-custom-component bump)
ruff check                     All checks passed!
ruff format --check            136 files already formatted
mypy                           8 errors — identical count and files on origin/main
```

Each new test was run against the unpatched production code first: 9 of the 11 new cases fail there (the two `nan` cases already raised `ValueError`, which was caught).
