### PR TITLE
fix(heat_pump): add the Z350iQ profile so its ON/OFF state is read (#221)

### DIFF
--- a/API-DISCOVERY.md
+++ b/API-DISCOVERY.md
@@ -548,7 +548,7 @@ correspondant.
 | `domoticS2` / `dm2` | Chlorinators / Bridges | Elite Connect, Control Connect, Neolysis | catch-all `chlorinator` |
 | `amt` | Heat Pumps | Z250iQ, Z260iQ, PX25, PX26, Eco Elyo | **non déclaré** — zone gelée, ces profils se départagent au composant 7 |
 | `nhpp` | Heat Pumps | Z450, Z650iQ, Verti/Silent/Eco Elyo R290 | **non déclaré** — famille trop large pour un seul profil |
-| `hpc` | Heat Pumps | Z350iQ | aucun profil |
+| `hpc` | Heat Pumps | Z350iQ | ✅ `z350iq_heat_pump` |
 | `proelyo` | Heat Pumps | PX50, HPO, Pro Elyo Touch | aucun profil |
 | `evoline` | Heat Pumps | PM40, Evoline | aucun profil |
 | `z950iq` | Heat Pumps | z950iQ Powerforce Inverter | aucun profil |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ profile, so unknown equipment is usually still usable.
   running hours, WiFi signal
 - **Z260iQ** — HVAC modes (heat / cool / heat-cool), presets, no-flow alarm, water/air temperatures
 - **Z550iQ+** — HVAC modes (heat / cool / auto), presets, HVAC action (heating/cooling/idle/no-flow), water/air temperatures
+- **Z350iQ** — shares the Z550iQ register map: on/off switch, target temperature, HVAC action
+  (heating/cooling/idle/no-flow). Its on/off flag, running state and setpoint were confirmed on a
+  live unit; water and air temperatures come from the shared map and are still being confirmed
+  on this model.
 - **Z650iQ** — HVAC modes (heat / cool / heat-cool), Smart+/Smart/Ecosilence/Boost presets,
   on/off switch, water/air temperatures, running hours, compressor running hours, WiFi
   signal, instantaneous power (Watts) and compressor modulation (percent). Reverse-

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -174,6 +174,55 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         },
         priority=96,  # Higher than z250iq.
     ),
