### PR TITLE
fix(device_registry): link devices by via_device_id on HA 2026.9

### DIFF
--- a/custom_components/fluidra_pool/__init__.py
+++ b/custom_components/fluidra_pool/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     FluidraPoolConfigEntry,
     FluidraPoolRuntimeData,
 )
-from .helpers import resolve_schedule_component
+from .helpers import pool_link_kwargs, resolve_schedule_component
 from .utils import mask_email
 
 if TYPE_CHECKING:
@@ -149,26 +149,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
         _LOGGER.debug("No pools returned yet (cloud not ready after restart); retrying setup")
         raise ConfigEntryNotReady("Fluidra returned no pools yet; Home Assistant will retry")
 
-    # Create devices for each pool
+    # Create devices for each pool. Their registry ids are kept: from HA 2026.9
+    # a child device links to its parent by id, not by identifiers, and this is
+    # the only point where those ids are known first-hand.
     device_registry = dr.async_get(hass)
+    pool_device_ids: dict[str, str] = {}
     for pool in pools:
         raw_pool_id = pool.get("id")
         if raw_pool_id is None:
             continue
         pool_id = str(raw_pool_id)
         pool_name = pool.get("name", f"Pool {pool_id}")
-        device_registry.async_get_or_create(
+        pool_device = device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, pool_id)},
             name=pool_name,
             manufacturer="Fluidra",
             model="Pool",
         )
+        pool_device_ids[pool_id] = pool_device.id
 
     # Create data update coordinator
     from .coordinator import FluidraDataUpdateCoordinator
 
     coordinator = FluidraDataUpdateCoordinator(hass, api, entry)
+    coordinator.pool_device_ids = pool_device_ids
 
     # 🏆 Utiliser runtime_data au lieu de hass.data (2024+)
     entry.runtime_data = FluidraPoolRuntimeData(
@@ -198,7 +203,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FluidraPoolConfigEntry) 
                         name=device_name,
                         manufacturer="Fluidra",
                         model=model,
-                        via_device=(DOMAIN, pool_id),
+                        **pool_link_kwargs(pool_id, pool_device_ids.get(pool_id)),
                     )
 
     # Set up platforms after coordinator has data

