### PR TITLE
fix(climate): treat the Z650iQ as heat-only, not reversible (#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 
 # Fluidra Pool Integration for Home Assistant 🏊‍♂️
 
-A Home Assistant integration for **Fluidra Connect** pool equipment — variable-speed pumps,
-heat pumps, salt chlorinators / electrolysers, water analysers and connected lighting.
-It talks to the Fluidra cloud (AWS Cognito auth) and exposes each device as native
-Home Assistant entities.
+A Home Assistant integration for **Fluidra Pool / iAquaLink+ / myFluidra** pool equipment
+(EMEA) — variable-speed pumps, heat pumps, salt chlorinators / electrolysers, water
+analysers and connected lighting. It talks to the Fluidra cloud (AWS Cognito auth) and
+exposes each device as native Home Assistant entities.
 
-> The integration was built by reverse-engineering the Fluidra Connect API. Most device
+> The integration was built by reverse-engineering the Fluidra Pool EMEA API. Most device
 > mappings were confirmed by the community against the official Fluidra Pool app — if your
 > model isn't recognised yet, [open an issue](#-adding-new-equipment) and help us add it.
+>
+> Not to be confused with **Fluidra Connect** (the installer platform behind the *Fluidra
+> Connect Box*, `portal.fluidraconnect.com`). That is a **separate cloud with separate
+> accounts** and is **not supported** — see [Troubleshooting](#-troubleshooting).
 
 ---
 
@@ -193,20 +197,27 @@ Then restart Home Assistant and add the integration from the UI.
 
 The integration is configured entirely from the UI (config flow):
 
-- **Email** — your Fluidra Connect account email
-- **Password** — your Fluidra Connect password
+- **Email** — your Fluidra Pool / myFluidra account email (not a Fluidra Connect account)
+- **Password** — your Fluidra Pool / myFluidra password
 - **MFA** — if your account uses multi-factor authentication, you'll be prompted for the code
 - **Re-auth / Reconfigure** — Home Assistant prompts you to re-authenticate if the token is
   rejected; you can also reconfigure (e.g. change the account email) from the integration menu
 
 > [!IMPORTANT]
 > **Region — EMEA (Europe) only.** This integration talks to Fluidra's **EMEA** backend
-> (`api.fluidra-emea.com`). Only myFluidra / Fluidra Connect accounts registered in the
-> EMEA region can log in. Accounts created in other regions — e.g. **North America**
+> (`api.fluidra-emea.com`). Only Fluidra Pool / myFluidra / iAquaLink+ accounts registered in
+> the EMEA region can log in. Accounts created in other regions — e.g. **North America**
 > (iAquaLink US) or **Australia / APAC** — live on a different Fluidra backend and will be
 > rejected with an "invalid credentials" error even though the same credentials work in the
 > official app. Multi-region support isn't available yet (it needs the regional endpoints and
 > a test account to implement safely).
+>
+> **Product — Fluidra Pool only, not Fluidra Connect.** The **FluidraConnect** app
+> (publisher *FLUIDRA S.A.*) and the *Fluidra Connect Box* are a different product line with
+> their own login (`portal.fluidraconnect.com`, OAuth) and their own accounts. This
+> integration cannot log those in — Cognito answers `NotAuthorizedException` because the
+> account does not exist in its user pool. Use the **Fluidra Pool** app (publisher *Zodiac
+> Pool Systems*) if your equipment is supported here.
 
 ### Options
 - **Update interval** — polling interval in seconds, configurable from **30 to 1800**
@@ -371,6 +382,7 @@ entities:
 | Symptom | Likely cause / fix |
 |---------|--------------------|
 | `Invalid credentials` but the app works | Account registered **outside EMEA** (North America, Australia, …) — not supported (see [Configuration](#-configuration)) |
+| `Authentication failed` / `Incorrect username or password` (Cognito `NotAuthorizedException`), account works in **FluidraConnect** | Different product line — **Fluidra Connect Box** accounts live on `portal.fluidraconnect.com`, not this integration's cloud. Not supported (see [Configuration](#-configuration)) |
 | `Authentication failed` | Wrong credentials or expired token → re-authenticate |
 | `No pools found` | Account has no equipment, or it's offline in the Fluidra app |
 | Wrong readings after a HACS update (e.g. a chlorinator's pH shows a temperature) | A custom integration's code only reloads on a **full Home Assistant restart** (Settings → System → Restart) — a "Reload" is not enough. Restart, then re-check |

--- a/custom_components/fluidra_pool/climate_behaviors.py
+++ b/custom_components/fluidra_pool/climate_behaviors.py
@@ -35,8 +35,6 @@ from .const import (
     Z550_STATE_NO_FLOW,
     Z550_TEMP_STEP,
     Z650_MODE_TO_VALUE,
-    Z650_PRESET_BOOST,
-    Z650_PRESET_SMART,
     Z650_PRESET_SMART_PLUS,
 )
 from .device_registry import DeviceIdentifier
@@ -392,50 +390,36 @@ class LgBehavior(HeatPumpBehavior):
 class Z650iqBehavior(HeatPumpBehavior):
     """Z650iQ command set: component 10 (on/off), 14 (mode/preset).
 
-    Shares the mode register with the Z260iQ but not its meaning: here c14 is
-    0 = Smart+ (Heat), 1 = Boost (Cool), 2 = Smart (Heat/Cool),
-    3 = Ecosilence (Heat), whereas the Z260iQ maps 1 → Heat and 3 → Cool. A
-    shared behavior would therefore invert this unit's modes and actions.
+    Heat-only. The Z650iQ is a heating pump — the manufacturer's own
+    documentation describes all four c14 presets as heating strategies
+    (Boost = maximum heating power, Smart+, Smart, Eco-silence), never a
+    heat/cool direction. The reversible model is the Z250iQ/Z260iQ, whose
+    page says heat *and* cool; this one says "designed to heat the pool"
+    (Issue #233). So the register selects how hard the unit heats, exactly
+    like the Z350iQ's c16, and the HVAC mode comes from the power register
+    alone.
+
+    The register is nonetheless shared with the Z260iQ, with different
+    values (here 0 = Smart+, 1 = Boost, 2 = Smart, 3 = Ecosilence), so a
+    shared behavior would misread this unit.
     """
 
-    hvac_modes: list[HVACMode] = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL]
+    hvac_modes: list[HVACMode] = [HVACMode.OFF, HVACMode.HEAT]
     min_temp: float = 15.0
     max_temp: float = 35.0
     temp_step: float = 0.5
 
     def hvac_mode(self, device_data: dict[str, Any]) -> HVACMode:
-        """ON/OFF from the coordinator-decoded state, direction from component 14."""
-        heat_pump_reported = device_data.get("heat_pump_reported")
-        if heat_pump_reported is not None and not bool(heat_pump_reported):
-            return HVACMode.OFF
-        mode_value = device_data.get("z260iq_mode_value")
-        if mode_value is not None:
-            # 0=Smart+ Heat, 3=Ecosilence Heat → HEAT
-            # 1=Boost Cool → COOL
-            # 2=Smart Heat/Cool → HEAT_COOL
-            if mode_value in (0, 3):
-                return HVACMode.HEAT
-            if mode_value == 1:
-                return HVACMode.COOL
-            if mode_value == 2:
-                return HVACMode.HEAT_COOL
-        return HVACMode.HEAT if bool(heat_pump_reported) else HVACMode.OFF
+        """ON/OFF only — c14 is a heating strategy here, not a direction."""
+        return HVACMode.HEAT if device_data.get("heat_pump_reported") else HVACMode.OFF
 
     def hvac_action(self, device_data: dict[str, Any], infer_heat_cool: InferHeatCoolAction) -> HVACAction:
-        """Derive the action from ON/OFF + mode direction (component 14)."""
-        heat_pump_reported = device_data.get("heat_pump_reported")
-        if heat_pump_reported is not None and not bool(heat_pump_reported):
+        """A heat-only unit is HEATING whenever it runs; IDLE if flow is blocked."""
+        if not device_data.get("heat_pump_reported"):
             return HVACAction.OFF
         if device_data.get("no_flow_alarm"):
             return HVACAction.IDLE
-        mode_value = device_data.get("z260iq_mode_value")
-        if mode_value == 1:  # Boost Cool
-            return HVACAction.COOLING
-        if mode_value in (0, 3):  # Smart+ Heat / Ecosilence Heat
-            return HVACAction.HEATING
-        if mode_value == 2:  # Smart Heat+Cool: infer direction from temps
-            return infer_heat_cool()
-        return HVACAction.HEATING if bool(heat_pump_reported) else HVACAction.OFF
+        return HVACAction.HEATING
 
     async def async_set_hvac_mode(
         self,
@@ -445,27 +429,22 @@ class Z650iqBehavior(HeatPumpBehavior):
         hvac_mode: HVACMode,
         current_preset: str | None,
     ) -> bool | None:
-        """Z650iQ: ON/OFF via start/stop_pump, mode via component 14.
+        """Z650iQ: ON/OFF via start/stop_pump, heating strategy via component 14.
 
         start_pump/stop_pump resolve the on/off register from the profile's
         "on_off_component" (c10 here), so this stays family-agnostic.
         """
         if hvac_mode == HVACMode.OFF:
             return await api.stop_pump(device_id)
-
-        if hvac_mode == HVACMode.HEAT:
-            # Keep current preset if it's already a heat preset, else default to Smart+
-            mode_value = Z650_MODE_TO_VALUE.get(
-                current_preset or Z650_PRESET_SMART_PLUS, Z650_MODE_TO_VALUE[Z650_PRESET_SMART_PLUS]
-            )
-            if mode_value not in (0, 3):
-                mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_SMART_PLUS]
-        elif hvac_mode == HVACMode.COOL:
-            mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_BOOST]
-        elif hvac_mode == HVACMode.HEAT_COOL:
-            mode_value = Z650_MODE_TO_VALUE[Z650_PRESET_SMART]
-        else:
+        if hvac_mode != HVACMode.HEAT:
+            # No cooling on this unit (Issue #233).
             return None
+
+        # Keep the current heating preset (Boost/Smart/Smart+/Ecosilence),
+        # defaulting to Smart+ when none is known.
+        mode_value = Z650_MODE_TO_VALUE.get(
+            current_preset or Z650_PRESET_SMART_PLUS, Z650_MODE_TO_VALUE[Z650_PRESET_SMART_PLUS]
+        )
 
         success = await api.control_device_component(device_id, 14, mode_value)
         if success:

--- a/custom_components/fluidra_pool/const.py
+++ b/custom_components/fluidra_pool/const.py
@@ -280,11 +280,13 @@ LG_VALUE_TO_MODE: Final = {v: k for k, v in LG_MODE_TO_VALUE.items()}
 
 # Z650iQ Heat Pump constants — the Fluidra App uses different names for the
 # same component-14 register values. Only 4 of the 7 LG presets are available.
+# Heat-only unit (Issue #233): all four are heating strategies, not a
+# heat/cool direction — Boost delivers maximum heating power.
 # Mapping: App "Smart+" -> c14=0, "Boost" -> c14=1, "Smart" -> c14=2, "Ecosilence" -> c14=3
-Z650_PRESET_SMART_PLUS: Final = "smart_plus"  # Fluidra App: "Smart+" (Heat)
-Z650_PRESET_SMART: Final = "smart"  # Fluidra App: "Smart" (Heat/Cool)
-Z650_PRESET_ECOSILENCE: Final = "ecosilence"  # Fluidra App: "Ecosilence" (Heat)
-Z650_PRESET_BOOST: Final = "boost"  # Fluidra App: "Boost" (Cool)
+Z650_PRESET_SMART_PLUS: Final = "smart_plus"  # Fluidra App: "Smart+" (heat, auto Boost/Eco-silence)
+Z650_PRESET_SMART: Final = "smart"  # Fluidra App: "Smart" (heat)
+Z650_PRESET_ECOSILENCE: Final = "ecosilence"  # Fluidra App: "Ecosilence" (heat)
+Z650_PRESET_BOOST: Final = "boost"  # Fluidra App: "Boost" (heat, max power)
 
 Z650_PRESET_MODES: Final = [
     Z650_PRESET_SMART_PLUS,
@@ -294,10 +296,10 @@ Z650_PRESET_MODES: Final = [
 ]
 
 Z650_MODE_TO_VALUE: Final = {
-    Z650_PRESET_SMART_PLUS: 0,  # c14=0 -> Heat
-    Z650_PRESET_BOOST: 1,  # c14=1 -> Cool
-    Z650_PRESET_SMART: 2,  # c14=2 -> Heat/Cool
-    Z650_PRESET_ECOSILENCE: 3,  # c14=3 -> Heat
+    Z650_PRESET_SMART_PLUS: 0,  # c14=0 -> Smart+
+    Z650_PRESET_BOOST: 1,  # c14=1 -> Boost
+    Z650_PRESET_SMART: 2,  # c14=2 -> Smart
+    Z650_PRESET_ECOSILENCE: 3,  # c14=3 -> Ecosilence
 }
 
 Z650_VALUE_TO_MODE: Final = {v: k for k, v in Z650_MODE_TO_VALUE.items()}

--- a/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
+++ b/custom_components/fluidra_pool/device_registry/configs/heat_pumps.py
@@ -298,7 +298,9 @@ HEAT_PUMP_CONFIGS: dict[str, DeviceConfig] = {
             "z650iq_mode": True,
             "preset_modes": True,
             "temperature_control": True,
-            "hvac_modes": ["off", "heat", "cool", "heat_cool"],
+            # Heat-only unit: c14 selects a heating strategy (Boost/Smart/
+            # Smart+/Ecosilence), not a heat/cool direction (Issue #233).
+            "hvac_modes": ["off", "heat"],
             "skip_auto_mode": True,
             "skip_schedules": True,
             "min_temp": 15.0,

--- a/tests/test_climate_full.py
+++ b/tests/test_climate_full.py
@@ -903,6 +903,50 @@ def test_z650iq_preset_mode_unknown_raw_falls_back() -> None:
     assert climate.preset_mode == Z650_PRESET_SMART_PLUS
 
 
+def test_hvac_modes_z650iq_heat_only() -> None:
+    """Z650iQ is a heating pump — no COOL/HEAT_COOL (Issue #233)."""
+    assert _make(_pin(features=_Z650)).hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+
+def test_hvac_mode_z650iq_from_power_only() -> None:
+    assert _make(_pin(features=_Z650, heat_pump_reported=1)).hvac_mode == HVACMode.HEAT
+    assert _make(_pin(features=_Z650, heat_pump_reported=0)).hvac_mode == HVACMode.OFF
+
+
+@pytest.mark.parametrize("mode_value", [0, 1, 2, 3])
+def test_hvac_mode_z650iq_preset_is_not_a_direction(mode_value: int) -> None:
+    """Every c14 preset is a heating strategy — never reported as COOL (Issue #233)."""
+    climate = _make(_pin(features=_Z650, heat_pump_reported=1, z260iq_mode_value=mode_value))
+    assert climate.hvac_mode == HVACMode.HEAT
+
+
+@pytest.mark.parametrize("mode_value", [0, 1, 2, 3])
+def test_hvac_action_z650iq_heating_for_every_preset(mode_value: int) -> None:
+    """Boost (c14=1) must report HEATING, not COOLING (Issue #233)."""
+    climate = _make(_pin(features=_Z650, heat_pump_reported=1, z260iq_mode_value=mode_value))
+    assert climate.hvac_action == HVACAction.HEATING
+
+
+def test_hvac_action_z650iq_off() -> None:
+    climate = _make(_pin(features=_Z650, heat_pump_reported=0))
+    assert climate.hvac_action == HVACAction.OFF
+
+
+def test_hvac_action_z650iq_no_flow_idle() -> None:
+    climate = _make(_pin(features=_Z650, heat_pump_reported=1, no_flow_alarm=True))
+    assert climate.hvac_action == HVACAction.IDLE
+
+
+async def test_z650iq_set_hvac_mode_cool_is_unsupported() -> None:
+    """No cooling on this unit — COOL is rejected without touching the device."""
+    api = _api()
+    climate = _make(_pin(features=_Z650), api)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+    api.control_device_component.assert_not_awaited()
+    api.start_pump.assert_not_awaited()
+    assert climate._pending_hvac_mode is None
+
+
 async def test_z650iq_set_preset_mode_writes_component_14() -> None:
     api = _api()
     climate = _make(_pin(features=_Z650), api)


### PR DESCRIPTION
## What

Fixes #233. The Z650iQ reported `hvac_action: cooling` while it was actively heating.

**Root cause** — the c14 register was read as a heat/cool direction. `1` (Boost) was hardcoded to COOL and the entity advertised `cool`/`heat_cool` modes.

The unit is **heat-only**: Fluidra's own documentation describes all four c14 presets (Boost, Smart, Smart+, Eco-silence) as *heating strategies*, Boost being maximum heating power. The reversible model is the Z250iQ/Z260iQ, whose page says heat *and* cool; the Z650iQ page says it is designed to heat the pool.

**Fix** — `Z650iqBehavior` now takes the HVAC mode from the power register alone, reports HEATING whenever the unit runs (IDLE when flow is blocked) and rejects COOL instead of mapping it to a heating preset. c14 stays a preset selector.

Also clarifies in the README that the supported backend is Fluidra Pool / iAquaLink+ / myFluidra, not the Fluidra Connect Box (the confusion behind #201).

## Files

- `custom_components/fluidra_pool/climate_behaviors.py` — Z650iqBehavior heat-only
- `custom_components/fluidra_pool/const.py` — preset comments corrected
- `custom_components/fluidra_pool/device_registry/configs/heat_pumps.py` — profile `hvac_modes: [off, heat]`
- `tests/test_climate_full.py` — +7 tests (modes, action per preset, COOL rejected)
- `README.md` — backend clarification

## Test plan

- [x] `pytest -q` → 2123 passed
- [x] `ruff check` / `ruff format --check`
- [x] `mypy custom_components/fluidra_pool` → no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Z650iQ heat pumps now appear as heating-only devices, with OFF and HEAT modes.
  * Cooling modes are no longer available for these units.
  * Heating presets now accurately reflect the available heating strategies.

* **Documentation**
  * Clarified supported Fluidra Pool, iAquaLink+, and myFluidra accounts and regions.
  * Added guidance for authentication failures caused by unsupported Fluidra Connect accounts.

* **Tests**
  * Added coverage for heat-only modes, presets, status reporting, idle behavior, and unsupported cooling commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->