### PR TITLE
feat(sensor): expose the Z350iQ operating mode as an entity (#221)

### DIFF
--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -205,7 +205,17 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
         # No family_patterns — see the module note (Issue #216).
         components_range=5,
         required_components=[0, 1, 2, 3],
-        entities=["climate", "switch", "sensor_info", "sensor_temperature", "sensor_running_hours", "sensor_activity"],
+        entities=[
+            "climate",
+            "switch",
+            "sensor_info",
+            "sensor_temperature",
+            "sensor_running_hours",
+            "sensor_activity",
+            # c16 cannot be an HVAC mode here and is not writable, so the
+            # Boost/Silence/Smart setting gets its own read-only sensor.
+            "sensor_mode",
+        ],
         features={
             "temperature_control": True,
             "hvac_modes": ["off", "heat"],

--- a/custom_components/fluidra_pool/sensor/__init__.py
+++ b/custom_components/fluidra_pool/sensor/__init__.py
@@ -39,6 +39,7 @@ from .device import (
     FluidraScheduleDaysSensor,
     FluidraTemperatureSensor,
     FluidraWifiSignalSensor,
+    FluidraZ350ModeSensor,
 )
 from .pool import (
     FluidraPoolLocationSensor,
@@ -130,6 +131,9 @@ async def async_setup_entry(
                 entities.append(FluidraHeatPumpActivitySensor(coordinator, coordinator.api, pool_id, device_id))
             elif device_type == DEVICE_TYPE_PUMP:
                 entities.append(FluidraPumpActivitySensor(coordinator, coordinator.api, pool_id, device_id))
+
+        if DeviceIdentifier.should_create_entity(device, "sensor_mode"):
+            entities.append(FluidraZ350ModeSensor(coordinator, coordinator.api, pool_id, device_id))
 
         if DeviceIdentifier.should_create_entity(device, "sensor_temperature"):
             # Temperature sensors for heaters / heat pumps.

--- a/custom_components/fluidra_pool/sensor/device.py
+++ b/custom_components/fluidra_pool/sensor/device.py
@@ -22,7 +22,7 @@ from homeassistant.util import dt as dt_util
 
 from ..api_resilience import FluidraError
 from ..climate_behaviors import resolve_behavior
-from ..const import HEAT_COOL_ACTION_DEADBAND, LUMIPLUS_COMPONENT_BRIGHTNESS
+from ..const import HEAT_COOL_ACTION_DEADBAND, LUMIPLUS_COMPONENT_BRIGHTNESS, Z350_MODE_NAMES
 from ..device_registry import DeviceIdentifier
 from ..helpers import parse_cron_time
 from .base import FluidraPoolSensorEntity
@@ -950,6 +950,45 @@ class FluidraCabinetPackedConfigSensor(FluidraPoolSensorEntity):
         if reported is None:
             return None
         return str(reported)
+
+
+class FluidraZ350ModeSensor(FluidraPoolSensorEntity):
+    """The Z350iQ operating mode: Boost, Silence or Smart (Issue #221).
+
+    Read off component 16. That register holds the HVAC mode on a Z550iQ, but
+    this line is heat-only and uses it to select how hard the unit works, so it
+    cannot be surfaced through the climate entity's hvac_mode. Its three values
+    were confirmed by reading them against the Fluidra app; nothing shows the
+    register accepts a write, so this stays a sensor rather than a preset.
+
+    The climate entity also carries the value as a z350_mode attribute, which is
+    where it lived first — an attribute is invisible in the device view and
+    awkward in automations, hence this entity.
+    """
+
+    _attr_translation_key = "z350_mode"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(Z350_MODE_NAMES.values())
+    _attr_icon = "mdi:heat-pump-outline"
+
+    def __init__(
+        self,
+        coordinator: FluidraDataUpdateCoordinator,
+        api: FluidraPoolAPI,
+        pool_id: str,
+        device_id: str,
+    ) -> None:
+        """Initialize the Z350iQ mode sensor."""
+        super().__init__(coordinator, api, pool_id, device_id, "z350_mode")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the mode name, or None while the register has not answered."""
+        # Shares the Z550iQ decoding, hence the z550_mode_reported key.
+        raw = self.device_data.get("z550_mode_reported")
+        if raw is None:
+            return None
+        return Z350_MODE_NAMES.get(raw)
 
 
 class FluidraHeatPumpActivitySensor(FluidraPoolSensorEntity):

--- a/custom_components/fluidra_pool/strings.json
+++ b/custom_components/fluidra_pool/strings.json
@@ -358,6 +358,14 @@
       },
       "wifi_signal": {
         "name": "WiFi Signal"
+      },
+      "z350_mode": {
+        "name": "Operating mode",
+        "state": {
+          "boost": "Boost",
+          "silence": "Silence",
+          "smart": "Smart"
+        }
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/en.json
+++ b/custom_components/fluidra_pool/translations/en.json
@@ -358,6 +358,14 @@
       },
       "wifi_signal": {
         "name": "WiFi Signal"
+      },
+      "z350_mode": {
+        "name": "Operating mode",
+        "state": {
+          "boost": "Boost",
+          "silence": "Silence",
+          "smart": "Smart"
+        }
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/es.json
+++ b/custom_components/fluidra_pool/translations/es.json
@@ -358,6 +358,14 @@
       },
       "wifi_signal": {
         "name": "Señal wifi"
+      },
+      "z350_mode": {
+        "name": "Modo de funcionamiento",
+        "state": {
+          "boost": "Boost",
+          "silence": "Silencio",
+          "smart": "Smart"
+        }
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/fr.json
+++ b/custom_components/fluidra_pool/translations/fr.json
@@ -358,6 +358,14 @@
       },
       "wifi_signal": {
         "name": "Signal Wi-Fi"
+      },
+      "z350_mode": {
+        "name": "Mode de fonctionnement",
+        "state": {
+          "boost": "Boost",
+          "silence": "Silence",
+          "smart": "Smart"
+        }
       }
     },
     "switch": {

--- a/custom_components/fluidra_pool/translations/pt.json
+++ b/custom_components/fluidra_pool/translations/pt.json
@@ -358,6 +358,14 @@
       },
       "wifi_signal": {
         "name": "Sinal Wi-Fi"
+      },
+      "z350_mode": {
+        "name": "Modo de funcionamento",
+        "state": {
+          "boost": "Boost",
+          "silence": "Silêncio",
+          "smart": "Smart"
+        }
       }
     },
     "switch": {

--- a/tests/test_new_device_support.py
+++ b/tests/test_new_device_support.py
@@ -17,6 +17,7 @@ from custom_components.fluidra_pool.sensor import (
     FluidraDeviceBatterySensor,
     FluidraHeatPumpActivitySensor,
     FluidraScheduleDaysSensor,
+    FluidraZ350ModeSensor,
 )
 from custom_components.fluidra_pool.switch import FluidraChlorinatorToggleSwitch
 from tests.test_sensor_full import _run_setup  # noqa: F401  (reused setup helper)
@@ -391,3 +392,45 @@ async def test_heat_pump_setup_creates_activity_sensor() -> None:
     activities = [e for e in entities if isinstance(e, FluidraHeatPumpActivitySensor)]
     assert len(activities) == 1
     assert activities[0].native_value == "off"
+
+
+class TestZ350ModeSensor:
+    """The Z350iQ operating mode as its own entity (Issue #221).
+
+    It lived only as a climate attribute at first, where the reporter could not
+    find it: attributes do not show in the device view.
+    """
+
+    def _device(self, **extra: Any) -> dict[str, Any]:
+        device = {
+            "device_id": "FE25000001",
+            "name": "Z350iQ",
+            "type": "heat_pump",
+            "thing_type": "hpc",
+            "components": {},
+        }
+        device.update(extra)
+        return device
+
+    def _sensor(self, device: dict[str, Any]) -> FluidraZ350ModeSensor:
+        return FluidraZ350ModeSensor(_coordinator(device), None, POOL_ID, device["device_id"])
+
+    def test_options_are_the_three_measured_modes(self) -> None:
+        sensor = self._sensor(self._device())
+        assert sensor._attr_options == ["boost", "silence", "smart"]
+
+    @pytest.mark.parametrize(("raw", "expected"), [(0, "boost"), (1, "silence"), (2, "smart")])
+    def test_decodes_component_16(self, raw, expected) -> None:
+        assert self._sensor(self._device(z550_mode_reported=raw)).native_value == expected
+
+    def test_unknown_while_the_register_is_silent(self) -> None:
+        """No reading is not a mode — better unknown than a made-up Boost."""
+        assert self._sensor(self._device()).native_value is None
+
+    def test_unmapped_value_reports_nothing(self) -> None:
+        """A fourth value would be outside what was measured on hardware."""
+        assert self._sensor(self._device(z550_mode_reported=7)).native_value is None
+
+    def test_the_profile_declares_the_entity(self) -> None:
+        """Without this the sensor is written but never created."""
+        assert "sensor_mode" in DEVICE_CONFIGS["z350iq_heat_pump"].entities


### PR DESCRIPTION
Refs #221. Follow-up to #231 (shipped in 2.86.4).

The reporter updated, confirmed the fix works — ON/OFF now switches the real equipment, the activity sensor shows Heating, no more lost writes — and asked one thing: **where is the Boost/Silence/Smart mode?**

It was there, but only as a `z350_mode` attribute on the climate entity. That is not a bug (the attribute is emitted; tests cover it), it is a discoverability problem: attributes do not appear in the device view, and using one in an automation means a template. So the mode gets its own entity.

## The sensor

`FluidraZ350ModeSensor`, an ENUM sensor with the three measured values, following the same shape as `FluidraHeatPumpActivitySensor` right next to it. Declared through a new `sensor_mode` entity token on the Z350iQ profile.

It stays a **sensor rather than a climate preset** on purpose: nothing establishes that component 16 accepts a write. Its values were confirmed by *reading* them against the Fluidra app, and the equivalent register on the Z550iQ answers HTTP 403 (#56, #88). A preset would advertise a control that may not exist — the climate entity would accept a selection it cannot apply.

Two silent cases, both deliberate: a register that has not answered yet reports nothing, and so does a value outside the three that were measured. Neither invents a mode.

The climate attribute is kept — it costs nothing and someone may already be reading it.

## Gate

```
2110 passed in 29.22s          # 2103 before, +7
ruff check                     All checks passed!
ruff format --check            137 files already formatted
mypy                           Success: no issues found in 67 source files
```

Translations added for all four supported languages (en, fr, es, pt) plus `strings.json`; the diff is additions only.

Deployed on a live HA 2026.9: no error, no deprecation, setup in 1.88 s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operating mode sensor for Z350iQ heat pumps.
  * Displays Boost, Silence, or Smart mode.
  * Added localized names and mode labels in English, Spanish, French, and Portuguese.
* **Bug Fixes**
  * Shows no mode when the heat pump reports unavailable or unknown data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->