--- a/custom_components/fluidra_pool/binary_sensor.py
+++ b/custom_components/fluidra_pool/binary_sensor.py
@@ -72,6 +72,7 @@ class FluidraChlorinatorProducingBinarySensor(FluidraPoolEntity, BinarySensorEnt
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property

--- a/custom_components/fluidra_pool/coordinator/coordinator.py
+++ b/custom_components/fluidra_pool/coordinator/coordinator.py
@@ -96,6 +96,11 @@ class FluidraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._read_only_pools_warned: set[str] = set()
         # Devices already flagged for an unverified profile — raise once, not every poll.
         self._unverified_profile_flagged: set[str] = set()
+        # Registry id of each pool device, keyed by cloud pool id. Filled by
+        # async_setup_entry right after it creates those devices, because that
+        # is the only place the ids are known: entities need them to express
+        # their parent link as via_device_id (see helpers.pool_link_kwargs).
+        self.pool_device_ids: dict[str, str] = {}
         # Consecutive bulk-fetch failures per device (Issue #144). Tracked per
         # device, not globally: some devices 404 the bulk endpoint while others on
         # the same account answer it fine (Issue #175), and a shared counter was

--- a/custom_components/fluidra_pool/entity.py
+++ b/custom_components/fluidra_pool/entity.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .fluidra_api import FluidraPoolAPI
 
 
-class FluidraPoolEntity(CoordinatorEntity):
+class FluidraPoolEntity(CoordinatorEntity["FluidraDataUpdateCoordinator"]):
     """Base class for all Fluidra Pool entities (read-only)."""
 
     _attr_has_entity_name = True
@@ -80,6 +80,7 @@ class FluidraPoolEntity(CoordinatorEntity):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property

--- a/custom_components/fluidra_pool/helpers.py
+++ b/custom_components/fluidra_pool/helpers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import time
 import logging
-from typing import Any, cast
+from typing import Any, Final, cast
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -18,23 +18,47 @@ from .const import DOMAIN, EXO_LED_COLOURS_LUMIPLUS, EXO_LED_COLOURS_ZODIAC_NL
 _LOGGER = logging.getLogger(__name__)
 
 
-def link_to_pool(info: DeviceInfo, pool_id: str) -> DeviceInfo:
+# HA 2026.9 replaced ``via_device`` — the parent's *identifiers* — with
+# ``via_device_id``, which carries the parent's *registry id*. The two are
+# mutually exclusive across the range this integration supports, so neither can
+# be written unconditionally:
+#
+#   * at the floor declared in ``hacs.json`` (2025.4.0) only ``via_device``
+#     exists, on both ``DeviceInfo`` and ``async_get_or_create``;
+#   * from 2026.9 ``DeviceInfo`` declares only ``via_device_id``, and passing
+#     ``via_device`` logs a deprecation warning on every device it links.
+#
+# Passing both raises, so the key is chosen from what the running core actually
+# declares. Reading it off ``DeviceInfo`` keeps this a pure data check — no
+# version parsing, no registry access — and it is evaluated once at import.
+_VIA_DEVICE_ID_SUPPORTED: Final = "via_device_id" in DeviceInfo.__annotations__
+
+
+def pool_link_kwargs(pool_id: str, pool_device_id: str | None) -> dict[str, Any]:
+    """Return the parent-pool link as keyword arguments for the device registry.
+
+    ``pool_device_id`` is the pool's registry id, which only the code that
+    created the pool device can know. When the caller cannot produce one, the
+    deprecated key is written instead: it still links the device, and a
+    deprecation warning is a far better outcome than a broken parent link. The
+    id is type-checked rather than merely tested against ``None`` because the
+    registry *raises* on a via_device_id it cannot resolve, which would abort
+    the device creation outright.
+    """
+    if _VIA_DEVICE_ID_SUPPORTED and isinstance(pool_device_id, str):
+        return {"via_device_id": pool_device_id}
+    return {"via_device": (DOMAIN, pool_id)}
+
+
+def link_to_pool(info: DeviceInfo, pool_id: str, pool_device_id: str | None = None) -> DeviceInfo:
     """Attach ``info`` to its parent pool device and return it.
 
-    HA 2026.9 dropped ``via_device`` from the ``DeviceInfo`` TypedDict in favour
-    of ``via_device_id``, which carries the *registry id* of the parent instead
-    of its identifiers. Two reasons keep us on the old key for now:
-
-    - ``via_device_id`` needs a lookup (``async_get_device_id_by_identifier``)
-      that does not exist at the HA floor declared in ``hacs.json``, and that
-      raises when the pool device is not registered yet — which is exactly the
-      state ``device_info`` is evaluated in for the first platform set up.
-    - ``via_device`` stays accepted by the registry until HA 2027.8.
-
-    So the key is written here, outside the TypedDict literal that no longer
-    types it, and this is the single place to migrate once the floor allows it.
+    The link is written here rather than in the ``DeviceInfo`` literal because
+    neither key is typed across the whole supported range — see
+    ``_VIA_DEVICE_ID_SUPPORTED`` for which one is picked and why. This is the
+    single place entities express the parent link.
     """
-    cast(dict[str, Any], info)["via_device"] = (DOMAIN, pool_id)
+    cast(dict[str, Any], info).update(pool_link_kwargs(pool_id, pool_device_id))
     return info
 
 

--- a/custom_components/fluidra_pool/sensor/base.py
+++ b/custom_components/fluidra_pool/sensor/base.py
@@ -41,7 +41,7 @@ class FluidraPoolSensorEntity(FluidraPoolEntity, SensorEntity):
         return f"{DOMAIN}_{self._pool_id}_{self._device_id}_sensor{suffix}"
 
 
-class FluidraPoolSensorBase(CoordinatorEntity, SensorEntity):
+class FluidraPoolSensorBase(CoordinatorEntity["FluidraDataUpdateCoordinator"], SensorEntity):
     """Base class for pool-level sensor entities (not bound to a single device)."""
 
     _attr_has_entity_name = True

--- a/custom_components/fluidra_pool/sensor/chlorinator.py
+++ b/custom_components/fluidra_pool/sensor/chlorinator.py
@@ -76,6 +76,7 @@ class FluidraBoostRemainingSensor(FluidraPoolEntity, SensorEntity):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property
@@ -146,6 +147,7 @@ class FluidraBoostRemainingHoursSensor(FluidraPoolEntity, SensorEntity):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property
@@ -231,6 +233,7 @@ class FluidraUvRunningHoursSensor(FluidraPoolEntity, SensorEntity):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property
@@ -430,6 +433,7 @@ class FluidraChlorinatorSensor(FluidraPoolEntity, SensorEntity):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     @property

--- a/custom_components/fluidra_pool/time/base.py
+++ b/custom_components/fluidra_pool/time/base.py
@@ -250,6 +250,7 @@ class FluidraScheduleTimeEntity(_FluidraTimeEntityBase):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )
 
     def _get_schedule_days(self, schedule: dict[str, Any] | None) -> set[int]:
