### PR TITLE
fix(heat_pump): stop reading the Z350iQ c16 as a Z550iQ HVAC mode (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ profile, so unknown equipment is usually still usable.
   running hours, WiFi signal
 - **Z260iQ** — HVAC modes (heat / cool / heat-cool), presets, no-flow alarm, water/air temperatures
 - **Z550iQ+** — HVAC modes (heat / cool / auto), presets, HVAC action (heating/cooling/idle/no-flow), water/air temperatures
-- **Z350iQ** — shares the Z550iQ register map: on/off switch, target temperature, HVAC action
-  (heating/cooling/idle/no-flow). Its on/off flag, running state and setpoint were confirmed on a
-  live unit; water and air temperatures come from the shared map and are still being confirmed
-  on this model.
+- **Z350iQ** — heat-only unit sharing the Z550iQ registers: on/off switch, target temperature,
+  water and air temperatures, running hours, and HVAC action (heating/idle/no-flow). Its operating
+  mode (Boost / Silence / Smart) is reported as an attribute rather than an HVAC mode — the register
+  that carries it holds heating/cooling/auto on the Z550iQ, but this line does not cool. Every
+  register was read back on a live unit.
 - **Z650iQ** — HVAC modes (heat / cool / heat-cool), Smart+/Smart/Ecosilence/Boost presets,
   on/off switch, water/air temperatures, running hours, compressor running hours, WiFi
   signal, instantaneous power (Watts) and compressor modulation (percent). Reverse-

--- a/custom_components/fluidra_pool/climate.py
+++ b/custom_components/fluidra_pool/climate.py
@@ -28,6 +28,7 @@ from .const import (
     LG_PRESET_MODES,
     LG_PRESET_SMART_HEATING,
     LG_VALUE_TO_MODE,
+    Z350_MODE_NAMES,
     Z550_STATE_NO_FLOW,
     Z650_MODE_TO_VALUE,
     Z650_PRESET_MODES,
@@ -521,12 +522,18 @@ class FluidraHeatPumpClimate(FluidraPoolControlEntity, ClimateEntity):
             if air_temp is not None:
                 attrs["air_temperature"] = air_temp
 
-            # Mode (0=heating, 1=cooling, 2=auto)
+            # Mode, read off c16. Same register on the Z550iQ and the Z350iQ,
+            # different meanings: heating/cooling/auto there, Boost/Silence/Smart
+            # here — the Z350iQ is heat-only and c16 sets how hard it works.
             z550_mode = device_data.get("z550_mode_reported")
             if z550_mode is not None:
-                mode_names = {0: "heating", 1: "cooling", 2: "auto"}
-                attrs["z550_mode"] = mode_names.get(z550_mode, f"unknown ({z550_mode})")
-                attrs["z550_mode_raw"] = z550_mode
+                if DeviceIdentifier.has_feature(device_data, "z350_mode"):
+                    attrs["z350_mode"] = Z350_MODE_NAMES.get(z550_mode, f"unknown ({z550_mode})")
+                    attrs["z350_mode_raw"] = z550_mode
+                else:
+                    mode_names = {0: "heating", 1: "cooling", 2: "auto"}
+                    attrs["z550_mode"] = mode_names.get(z550_mode, f"unknown ({z550_mode})")
+                    attrs["z550_mode_raw"] = z550_mode
 
             # State (0=idle, 2=heating, 3=cooling, 11=no flow)
             z550_state = device_data.get("z550_state_reported")

--- a/custom_components/fluidra_pool/climate_behaviors.py
+++ b/custom_components/fluidra_pool/climate_behaviors.py
@@ -198,6 +198,47 @@ class Z550Behavior(HeatPumpBehavior):
         return success
 
 
+class Z350Behavior(Z550Behavior):
+    """Z350iQ: the Z550iQ registers, but a heat-only unit.
+
+    It shares c21 (on/off), c37/c40 (water/air) and c61 (running state) with the
+    Z550iQ, so everything else is inherited. What it does NOT share is the
+    meaning of c16: on the Z550iQ that register selects heating/cooling/auto,
+    while on the Z350iQ it selects Boost/Silence/Smart — how hard the unit
+    works, not what it does. This line has no cooling at all.
+
+    Reading c16 as an HVAC mode would therefore report a Z350iQ running in
+    Silence as "cool" and one in Smart as "heat_cool". So the mode is taken from
+    the power register alone, and c16 is surfaced as a plain attribute instead
+    (see climate.py). It is not written either: the reporter confirmed the three
+    values by reading them, and nothing establishes that the register accepts a
+    write — the Z550iQ's own c17 answers 403 (Issues #56, #88).
+
+    Measured on a live unit for Issue #221.
+    """
+
+    hvac_modes: list[HVACMode] = [HVACMode.OFF, HVACMode.HEAT]
+
+    def hvac_mode(self, device_data: dict[str, Any]) -> HVACMode:
+        """ON/OFF only — c21 is the whole story on a heat-only unit."""
+        return HVACMode.HEAT if device_data.get("heat_pump_reported") else HVACMode.OFF
+
+    async def async_set_hvac_mode(
+        self,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+        hvac_mode: HVACMode,
+        current_preset: str | None,
+    ) -> bool | None:
+        """Write the power register and nothing else.
+
+        The Z550iQ path would follow up with a mode write on c16, which here
+        would change how hard the unit runs as a side effect of turning it on.
+        """
+        return await api.control_device_component(device_id, 21, 0 if hvac_mode == HVACMode.OFF else 1)
+
+
 # Live compressor state on c75, confirmed on a Z250iQ across Boost/Silent and
 # Heating/Cooling (Issue #139, @Kal42). Only these three values are mapped: a
 # transient 8 was observed right after a mode change and never explained, so
@@ -434,6 +475,7 @@ class Z650iqBehavior(HeatPumpBehavior):
 
 # Behaviors are stateless: one singleton per family is enough.
 Z550_BEHAVIOR = Z550Behavior()
+Z350_BEHAVIOR = Z350Behavior()
 Z260IQ_BEHAVIOR = Z260iqBehavior()
 Z650IQ_BEHAVIOR = Z650iqBehavior()
 LG_BEHAVIOR = LgBehavior()
@@ -447,10 +489,15 @@ def resolve_behavior(device_data: dict[str, Any]) -> HeatPumpBehavior:
     comp-7 signature yet) and later ones; DeviceIdentifier.identify_device is
     cached, so re-resolving on every property/action access is cheap and
     mirrors the pre-refactor per-property has_feature() checks. Precedence
-    order matches the original dispatch: z550_mode, then z650iq_mode (before
+    order matches the original dispatch: z350_mode, then z550_mode, then
+    z650iq_mode (before
     z260iq_mode since it also sets z260iq_mode=True), then z260iq_mode, then
     preset_modes, else standard.
     """
+    # z350_mode before z550_mode: a Z350iQ sets both (it borrows the Z550iQ
+    # register decoding) but must not inherit its c16 mode semantics.
+    if DeviceIdentifier.has_feature(device_data, "z350_mode"):
+        return Z350_BEHAVIOR
     if DeviceIdentifier.has_feature(device_data, "z550_mode"):
         return Z550_BEHAVIOR
     if DeviceIdentifier.has_feature(device_data, "z650iq_mode"):

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -234,6 +234,19 @@ Z550_STATE_HEATING: Final = 2
 Z550_STATE_COOLING: Final = 3
 Z550_STATE_NO_FLOW: Final = 11
 
+# Z350iQ component 16. The register sits where the Z550iQ keeps its HVAC mode,
+# but it does NOT mean the same thing: this line has no cooling, and the three
+# values select how hard the unit works, not what it does. Measured on a live
+# unit by the reporter of Issue #221, against the Fluidra app.
+Z350_MODE_BOOST: Final = 0
+Z350_MODE_SILENCE: Final = 1
+Z350_MODE_SMART: Final = 2
+Z350_MODE_NAMES: Final = {
+    Z350_MODE_BOOST: "boost",
+    Z350_MODE_SILENCE: "silence",
+    Z350_MODE_SMART: "smart",
+}
+
 # LG Heat Pump constants (component 14 values)
 LG_PRESET_SMART_HEATING: Final = "smart_heating"
 LG_PRESET_SMART_COOLING: Final = "smart_cooling"

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -181,21 +181,23 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         # while the heat pump runs, so Home Assistant reported it permanently
         # OFF and its switch did nothing.
         #
-        # The register map is the Z550iQ one, which is where the reporter's
-        # measurements landed. Confirmed on their hardware, across two separate
-        # captures:
-        #   - c21 ON/OFF   — 1 with the unit running, 0 after switching it off
-        #                    from the Fluidra app; c13 stayed 0 throughout.
-        #   - c61 state    — 11 (no flow) on the first capture, 2 (heating) on
-        #                    the second, both matching the Z550iQ table.
-        #   - c15 setpoint — already read correctly through the generic profile,
-        #                    which happens to scan it; the reporter confirms the
-        #                    target temperature reads and writes.
-        # Inherited from the Z550iQ map but NOT yet confirmed on a Z350iQ:
-        # c16 (mode), c37 (water), c40 (air), c60 (running hours). Each is
-        # range-validated by the decoder, so a register that means something
-        # else on this model is dropped rather than shown — and the full
-        # register dump is still being collected to settle them.
+        # The register map is the Z550iQ one. Every entry below was then read
+        # back on the reporter's own unit, against the Fluidra app:
+        #   - c21 ON/OFF     — 1 running, 0 off; c13 stayed 0 throughout, and a
+        #                      write to c13 from Home Assistant was recorded as a
+        #                      lost write while the unit kept running.
+        #   - c15 setpoint   — 280 = 28.0 degC
+        #   - c37 water      — 251 = 25.1 degC
+        #   - c40 air        — 194 = 19.4 degC
+        #   - c60 hours      — 1151 h
+        #   - c61 state      — 0 off, 2 heating, 11 no flow
+        #   - c16 mode       — 0 Boost, 1 Silence, 2 Smart. NOT the Z550iQ
+        #                      meaning (heating/cooling/auto): this line is
+        #                      heat-only and c16 sets how hard it works. Hence
+        #                      z350_mode below, which keeps the shared decoding
+        #                      but takes the HVAC mode from c21 alone — see
+        #                      Z350Behavior in climate_behaviors.py.
+        # Only the temperature bounds are still inherited rather than measured.
         device_type="heat_pump",
         thing_type_patterns=["hpc"],
         name_patterns=["z350", "z35"],
@@ -206,13 +208,17 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours", "sensor_activity"],
         features={
             "temperature_control": True,
-            "hvac_modes": ["off", "heat", "cool", "auto"],
+            "hvac_modes": ["off", "heat"],
             "skip_auto_mode": True,
             "skip_schedules": True,
             # Drives the shared Z550iQ decoding: c21 as the on/off state, c61 as
-            # the running action, c16/c37/c40 as mode, water and air. It also
-            # stops c13 being read as an on/off flag, which is the actual bug.
+            # the running action, c37/c40 as water and air. It also stops c13
+            # being read as an on/off flag, which is the bug this profile fixes.
             "z550_mode": True,
+            # Overrides the part of that family which does not carry over: c16
+            # is Boost/Silence/Smart here, not heating/cooling/auto, so it is
+            # reported as an attribute and never written as an HVAC mode.
+            "z350_mode": True,
             "on_off_component": 21,
             "setpoint_component": 15,
             "mode_component": 16,

--- a/tests/test_climate_full.py
+++ b/tests/test_climate_full.py
@@ -1138,3 +1138,72 @@ async def test_setup_adds_new_device_dynamically() -> None:
     new_uids = {e.unique_id for e in added} - uids_after_setup
     assert new_uids, "new device entities should be added without a reload"
     assert all("HP-DYN-2" in u for u in new_uids), "only the newly-added device's entities are created"
+
+
+# --- Z350iQ: the Z550iQ registers, minus its c16 meaning (Issue #221) --------
+
+
+@pytest.mark.parametrize(
+    ("mode", "label"),
+    [(0, "boost"), (1, "silence"), (2, "smart")],
+)
+def test_hvac_mode_z350_is_heat_whatever_c16_says(mode, label) -> None:
+    """c16 selects Boost/Silence/Smart on this line, not heating/cooling/auto.
+
+    Decoded as a Z550iQ, a unit in Silence reads back as COOL and one in Smart
+    as HEAT_COOL — neither of which a heat-only Z350iQ can do.
+    """
+    device = _pin(features={"z550_mode": True, "z350_mode": True}, heat_pump_reported=1, z550_mode_reported=mode)
+    climate = _make(device)
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.extra_state_attributes["z350_mode"] == label
+    assert climate.extra_state_attributes["z350_mode_raw"] == mode
+    # The Z550iQ naming must not leak onto this model.
+    assert "z550_mode" not in climate.extra_state_attributes
+
+
+def test_hvac_mode_z350_off_follows_the_power_register() -> None:
+    """c21 alone decides on/off — the whole point of the profile."""
+    climate = _make(_pin(features={"z550_mode": True, "z350_mode": True}, heat_pump_reported=0, z550_mode_reported=2))
+    assert climate.hvac_mode == HVACMode.OFF
+
+
+def test_hvac_modes_z350_offers_no_cooling() -> None:
+    """A heat-only unit must not advertise cool or heat_cool."""
+    climate = _make(_pin(features={"z550_mode": True, "z350_mode": True}))
+    assert climate.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+
+def test_hvac_action_z350_still_reads_c61() -> None:
+    """The running state is genuinely shared with the Z550iQ."""
+    device = _pin(features={"z550_mode": True, "z350_mode": True}, heat_pump_reported=1, z550_state_reported=2)
+    assert _make(device).hvac_action == HVACAction.HEATING
+
+
+async def test_set_hvac_mode_z350_writes_only_the_power_register() -> None:
+    """Turning it on must not also write c16 and change how hard it runs."""
+    api = _api()
+    api.control_device_component = AsyncMock(return_value=True)
+    climate = _make(_pin(features={"z550_mode": True, "z350_mode": True}), api=api)
+
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    written = [call.args[1] for call in api.control_device_component.await_args_list]
+    assert written == [21]
+
+
+async def test_set_hvac_mode_z350_off_writes_the_power_register() -> None:
+    api = _api()
+    api.control_device_component = AsyncMock(return_value=True)
+    climate = _make(_pin(features={"z550_mode": True, "z350_mode": True}), api=api)
+
+    await climate.async_set_hvac_mode(HVACMode.OFF)
+
+    assert api.control_device_component.await_args.args[1:] == (21, 0)
+
+
+def test_z550_mode_semantics_are_untouched() -> None:
+    """Without z350_mode, c16 keeps meaning heating/cooling/auto."""
+    climate = _make(_pin(features={"z550_mode": True}, heat_pump_reported=1, z550_mode_reported=1))
+    assert climate.hvac_mode == HVACMode.COOL
+    assert climate.extra_state_attributes["z550_mode"] == "cooling"


### PR DESCRIPTION
Refs #221. Follow-up to #229 (shipped in 2.86.3).

That profile reuses the Z550iQ register map. Right for c21, c37, c40 and c61 — **wrong for c16**. The reporter has since read every register back against the Fluidra app, and c16 does not mean the same thing on the two models:

| c16 | Z550iQ | Z350iQ |
|---|---|---|
| 0 | heating → `HVACMode.HEAT` | **Boost** |
| 1 | cooling → `HVACMode.COOL` | **Silence** |
| 2 | auto → `HVACMode.HEAT_COOL` | **Smart** |

The Z350iQ is **heat-only**. Under 2.86.3 a unit running in Silence reported `COOL`, one in Smart reported `HEAT_COOL` — neither of which the equipment can do — and the climate entity offered `cool` and `heat_cool` as settable modes, where picking one would have written c16 and changed how hard the unit runs as a side effect of a mode change.

## The fix

`Z350Behavior` inherits everything genuinely shared (c21 on/off, c61 running state, c37/c40 temperatures) and overrides only what does not carry over:

- HVAC mode comes from **c21 alone**;
- `hvac_modes` is `[off, heat]`;
- setting a mode writes c21 and does **not** follow up on c16.

c16 is surfaced as a `z350_mode` attribute (`boost` / `silence` / `smart`). It is deliberately **not written**: the three values were confirmed by reading, and nothing establishes that the register accepts a write — the Z550iQ's own c17 answers 403 (#56, #88). The dispatch checks `z350_mode` before `z550_mode`, since a Z350iQ sets both.

## Now measured rather than inherited

Everything #229 listed as unconfirmed has been read back on the reporter's unit: c15 setpoint (`280` = 28.0 °C), c37 water (`251` = 25.1 °C), c40 air (`194` = 19.4 °C), c60 running hours (`1151`), c61 state (`0` off, `2` heating, `11` no flow), c21 on/off. Their diagnostics also recorded a **lost write on c13** while the unit kept running — which closes the case on c13 for this model. Only the temperature bounds remain inherited.

## Gate

```
2103 passed in 33.06s          # 2094 before, +9
ruff check                     All checks passed!
ruff format --check            137 files already formatted
mypy                           Success: no issues found in 67 source files
```

Run against 2.86.3's behaviour, four of the new tests fail — on exactly the Silence and Smart cases, the advertised cooling modes, and the stray c16 write. A regression test pins that the Z550iQ keeps its own c16 semantics.

Deployed on a live HA 2026.9: no error, no deprecation, setup in 1.32 s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Z350iQ heat pumps as heat-only devices.
  - Z350iQ units now report On/Off and Heat modes accurately.
  - Boost, Silence, and Smart settings are displayed as device attributes.
  - Improved reporting for target temperature, water and air temperature, running hours, and HVAC activity.
  - Z350iQ controls now change only the power state when turning the unit on or off.

- **Documentation**
  - Updated Z350iQ documentation with supported features and verified register behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->