+    "z350iq_heat_pump": DeviceConfig(
+        # Zodiac Z350iQ — Issue #221 (@HHjung1981). Cloud family id "hpc",
+        # which no profile claimed, so it fell through to generic_heat_pump.
+        # That fallback assumes c13 carries ON/OFF; on this unit c13 stays 0
+        # while the heat pump runs, so Home Assistant reported it permanently
+        # OFF and its switch did nothing.
+        #
+        # The register map is the Z550iQ one, which is where the reporter's
+        # measurements landed. Confirmed on their hardware, across two separate
+        # captures:
+        #   - c21 ON/OFF   — 1 with the unit running, 0 after switching it off
+        #                    from the Fluidra app; c13 stayed 0 throughout.
+        #   - c61 state    — 11 (no flow) on the first capture, 2 (heating) on
+        #                    the second, both matching the Z550iQ table.
+        #   - c15 setpoint — already read correctly through the generic profile,
+        #                    which happens to scan it; the reporter confirms the
+        #                    target temperature reads and writes.
+        # Inherited from the Z550iQ map but NOT yet confirmed on a Z350iQ:
+        # c16 (mode), c37 (water), c40 (air), c60 (running hours). Each is
+        # range-validated by the decoder, so a register that means something
+        # else on this model is dropped rather than shown — and the full
+        # register dump is still being collected to settle them.
+        device_type="heat_pump",
+        thing_type_patterns=["hpc"],
+        name_patterns=["z350", "z35"],
+        model_patterns=["z350", "z35"],
+        # No family_patterns — see the module note (Issue #216).
+        components_range=5,
+        required_components=[0, 1, 2, 3],
+        entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours", "sensor_activity"],
+        features={
+            "temperature_control": True,
+            "hvac_modes": ["off", "heat", "cool", "auto"],
+            "skip_auto_mode": True,
+            "skip_schedules": True,
+            # Drives the shared Z550iQ decoding: c21 as the on/off state, c61 as
+            # the running action, c16/c37/c40 as mode, water and air. It also
+            # stops c13 being read as an on/off flag, which is the actual bug.
+            "z550_mode": True,
+            "on_off_component": 21,
+            "setpoint_component": 15,
+            "mode_component": 16,
+            "water_temp_component": 37,
+            "air_temp_component": 40,
+            "state_component": 61,
+            "specific_components": [15, 16, 17, 18, 21, 37, 40, 60, 61],
+        },
+        priority=98,  # Above z550iq (96) — "hpc" is this model alone.
+    ),
     "hpgic_gre_heat_pump": DeviceConfig(
         device_type="heat_pump",
         # Gre HPGIC full-inverter heat pump — Issue #92 (@sterubbg). Its cloud

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -333,15 +333,16 @@ async def test_diagnostics_dump_every_register_of_an_unverified_device() -> None
 
     The generic heat-pump profile polls components 0-3 plus 13/14/15, so the
     pools block can only ever contain those. That is exactly the device for which
-    nobody knows the map yet: Issue #221's Z350iQ reads OFF because component 13
-    is not its ON/OFF flag, and no export could show which register is.
+    nobody knows the map yet — the case Issue #221 made, on a Z350iQ whose c13 was
+    not the ON/OFF flag. That model now has a profile; "evoline" (PM40) stands in
+    as a family that still has none.
     """
     device = {
         "device_id": "FE25000001",
-        "name": "Z350iQ",
+        "name": "PM40",
         "family": "Heat Pumps",
         "type": "heat_pump",
-        "thing_type": "hpc",
+        "thing_type": "evoline",
         "components": {"13": {"reportedValue": 0}, "15": {"reportedValue": 280}},
     }
     api = SimpleNamespace(
@@ -376,7 +377,7 @@ async def test_diagnostics_dump_every_register_of_an_unverified_device() -> None
     assert len(dumped) == 1
     assert dumped[0]["profile"] == "generic_heat_pump"
     # The family id is what places an unreported model on a register map.
-    assert dumped[0]["thing_type"] == "hpc"
+    assert dumped[0]["thing_type"] == "evoline"
     assert dumped[0]["scanned_components"] == [13, 15]
     # Registers the profile never polls — the whole point of the block.
     assert dumped[0]["all_registers"]["21"]["reportedValue"] == 1

--- a/tests/test_thing_type_identification.py
+++ b/tests/test_thing_type_identification.py
@@ -119,6 +119,7 @@ def test_declared_families_are_the_measured_ones() -> None:
         "victoria_smart_connect_pump": ["mppvs"],
         "ns25_exo_chlorinator": ["exr"],
         "z550iq_heat_pump": ["zs500"],
+        "z350iq_heat_pump": ["hpc"],
         "command_connect_cabinet": ["SRC"],
         "blue_connect_silver": ["BC3"],
     }
@@ -208,3 +209,41 @@ def test_component_7_product_codes_do_not_mislabel_heat_pumps() -> None:
     )
     config = DeviceIdentifier.identify_device(device)
     assert config is DEVICE_CONFIGS["z260iq_heat_pump"]
+
+
+# --- Z350iQ (Issue #221) ------------------------------------------------------
+
+
+def test_z350iq_routed_by_its_family_id() -> None:
+    """The Z350iQ reports family "hpc" and nothing else identifying.
+
+    Its serial carries no recognised prefix and the cloud name is not guaranteed,
+    so the family id is the only reliable signal — which is why it fell through
+    to generic_heat_pump before this profile existed.
+    """
+    device = {
+        "device_id": "FE25000001",
+        "name": "Heat Pump",
+        "type": "heat_pump",
+        "thing_type": "hpc",
+        "family": "Heat Pumps",
+    }
+    config = DeviceIdentifier.identify_device(device)
+    assert config is DEVICE_CONFIGS["z350iq_heat_pump"]
+    assert config.verified is True
+
+
+def test_z350iq_reads_its_on_off_flag_off_component_21() -> None:
+    """c21 is the ON/OFF register, not c13 — the whole of Issue #221.
+
+    The reporter measured c13 stuck at 0 while the unit ran, and c21 tracking
+    the state exactly. The generic profile's guess (c13) is what made Home
+    Assistant report the heat pump permanently OFF.
+    """
+    config = DEVICE_CONFIGS["z350iq_heat_pump"]
+    assert config.features["on_off_component"] == 21
+    assert config.features["setpoint_component"] == 15
+    # z550_mode is what routes c21/c61 through the decoder and, just as
+    # importantly, stops c13 being read as an on/off flag.
+    assert config.features["z550_mode"] is True
+    assert 13 not in config.features["specific_components"]


### PR DESCRIPTION
Refs #221.

The Z350iQ reports cloud family `hpc`, which no profile claimed, so it fell through to `generic_heat_pump`. That fallback assumes **component 13** carries the ON/OFF flag. On this unit c13 stays `0` while the heat pump runs — so Home Assistant reported it permanently OFF, its switch did nothing, and the reporter's automations stopped working.

## What the measurements say

The reporter's readings land on the register map this integration already ships for the **Z550iQ**. Confirmed on their hardware across two separate captures:

| Register | Capture 1 | Capture 2 | Z550iQ map |
|---|---|---|---|
| **c21** | 1 running → 0 off | 1 (running) | **ON/OFF** ✅ |
| **c61** | 11 | 2 | **state** — 11 = no flow, 2 = heating ✅ |
| **c15** | — | reads *and writes* | **setpoint** ✅ |
| c13 | 0 while running | 0 while running | the generic profile's wrong guess |

Two distinct values of the c61 table observed on two occasions, and c21 tracking the state in both directions. c15 already worked because the generic profile happens to scan it.

## The profile

Keyed on the family id alone — `hpc` is this model and no other, unlike the coarse families deliberately left undeclared for #216. Priority 98, above `z550iq` (96), though no collision is possible on a distinct `thingType`.

The `z550_mode` feature does the real work: it routes c21 to `heat_pump_reported`, c61 to `hvac_action`, and — just as importantly — **stops c13 being read as an on/off flag at all** (`coordinator.py:604`). That last part is the actual bug.

`c16` (mode), `c37` (water), `c40` (air) and `c60` (running hours) come from the shared map and are **not yet confirmed** on a Z350iQ. Each is range-validated by the decoder, so a register meaning something else on this model is dropped rather than displayed. The full register dump is still being collected to settle them; this is stated in the profile comment and the README rather than glossed over.

## Gate

```
2094 passed in 28.97s          # 2092 before, +2 new
ruff check                     All checks passed!
ruff format --check            137 files already formatted
mypy                           Success: no issues found in 67 source files
```

Deployed on a live HA 2026.9 install: no error, no deprecation, setup in 1.52 s, existing devices unaffected.

Two existing tests moved rather than broke: `test_declared_families_are_the_measured_ones` gains the new family, and the diagnostics test that used the Z350iQ as its *unverified device* example now uses `evoline` (PM40) — a family that still has no profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Zodiac Z350iQ heat pumps.
  - Z350iQ devices now provide on/off control, target temperature, and HVAC status (heating, cooling, idle, or no flow).
  - Water and air temperature readings are supported using the shared Z550iQ register map.

- **Bug Fixes**
  - Corrected Z350iQ device identification and status reporting.
  - The power switch now accurately reflects and controls the heat pump’s running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->