@@ -352,4 +353,5 @@ class FluidraLightScheduleTimeEntity(_FluidraTimeEntityBase):
                 sw_version=str(firmware) if firmware is not None else None,
             ),
             self._pool_id,
+            self.coordinator.pool_device_ids.get(self._pool_id),
         )

--- a/tests/pool_link_asserts.py
+++ b/tests/pool_link_asserts.py
@@ -1,0 +1,33 @@
+"""Assertion helper for the parent-pool link on ``device_info``.
+
+Which key carries that link depends on the running core: HA 2026.9 replaced
+``via_device`` (the parent's identifiers) with ``via_device_id`` (its registry
+id). The production code picks one; these tests check the *value* that lands
+under whichever key the core declares, so they stay meaningful on both sides of
+that change instead of pinning the key the current pin happens to use.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.fluidra_pool.const import DOMAIN
+
+CORE_USES_VIA_DEVICE_ID = "via_device_id" in DeviceInfo.__annotations__
+
+
+def assert_linked_to_pool(info: Any, pool_id: str, pool_device_id: str | None = None) -> None:
+    """Assert ``info`` links to the pool, whichever key the core expects."""
+    if CORE_USES_VIA_DEVICE_ID and pool_device_id is not None:
+        assert info["via_device_id"] == pool_device_id
+        assert "via_device" not in info
+    else:
+        assert info["via_device"] == (DOMAIN, pool_id)
+        assert "via_device_id" not in info
+
+
+# Registry id handed to the mock coordinators so the link they produce carries a
+# real value to assert on, not a MagicMock attribute.
+POOL_DEVICE_ID = "pool-registry-id"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,6 +15,8 @@ from custom_components.fluidra_pool.binary_sensor import (
 from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.device_registry import DEVICE_CONFIGS, DeviceIdentifier
 
+from .pool_link_asserts import POOL_DEVICE_ID, assert_linked_to_pool
+
 POOL_ID = "pool-1"
 DEVICE_ID = "TEST-DEV-001"
 PRODUCTION_COMPONENT = 154
@@ -24,6 +26,7 @@ def _coord(devices: list[dict]) -> Any:
     coordinator = MagicMock()
     coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": devices}}
     coordinator.last_update_success = True
+    coordinator.pool_device_ids = {POOL_ID: POOL_DEVICE_ID}
     return coordinator
 
 
@@ -108,7 +111,7 @@ def test_device_info_uses_device_name_and_links_pool() -> None:
     info = _sensor(device).device_info
     assert info["name"] == "Chlorinator"
     assert (DOMAIN, DEVICE_ID) in info["identifiers"]
-    assert info["via_device"] == (DOMAIN, POOL_ID)
+    assert_linked_to_pool(info, POOL_ID, POOL_DEVICE_ID)
 
 
 async def test_setup_ignores_non_chlorinator_devices() -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -9,6 +9,8 @@ import pytest
 from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.entity import FluidraPoolControlEntity, FluidraPoolEntity
 
+from .pool_link_asserts import POOL_DEVICE_ID, assert_linked_to_pool
+
 
 @pytest.fixture
 def mock_coordinator(mock_pool_data: dict) -> MagicMock:
@@ -16,6 +18,7 @@ def mock_coordinator(mock_pool_data: dict) -> MagicMock:
     coordinator = MagicMock()
     coordinator.data = mock_pool_data
     coordinator.last_update_success = True
+    coordinator.pool_device_ids = {"pool_001": POOL_DEVICE_ID}
     return coordinator
 
 
@@ -69,7 +72,7 @@ class TestFluidraPoolEntity:
         assert (DOMAIN, "E30-001") in info["identifiers"]
         assert info["name"] == "Pool Pump"
         assert info["manufacturer"] == "Fluidra"
-        assert info["via_device"] == (DOMAIN, "pool_001")
+        assert_linked_to_pool(info, "pool_001", POOL_DEVICE_ID)
 
     def test_device_info_unknown_device(self, mock_coordinator: MagicMock):
         entity = FluidraPoolEntity(mock_coordinator, "pool_001", "UNKNOWN")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from datetime import time
 
+from homeassistant.helpers.device_registry import DeviceInfo
 import pytest
 
+from custom_components.fluidra_pool import helpers
+from custom_components.fluidra_pool.const import DOMAIN
 from custom_components.fluidra_pool.helpers import (
     get_schedule_data,
     parse_cron_time,
@@ -128,3 +131,40 @@ def test_pool_access_unknown_without_contracts() -> None:
 
     assert determine_pool_access({"owner": "x"}, None) == "unknown"
     assert determine_pool_access({}, "user-1") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# pool_link_kwargs — which key expresses the parent-pool link
+# ---------------------------------------------------------------------------
+
+
+def test_pool_link_kwargs_uses_the_registry_id_on_a_modern_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With via_device_id available and an id to hand, the id is what is written."""
+    monkeypatch.setattr(helpers, "_VIA_DEVICE_ID_SUPPORTED", True)
+    assert helpers.pool_link_kwargs("pool-1", "reg-42") == {"via_device_id": "reg-42"}
+
+
+def test_pool_link_kwargs_falls_back_to_identifiers_without_an_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No registry id means the link can only be expressed by identifiers."""
+    monkeypatch.setattr(helpers, "_VIA_DEVICE_ID_SUPPORTED", True)
+    assert helpers.pool_link_kwargs("pool-1", None) == {"via_device": (DOMAIN, "pool-1")}
+
+
+def test_pool_link_kwargs_rejects_a_non_string_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-string id would make the registry raise; the deprecated key still links."""
+    monkeypatch.setattr(helpers, "_VIA_DEVICE_ID_SUPPORTED", True)
+    assert helpers.pool_link_kwargs("pool-1", object()) == {"via_device": (DOMAIN, "pool-1")}
+
+
+def test_pool_link_kwargs_uses_identifiers_at_the_ha_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """At the declared HA floor via_device_id does not exist, id or no id."""
+    monkeypatch.setattr(helpers, "_VIA_DEVICE_ID_SUPPORTED", False)
+    assert helpers.pool_link_kwargs("pool-1", "reg-42") == {"via_device": (DOMAIN, "pool-1")}
+
+
+def test_link_to_pool_writes_the_link_onto_the_device_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """link_to_pool returns the same mapping, with the link added."""
+    monkeypatch.setattr(helpers, "_VIA_DEVICE_ID_SUPPORTED", True)
+    info = DeviceInfo(identifiers={(DOMAIN, "dev-1")})
+    assert helpers.link_to_pool(info, "pool-1", "reg-42") is info
+    assert info["via_device_id"] == "reg-42"

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -8,6 +8,7 @@ the options-update reload listener, and the pure time/schedule helpers.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.config_entries import ConfigEntryState
@@ -120,6 +121,47 @@ async def test_setup_entry_registers_devices(hass: HomeAssistant, mock_api: Asyn
     assert pool_device.manufacturer == "Fluidra"
     assert pump_device is not None
     assert pump_device.model == "Pump"
+
+
+async def test_setup_entry_links_devices_to_their_pool(hass: HomeAssistant, mock_api: AsyncMock) -> None:
+    """The pump hangs off the pool device, and the coordinator keeps the pool's id.
+
+    Driven against a real device registry rather than a mock: the two keys that
+    can express this link (`via_device`, `via_device_id`) are resolved by the
+    registry itself, so only a real one proves the child actually ended up
+    attached rather than silently unlinked.
+    """
+    _prepare_api(mock_api)
+    entry = await _setup(hass, mock_api)
+
+    registry = dr.async_get(hass)
+    pool_device = registry.async_get_device_by_identifier((DOMAIN, POOL_ID), entry.entry_id)
+    pump_device = registry.async_get_device_by_identifier((DOMAIN, DEVICE_ID), entry.entry_id)
+
+    assert pool_device is not None
+    assert pump_device is not None
+    assert pump_device.via_device_id == pool_device.id
+    # The id the entities need to express the same link is published on the
+    # coordinator; without it every device_info would fall back to the
+    # deprecated key.
+    assert entry.runtime_data.coordinator.pool_device_ids == {POOL_ID: pool_device.id}
+
+
+async def test_setup_entry_links_without_the_deprecated_parameter(
+    hass: HomeAssistant, mock_api: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Setting up emits no `via_device` deprecation warning on a core that dropped it.
+
+    HA only logs — rather than raises — for a custom integration, so nothing but
+    reading the log catches this: the whole setup, pool devices, child devices
+    and every entity's device_info, must go through without one.
+    """
+    _prepare_api(mock_api)
+    with caplog.at_level(logging.WARNING):
+        await _setup(hass, mock_api)
+
+    deprecations = [r.getMessage() for r in caplog.records if "deprecated `via_device`" in r.getMessage()]
+    assert deprecations == []
 
 
 async def test_setup_entry_no_pools_retries(hass: HomeAssistant, mock_api: AsyncMock) -> None:

--- a/tests/test_sensor_full.py
+++ b/tests/test_sensor_full.py
@@ -42,6 +42,8 @@ from custom_components.fluidra_pool.sensor import (
     async_setup_entry,
 )
 
+from .pool_link_asserts import POOL_DEVICE_ID, assert_linked_to_pool
+
 POOL_ID = "pool-1"
 DEVICE_ID = "TEST-DEV-001"
 
@@ -58,6 +60,7 @@ def _coord(devices: list[dict], pool_extra: dict | None = None) -> Any:
     pool.update(pool_extra or {})
     coordinator.data = {POOL_ID: pool}
     coordinator.last_update_success = True
+    coordinator.pool_device_ids = {POOL_ID: POOL_DEVICE_ID}
     return coordinator
 
 
@@ -1312,7 +1315,7 @@ def test_chlorinator_device_info_uses_device_name_and_manufacturer() -> None:
     assert info["manufacturer"] == "Hayward"
     assert info["model"] == "Chlorinator"
     assert (DOMAIN, DEVICE_ID) in info["identifiers"]
-    assert info["via_device"] == (DOMAIN, POOL_ID)
+    assert_linked_to_pool(info, POOL_ID, POOL_DEVICE_ID)
 
 
 def test_chlorinator_device_info_falls_back_to_generated_name() -> None:

--- a/tests/test_time_light.py
+++ b/tests/test_time_light.py
@@ -21,6 +21,8 @@ from custom_components.fluidra_pool.time.light import (
     FluidraLightScheduleStartTimeEntity,
 )
 
+from .pool_link_asserts import POOL_DEVICE_ID, assert_linked_to_pool
+
 POOL_ID = "pool-1"
 LIGHT_ID = "LE24500883"
 
@@ -50,6 +52,7 @@ def _coord(device: dict) -> Any:
     coordinator.data = {POOL_ID: {"id": POOL_ID, "name": "Pool", "devices": [device]}}
     coordinator.async_request_refresh = AsyncMock()
     coordinator.last_update_success = True
+    coordinator.pool_device_ids = {POOL_ID: POOL_DEVICE_ID}
     return coordinator
 
 
@@ -262,7 +265,7 @@ def test_device_info_uses_device_name_and_model() -> None:
     assert info["name"] == "Pool Light"
     assert info["manufacturer"] == "Fluidra"
     assert info["model"] == "LumiPlus Connect"
-    assert info["via_device"] == ("fluidra_pool", POOL_ID)
+    assert_linked_to_pool(info, POOL_ID, POOL_DEVICE_ID)
 
 
 def test_device_info_falls_back_to_default_name_and_model() -> None:


### PR DESCRIPTION
Two `via_device` deprecation warnings fired on every start under HA 2026.9, one from `__init__.py` and one from every entity's `device_info`. Both are gone.

## Why it could not just be swapped

`via_device` carries the parent's *identifiers*, `via_device_id` its *registry id*. The two are mutually exclusive across the range this integration supports, verified empirically against each version rather than assumed:

| | HA 2025.4.0 (floor in `hacs.json`) | HA 2026.9.0b4 |
|---|---|---|
| `async_get_or_create(via_device=…)` | only form | deprecated → warning |
| `async_get_or_create(via_device_id=…)` | **absent** | required |
| `DeviceInfo["via_device"]` | present | **removed** |
| `DeviceInfo["via_device_id"]` | **absent** | present |

Passing both raises. So neither key can be written unconditionally, and this is not something a floor bump would settle either — 2026.9 is days old.

## The fix

The key is chosen from what the running core declares, read once off `DeviceInfo.__annotations__` — a pure data check, no version parsing, no registry access.

Writing `via_device_id` needs the pool's registry id. Only `async_setup_entry` knows it first-hand, at the moment it creates the pool devices, so it now keeps what `async_get_or_create` returns and publishes the mapping on the coordinator, where `device_info` can reach it. `helpers.link_to_pool()` stays the single place entities express the link; `pool_link_kwargs()` is the same choice for the registry call in `__init__.py`.

The deprecated key remains the fallback whenever no id is available: it still links the device, and a warning beats an orphaned device. The id is type-checked rather than merely compared to `None`, because the registry *raises* on a `via_device_id` it cannot resolve, which would abort the device creation outright.

While here, `CoordinatorEntity` is parameterised on the concrete coordinator in the two base classes, so `self.coordinator` types correctly — mypy stays clean with no other change.

## Correcting #225

That PR left a note saying the migration was blocked by `async_get_device_id_by_identifier` missing at the floor. That method exists in **neither** version; the real one is `async_get_device_by_identifier` (2026.9 only), and the id needs no lookup at all — it comes back from the call that creates the device. The note is replaced.

## Gate

```
2092 passed in 32.09s          # 2085 before, +7
ruff check                     All checks passed!
ruff format --check            137 files already formatted
mypy                           Success: no issues found in 67 source files
check_floor_compat.py          OK: imported 67 modules against homeassistant==2025.4.0
```

The new `test_setup_entry_links_without_the_deprecated_parameter` drives the whole setup against a **real** device registry and asserts no deprecation is logged. Run against the unpatched code it fails with the exact two warnings seen in production. At the floor, the helper was checked to still return `via_device` even when handed an id.

Deployed on a live HA 2026.9.0b4: no deprecation warning, no error, and the pump still hangs off its pool in the device registry (`via_device_id` → the pool's id).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device organization by correctly linking pool-related devices to their parent pool.
  * Added compatibility across Home Assistant versions by using the supported device-linking method automatically.
  * Prevented deprecated device-link warnings during setup.

* **Tests**
  * Added coverage for device linking, compatibility behavior, and setup-time registry relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->